### PR TITLE
[BUG] Fix security scan not blocking PR merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # Required for SARIF upload
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -110,7 +114,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
-          exit-code: '0'
+          exit-code: '1'  # Fail if vulnerabilities found
           ignore-unfixed: true
 
       - name: Upload Trivy results


### PR DESCRIPTION
Part of PetroSa2/petrosa_k8s#77

- Added permissions: security-events: write
- Changed exit-code: '0' to '1' to block on vulnerabilities