### PR TITLE
fix: PyPI publishing to use client library package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,8 +143,13 @@ jobs:
       env:
         RELEASE_VERSION: ${{ steps.version.outputs.pypi_version }}
       run: |
-        echo "Building package with version: $RELEASE_VERSION"
-        python -m build
+        echo "Building client package with version: $RELEASE_VERSION"
+        # Temporarily rename pyproject.toml to avoid conflict with setup.py
+        mv pyproject.toml pyproject.toml.bak
+        # Build using setup.py which is configured for the client library
+        python setup.py sdist bdist_wheel
+        # Restore pyproject.toml
+        mv pyproject.toml.bak pyproject.toml
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
## Issue

The previous PyPI publishing job was incorrectly publishing `petrosa-data-manager` (the main service package) instead of `petrosa-data-manager-client` (the client library).

## Root Cause

`python -m build` prefers `pyproject.toml` over `setup.py`. Since both files exist in the root directory:
- `pyproject.toml` defines the main service package (`petrosa-data-manager`)
- `setup.py` defines the client library (`petrosa-data-manager-client`)

The build tool was using `pyproject.toml`, resulting in the wrong package being published.

## Solution

- Temporarily rename `pyproject.toml` during the client build
- Use `setup.py` directly with `python setup.py sdist bdist_wheel`
- Restore `pyproject.toml` after build
- This ensures `petrosa-data-manager-client` is published with correct dependencies

## Verification

After this fix:
- Package name: `petrosa-data-manager-client` ✅
- Version: Auto-synced from Git tags ✅
- Dependencies: httpx, pydantic, tenacity ✅

## Services Using Package

- petrosa-binance-data-extractor
- petrosa-realtime-strategies