### PR TITLE
[BUG][P2] Data Manager: fix 404 to 500 masking in analysis routes

### DIFF
--- a/data_manager/api/routes/analysis.py
+++ b/data_manager/api/routes/analysis.py
@@ -412,6 +412,8 @@ async def get_deviation(
             },
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error fetching deviation metrics: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
@@ -469,6 +471,8 @@ async def get_seasonality(
             },
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error fetching seasonality metrics: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
@@ -522,6 +526,8 @@ async def get_regime(
             },
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error fetching regime: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
@@ -669,6 +675,8 @@ async def market_overview(
             "pairs_available": len([v for v in overview.values() if v is not None]),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error generating market overview: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_analysis_masking.py
+++ b/tests/test_analysis_masking.py
@@ -1,0 +1,58 @@
+import pytest
+from fastapi import HTTPException
+from unittest.mock import MagicMock, AsyncMock, patch
+from data_manager.api.routes.analysis import get_regime, get_deviation, get_seasonality
+
+@pytest.mark.asyncio
+async def test_get_regime_404_not_masked():
+    """Verify that 404 is not masked as 500 in get_regime."""
+    # Mock db_manager and mongodb_adapter
+    mock_db = MagicMock()
+    mock_adapter = AsyncMock()
+    mock_db.mongodb_adapter = mock_adapter
+    
+    # query_latest returns empty list -> triggers 404
+    mock_adapter.query_latest.return_value = []
+    
+    with patch("data_manager.api.routes.analysis.api_module") as mock_api:
+        mock_api.db_manager = mock_db
+        
+        with pytest.raises(HTTPException) as exc_info:
+            await get_regime(pair="UNKNOWN", period="1h")
+        
+        assert exc_info.value.status_code == 404
+        assert "No regime data available" in exc_info.value.detail
+
+@pytest.mark.asyncio
+async def test_get_deviation_404_not_masked():
+    """Verify that 404 is not masked as 500 in get_deviation."""
+    mock_db = MagicMock()
+    mock_adapter = AsyncMock()
+    mock_db.mongodb_adapter = mock_adapter
+    mock_adapter.query_latest.return_value = []
+    
+    with patch("data_manager.api.routes.analysis.api_module") as mock_api:
+        mock_api.db_manager = mock_db
+        
+        with pytest.raises(HTTPException) as exc_info:
+            await get_deviation(pair="UNKNOWN", period="1h")
+        
+        assert exc_info.value.status_code == 404
+        assert "No deviation data available" in exc_info.value.detail
+
+@pytest.mark.asyncio
+async def test_get_seasonality_404_not_masked():
+    """Verify that 404 is not masked as 500 in get_seasonality."""
+    mock_db = MagicMock()
+    mock_adapter = AsyncMock()
+    mock_db.mongodb_adapter = mock_adapter
+    mock_adapter.query_latest.return_value = []
+    
+    with patch("data_manager.api.routes.analysis.api_module") as mock_api:
+        mock_api.db_manager = mock_db
+        
+        with pytest.raises(HTTPException) as exc_info:
+            await get_seasonality(pair="UNKNOWN", period="1h")
+        
+        assert exc_info.value.status_code == 404
+        assert "No seasonality data available" in exc_info.value.detail

--- a/tests/test_analysis_masking.py
+++ b/tests/test_analysis_masking.py
@@ -1,7 +1,9 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from fastapi import HTTPException
-from unittest.mock import MagicMock, AsyncMock, patch
-from data_manager.api.routes.analysis import get_regime, get_deviation, get_seasonality
+
+from data_manager.api.routes.analysis import get_deviation, get_regime, get_seasonality
 
 @pytest.mark.asyncio
 async def test_get_regime_404_not_masked():


### PR DESCRIPTION
Implements PetroSa2/petrosa-data-manager#119.

- Fixes HTTPException masking as 500.
- Adds regression tests in tests/test_analysis_masking.py.