### PR TITLE
fix: Add petrosa-otel dependency for Grafana log export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,9 @@ opentelemetry-exporter-otlp-proto-grpc>=1.22.0
 prometheus-client>=0.19.0
 python-json-logger>=2.0.7
 
+# Unified OpenTelemetry package for Petrosa services
+petrosa-otel>=1.0.0
+
 # HTTP client
 httpx>=0.26.0
 


### PR DESCRIPTION
## Problem

Data-manager logs are not appearing in Grafana because the service is missing the `petrosa-otel` package.

## Root Cause

- `data_manager/main.py` attempts to import `petrosa_otel` package (lines 287-308)
- The import fails silently due to try/except ImportError
- Without the package, `attach_logging_handler()` is never called
- Logs remain local to container and never export to OpenTelemetry/Grafana

## Solution

Add `petrosa-otel>=1.0.0` to requirements.txt

This package provides:
- Standardized OpenTelemetry initialization
- `attach_logging_handler()` function for OTLP log export
- Consistent trace context propagation
- NATS trace propagation support

## Changes

- ✅ Added `petrosa-otel>=1.0.0` to requirements.txt
- Matches pattern used across all other services (socket-client, ta-bot, etc.)

## Testing

After CI/CD deployment, verify:

1. **Pod logs show handler attached**:
```bash
kubectl logs -n petrosa-apps deployment/petrosa-data-manager --tail=50
```
Look for: `✅ OTLP logging handler attached to root logger`

2. **Grafana query returns logs**:
```
{service_name="petrosa-data-manager"}
```

## Impact

- ✅ Low risk: Only adds logging export capability
- ✅ No functional changes to service behavior
- ✅ No breaking changes
- ✅ Aligns with ecosystem-wide observability standards

## Configuration (Already Set)

- `OTEL_ENABLED=true` in ConfigMap ✓
- `OTEL_EXPORTER_OTLP_ENDPOINT` configured ✓
- `OTEL_SERVICE_NAME=petrosa-data-manager` ✓