### PR TITLE
fix: use setuptools and wheel for PyPI client build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,12 +144,16 @@ jobs:
         RELEASE_VERSION: ${{ steps.version.outputs.pypi_version }}
       run: |
         echo "Building client package with version: $RELEASE_VERSION"
-        # Temporarily rename pyproject.toml to avoid conflict with setup.py
+        # Install setuptools and wheel
+        python -m pip install setuptools wheel
+        # Temporarily rename pyproject.toml to avoid conflict
         mv pyproject.toml pyproject.toml.bak
-        # Build using setup.py which is configured for the client library
-        python setup.py sdist bdist_wheel
+        # Build using setup.py (client library configuration)
+        python setup.py sdist bdist_wheel --universal
         # Restore pyproject.toml
         mv pyproject.toml.bak pyproject.toml
+        # Verify packages were created
+        ls -lh dist/
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
## Issue

Previous attempt to build client package failed with exit code 1.

## Root Cause

The command `python setup.py sdist bdist_wheel` requires setuptools and wheel to be explicitly installed and configured properly.

## Solution

- Install `setuptools` and `wheel` packages explicitly before building
- Use `--universal` flag for py2/py3 wheel compatibility
- Add verification step to list dist/ contents for debugging

## Testing

This should resolve the build failure and successfully create:
- `petrosa-data-manager-client-{version}.tar.gz` (source distribution)
- `petrosa-data-manager-client-{version}-py2.py3-none-any.whl` (wheel)

Version will be auto-synced from Git tags (currently v1.0.22).