### PR TITLE
fix: #498 - normalize deploy.yml image sed to canonical Type A pattern

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,8 @@ jobs:
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           # Update the image tag in manifests robustly (preserves registry/repo, only updates tag)
-          find petrosa_k8s/k8s/data-manager -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s|(image:[[:space:]]*[^[:space:]]*/petrosa-data-manager):[^[:space:]]*|\1:$VERSION|g"
+          # Handles both qualified (e.g., repo/petrosa-data-manager:tag) and unqualified (petrosa-data-manager:tag) image names
+          find petrosa_k8s/k8s/data-manager -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-data-manager):[^[:space:]]*|\1\2\3:$VERSION|g"
 
           # Update version labels specifically (targets common label patterns)
           find petrosa_k8s/k8s/data-manager -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s/(version|app.kubernetes.io\/version):.*/\1: $VERSION/g"


### PR DESCRIPTION
## Summary

Implements one of three acceptance criteria from [petrosa_k8s#498](https://github.com/PetroSa2/petrosa_k8s/issues/498).

The previous `image:` sed in this workflow required a literal `/` before `petrosa-data-manager`, which fails to match unqualified image refs (`image: petrosa-data-manager:tag`). Normalize to the canonical Type A pattern used by 5 of 7 services (optional registry capture group) so the sed works for both qualified and unqualified refs.

### Before
```bash
sed -E -i "s|(image:[[:space:]]*[^[:space:]]*/petrosa-data-manager):[^[:space:]]*|\1:$VERSION|g"
```

### After (canonical)
```bash
sed -E -i "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-data-manager):[^[:space:]]*|\1\2\3:$VERSION|g"
```

## Regression Risk

**Low.** The new pattern is a superset of the old one — every image ref the old sed would match is still matched, plus unqualified refs now match too. Manifest content is unchanged in the current state of `petrosa_k8s/main`.

## Verification

- `sed -E "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-data-manager):[^[:space:]]*|\1\2\3:v9.9.9|g"` against `yurisa2/petrosa-data-manager:v0.0.1`, `petrosa-data-manager:v0.0.1`, and `registry.io/scope/petrosa-data-manager:v1.2.3-r5-def123` — all rewritten correctly.
- actionlint shows no new findings on the changed lines (only pre-existing runner-label and SC2086 noise on unrelated lines).

## Test Plan

- [ ] CI passes on this PR.
- [ ] On next data-manager deploy run, confirm the manifest in `petrosa_k8s/k8s/data-manager/` receives the expected tag.