### PR TITLE
feat: 585 - add signals.trading.> subscriber + cio_decisions collection (P0.2b)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -19,6 +19,7 @@ NATS_CONSUMER_SUBJECT = os.getenv(
 )
 # Audit-trail subscribers (cross-service identifier contract, P0.2 epic)
 NATS_INTENT_SUBJECT = os.getenv("NATS_INTENT_SUBJECT", "cio.intent.>")
+NATS_DECISION_SUBJECT = os.getenv("NATS_DECISION_SUBJECT", "signals.trading.>")
 NATS_CLIENT_NAME = f"{SERVICE_NAME}-consumer"
 NATS_CONNECT_TIMEOUT = int(os.getenv("NATS_CONNECT_TIMEOUT", "10"))
 NATS_MAX_RECONNECT_ATTEMPTS = int(os.getenv("NATS_MAX_RECONNECT_ATTEMPTS", "10"))
@@ -53,6 +54,9 @@ ENABLE_BACKFILLER = os.getenv("ENABLE_BACKFILLER", "true").lower() == "true"
 ENABLE_ANALYTICS = os.getenv("ENABLE_ANALYTICS", "true").lower() == "true"
 ENABLE_API = os.getenv("ENABLE_API", "true").lower() == "true"
 ENABLE_INTENT_CONSUMER = os.getenv("ENABLE_INTENT_CONSUMER", "true").lower() == "true"
+ENABLE_DECISION_CONSUMER = (
+    os.getenv("ENABLE_DECISION_CONSUMER", "true").lower() == "true"
+)
 
 # Scheduling Configuration
 AUDIT_INTERVAL = int(os.getenv("AUDIT_INTERVAL", "300"))  # 5 minutes

--- a/data_manager/consumer/decision_consumer.py
+++ b/data_manager/consumer/decision_consumer.py
@@ -1,0 +1,271 @@
+"""CIO decision NATS consumer that persists messages into the `cio_decisions` collection (P0.2b)."""
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from opentelemetry import trace
+from prometheus_client import Counter, Histogram
+
+try:
+    from petrosa_otel import (
+        extract_decision_context_from_nats,
+        set_decision_context,
+    )
+except ImportError:
+
+    def extract_decision_context_from_nats(message_dict: Any) -> dict[str, Any]:
+        return {}
+
+    def set_decision_context(span: Any, **attributes: Any) -> None:
+        return None
+
+
+import constants
+from data_manager.consumer.nats_client import NATSClient
+from data_manager.models.decision import DecisionEvent
+from data_manager.utils.nats_trace_propagator import NATSTracePropagator
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+CIO_DECISIONS_COLLECTION = "cio_decisions"
+
+decision_messages_received = Counter(
+    "data_manager_decision_messages_received_total",
+    "Total CIO decision messages received from NATS",
+    ["subject"],
+)
+decision_messages_persisted = Counter(
+    "data_manager_decision_messages_persisted_total",
+    "Total CIO decision messages successfully persisted",
+)
+decision_messages_failed = Counter(
+    "data_manager_decision_messages_failed_total",
+    "Total CIO decision messages that failed processing",
+    ["error_type"],
+)
+decision_processing_time = Histogram(
+    "data_manager_decision_processing_seconds",
+    "CIO decision message processing time in seconds",
+)
+
+
+class DecisionConsumer:
+    """Subscribes to `signals.trading.>` and persists each event to MongoDB `cio_decisions`.
+
+    Wires OpenTelemetry decision context (decision_id, strategy_id, action) onto
+    each persistence span via petrosa-otel helpers, and emits structured log
+    fields matching the cross-service identifier contract. Captures the CIO
+    reasoning context (justification, thought_trace, correlation_id) per FR27.
+    """
+
+    def __init__(
+        self,
+        nats_client: NATSClient | None = None,
+        db_manager: Any | None = None,
+        subject: str | None = None,
+    ) -> None:
+        self.nats_client = nats_client or NATSClient()
+        self.db_manager = db_manager
+        self.subject = subject or constants.NATS_DECISION_SUBJECT
+        self.running = False
+        self.subscription: Any = None
+        self._message_queue: asyncio.Queue = asyncio.Queue(
+            maxsize=constants.MESSAGE_QUEUE_SIZE
+        )
+        self._processing_tasks: list[asyncio.Task] = []
+        self._owns_nats_client = nats_client is None
+
+    async def start(self) -> bool:
+        try:
+            logger.info("Starting decision consumer", extra={"subject": self.subject})
+
+            if self._owns_nats_client and not await self.nats_client.connect():
+                logger.error("Failed to connect to NATS for decision consumer")
+                return False
+
+            await self._ensure_indexes()
+
+            self.subscription = await self.nats_client.subscribe(
+                subject=self.subject,
+                callback=self._on_message,
+            )
+            if not self.subscription:
+                logger.error(
+                    "Failed to subscribe to decision subject",
+                    extra={"subject": self.subject},
+                )
+                return False
+
+            self.running = True
+            workers = min(constants.MAX_CONCURRENT_TASKS, 5)
+            for i in range(workers):
+                self._processing_tasks.append(asyncio.create_task(self._worker(i)))
+
+            logger.info(
+                "Decision consumer started",
+                extra={"subject": self.subject, "workers": workers},
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to start decision consumer: {e}", exc_info=True)
+            return False
+
+    async def stop(self) -> None:
+        logger.info("Stopping decision consumer")
+        self.running = False
+
+        if self._processing_tasks:
+            for task in self._processing_tasks:
+                task.cancel()
+            await asyncio.gather(*self._processing_tasks, return_exceptions=True)
+
+        if self.subscription:
+            try:
+                await self.subscription.unsubscribe()
+            except Exception as e:
+                logger.warning(f"Error unsubscribing decision consumer: {e}")
+
+        if self._owns_nats_client:
+            await self.nats_client.disconnect()
+
+        logger.info("Decision consumer stopped")
+
+    async def _ensure_indexes(self) -> None:
+        if not self.db_manager or not getattr(self.db_manager, "mongodb_adapter", None):
+            logger.warning(
+                "Decision consumer: MongoDB unavailable; persistence will no-op"
+            )
+            return
+        try:
+            await self.db_manager.mongodb_adapter.ensure_indexes(
+                CIO_DECISIONS_COLLECTION
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to ensure indexes for {CIO_DECISIONS_COLLECTION}: {e}"
+            )
+
+    async def _on_message(self, msg: Any) -> None:
+        try:
+            await self._message_queue.put(msg)
+        except asyncio.QueueFull:
+            logger.warning("Decision queue full; dropping message")
+            decision_messages_failed.labels(error_type="queue_full").inc()
+
+    async def _worker(self, worker_id: int) -> None:
+        logger.info(f"Decision worker {worker_id} started")
+        try:
+            while self.running:
+                try:
+                    msg = await asyncio.wait_for(self._message_queue.get(), timeout=1.0)
+                except TimeoutError:
+                    continue
+                try:
+                    await self._process_message(msg)
+                except Exception as e:
+                    logger.error(
+                        f"Error in decision worker {worker_id}: {e}", exc_info=True
+                    )
+                    decision_messages_failed.labels(error_type="processing").inc()
+        except asyncio.CancelledError:
+            pass
+        logger.info(f"Decision worker {worker_id} stopped")
+
+    async def _process_message(self, msg: Any) -> None:
+        start_time = asyncio.get_event_loop().time()
+        subject = getattr(msg, "subject", self.subject)
+
+        try:
+            data = json.loads(msg.data.decode())
+        except (json.JSONDecodeError, AttributeError) as e:
+            logger.error(f"Failed to decode decision message: {e}")
+            decision_messages_failed.labels(error_type="json_decode").inc()
+            return
+
+        decision_messages_received.labels(subject=subject).inc()
+
+        with NATSTracePropagator.create_span_from_message(
+            tracer,
+            data,
+            "persist_decision_event",
+            span_kind=trace.SpanKind.CONSUMER,
+        ) as span:
+            span.set_attribute("messaging.destination", subject)
+
+            event = DecisionEvent.from_nats_message(data, subject=subject)
+            if event is None:
+                span.set_attribute("message.invalid", True)
+                logger.warning(
+                    "invalid_decision_message_received",
+                    extra={"subject": subject, "raw_data": data},
+                )
+                decision_messages_failed.labels(error_type="invalid_payload").inc()
+                return
+
+            decision_attrs: dict[str, Any] = {
+                "decision_id": event.decision_id,
+                "strategy_id": event.strategy_id,
+            }
+            if event.symbol:
+                decision_attrs["symbol"] = event.symbol
+            if event.action:
+                decision_attrs["action"] = event.action
+            embedded_ctx = extract_decision_context_from_nats(data)
+            for k, v in embedded_ctx.items():
+                decision_attrs.setdefault(k, v)
+            set_decision_context(span, **decision_attrs)
+
+            log_extra = {
+                "subject": subject,
+                "decision_id": event.decision_id,
+                "strategy_id": event.strategy_id,
+                "action": event.action,
+            }
+
+            persisted = await self._persist(event)
+            if persisted:
+                decision_messages_persisted.inc()
+                logger.debug("decision_persisted", extra=log_extra)
+                span.set_status(trace.Status(trace.StatusCode.OK))
+            else:
+                decision_messages_failed.labels(error_type="persistence").inc()
+                logger.warning("decision_persistence_skipped", extra=log_extra)
+                span.set_attribute("persistence.skipped", True)
+
+            decision_processing_time.observe(
+                asyncio.get_event_loop().time() - start_time
+            )
+
+    async def _persist(self, event: DecisionEvent) -> bool:
+        adapter = (
+            getattr(self.db_manager, "mongodb_adapter", None)
+            if self.db_manager
+            else None
+        )
+        if adapter is None or getattr(adapter, "db", None) is None:
+            return False
+        try:
+            doc = event.model_dump(exclude_none=True)
+            doc["_id"] = event.decision_id
+            doc = adapter._prepare_for_bson(doc)
+            try:
+                from pymongo.errors import DuplicateKeyError
+            except (
+                ImportError
+            ):  # pragma: no cover - pymongo always installed alongside motor
+                DuplicateKeyError = Exception  # type: ignore[assignment, misc]
+            try:
+                await adapter.db[CIO_DECISIONS_COLLECTION].insert_one(doc)
+                return True
+            except DuplicateKeyError:
+                logger.debug(
+                    "decision_already_persisted",
+                    extra={"decision_id": event.decision_id},
+                )
+                return True
+        except Exception as e:
+            logger.error(f"Failed to persist decision {event.decision_id}: {e}")
+            return False

--- a/data_manager/db/mongodb_adapter.py
+++ b/data_manager/db/mongodb_adapter.py
@@ -265,6 +265,16 @@ class MongoDBAdapter(BaseAdapter):
                     IndexModel([("decision_id", ASCENDING)], sparse=True),
                     IndexModel([("timestamp", ASCENDING)]),
                 ]
+            elif collection == "cio_decisions":
+                # Cross-service identifier contract (P0.2b): `cio_decisions` collection
+                # CIO has assigned decision_id by the time it publishes onto
+                # signals.trading.> — so decision_id is the unique key.
+                indexes = [
+                    IndexModel([("decision_id", ASCENDING)], unique=True),
+                    IndexModel([("strategy_id", ASCENDING)]),
+                    IndexModel([("timestamp", ASCENDING)]),
+                    IndexModel([("action", ASCENDING)]),
+                ]
             else:
                 # Default time-series indexes
                 indexes = [

--- a/data_manager/main.py
+++ b/data_manager/main.py
@@ -25,6 +25,7 @@ from prometheus_client import start_http_server
 
 import constants
 from data_manager.api.app import create_app
+from data_manager.consumer.decision_consumer import DecisionConsumer
 from data_manager.consumer.intent_consumer import IntentConsumer
 from data_manager.consumer.market_data_consumer import MarketDataConsumer
 from data_manager.db.database_manager import DatabaseManager
@@ -67,6 +68,7 @@ class DataManagerApp:
         self.db_manager: DatabaseManager | None = None
         self.consumer: MarketDataConsumer | None = None
         self.intent_consumer: IntentConsumer | None = None
+        self.decision_consumer: DecisionConsumer | None = None
         self.api_server_task: asyncio.Task | None = None
         self.leader_election: LeaderElectionManager | None = None
         self.backfill_orchestrator: BackfillOrchestrator | None = None
@@ -162,6 +164,14 @@ class DataManagerApp:
             else:
                 logger.error("Failed to start intent consumer")
 
+        # Initialize and start CIO decision consumer (P0.2b)
+        if constants.ENABLE_DECISION_CONSUMER:
+            self.decision_consumer = DecisionConsumer(db_manager=self.db_manager)
+            if await self.decision_consumer.start():
+                logger.info("Decision consumer started successfully")
+            else:
+                logger.error("Failed to start decision consumer")
+
         # Initialize backfill orchestrator
         if self.db_manager and constants.ENABLE_BACKFILLER:
             from data_manager.backfiller.orchestrator import BackfillOrchestrator
@@ -209,6 +219,11 @@ class DataManagerApp:
         if self.intent_consumer:
             await self.intent_consumer.stop()
             logger.info("Intent consumer stopped")
+
+        # Stop decision consumer
+        if self.decision_consumer:
+            await self.decision_consumer.stop()
+            logger.info("Decision consumer stopped")
 
         # Stop API server
         if self.api_server_task:

--- a/data_manager/models/decision.py
+++ b/data_manager/models/decision.py
@@ -1,0 +1,122 @@
+"""CIO decision event model persisted to the `cio_decisions` audit-trail collection (P0.2b)."""
+
+from datetime import datetime
+from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from pydantic import BaseModel, Field
+
+
+class DecisionEvent(BaseModel):
+    """A `signals.trading.*` NATS message persisted into the `cio_decisions` collection.
+
+    Publisher is `petrosa-cio` (post-routing legacy signal). Aligns with the
+    cross-service identifier contract: `decision_id` is the unique key here
+    (CIO has already assigned one before publishing onto `signals.trading.>`).
+    The full CIO reasoning context (`metadata.cio_justification`,
+    `metadata.thought_trace`, `metadata.correlation_id`) is captured under
+    `reasoning` to satisfy FR27.
+    """
+
+    decision_id: str = Field(..., description="CIO decision identifier (unique)")
+    strategy_id: str = Field(..., description="Strategy that produced the decision")
+    timestamp: datetime = Field(..., description="Event timestamp from publisher")
+    symbol: str | None = Field(default=None, description="Trading pair symbol")
+    action: str | None = Field(default=None, description="Decision action verb")
+    price: float | None = Field(default=None, description="Reference price")
+    quantity: float | None = Field(default=None, description="Order quantity")
+    confidence: float | None = Field(default=None, description="Publisher confidence")
+    source: str | None = Field(default=None, description="Publisher identifier")
+    reasoning: dict[str, Any] = Field(
+        default_factory=dict,
+        description="CIO reasoning context (justification, thought_trace, correlation_id)",
+    )
+    subject: str | None = Field(default=None, description="Originating NATS subject")
+    payload: dict[str, Any] = Field(
+        default_factory=dict, description="Full message body (post-trace-strip)"
+    )
+    received_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="Subscriber persistence timestamp",
+    )
+
+    @staticmethod
+    def from_nats_message(
+        msg_data: dict[str, Any], subject: str | None = None
+    ) -> "DecisionEvent | None":
+        """Parse a NATS JSON body into a DecisionEvent. Returns None if invalid.
+
+        Required fields: `decision_id`, `strategy_id`, `timestamp`. All others
+        are best-effort and may be missing in older payload shapes.
+        """
+        decision_id = msg_data.get("decision_id")
+        strategy_id = msg_data.get("strategy_id") or msg_data.get("strategy")
+        raw_ts = msg_data.get("timestamp")
+
+        if not decision_id or not strategy_id or not raw_ts:
+            return None
+
+        try:
+            if isinstance(raw_ts, datetime):
+                ts = raw_ts if raw_ts.tzinfo else raw_ts.replace(tzinfo=UTC)
+            elif isinstance(raw_ts, int | float):
+                ts = datetime.fromtimestamp(float(raw_ts), tz=UTC)
+            else:
+                ts = datetime.fromisoformat(str(raw_ts).replace("Z", "+00:00"))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            return None
+
+        def _maybe_float(v: Any) -> float | None:
+            if v is None:
+                return None
+            try:
+                return float(v)
+            except (ValueError, TypeError):
+                return None
+
+        metadata = msg_data.get("metadata") or {}
+        reasoning: dict[str, Any] = {}
+        if isinstance(metadata, dict):
+            for k in ("cio_justification", "thought_trace", "correlation_id"):
+                if metadata.get(k) is not None:
+                    reasoning[k] = metadata[k]
+
+        canonical = {
+            "decision_id",
+            "strategy_id",
+            "strategy",
+            "timestamp",
+            "symbol",
+            "action",
+            "price",
+            "quantity",
+            "confidence",
+            "source",
+            "metadata",
+            "_trace_context",
+            "_decision_context",
+        }
+        payload = {k: v for k, v in msg_data.items() if k not in canonical}
+
+        return DecisionEvent(
+            decision_id=str(decision_id),
+            strategy_id=str(strategy_id),
+            timestamp=ts,
+            symbol=(str(msg_data["symbol"]) if msg_data.get("symbol") else None),
+            action=(str(msg_data["action"]) if msg_data.get("action") else None),
+            price=_maybe_float(msg_data.get("price")),
+            quantity=_maybe_float(msg_data.get("quantity")),
+            confidence=_maybe_float(msg_data.get("confidence")),
+            source=(str(msg_data["source"]) if msg_data.get("source") else None),
+            reasoning=reasoning,
+            subject=subject,
+            payload=payload,
+        )

--- a/env.example
+++ b/env.example
@@ -10,6 +10,7 @@ NATS_URL=nats://localhost:4222
 NATS_CONSUMER_SUBJECT=binance.futures.websocket.data
 # Cross-service audit-trail subscribers (P0.2 epic)
 NATS_INTENT_SUBJECT=cio.intent.>
+NATS_DECISION_SUBJECT=signals.trading.>
 
 # PostgreSQL Configuration
 POSTGRES_HOST=localhost
@@ -31,6 +32,7 @@ ENABLE_BACKFILLER=true
 ENABLE_ANALYTICS=true
 ENABLE_API=true
 ENABLE_INTENT_CONSUMER=true
+ENABLE_DECISION_CONSUMER=true
 
 # Scheduling Configuration
 AUDIT_INTERVAL=300

--- a/tests/test_decision_consumer.py
+++ b/tests/test_decision_consumer.py
@@ -1,0 +1,246 @@
+"""Tests for the CIO decision consumer (P0.2b)."""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from data_manager.consumer.decision_consumer import (
+    CIO_DECISIONS_COLLECTION,
+    DecisionConsumer,
+)
+from data_manager.consumer.nats_client import NATSClient
+from data_manager.models.decision import DecisionEvent
+
+try:
+    from datetime import UTC
+except ImportError:
+    UTC = timezone.utc  # noqa: UP017
+
+
+@pytest.fixture
+def mock_nats_client_async():
+    return AsyncMock(spec=NATSClient)
+
+
+@pytest.fixture
+def mock_db_manager():
+    db_manager = MagicMock()
+    mongo = MagicMock()
+    mongo.ensure_indexes = AsyncMock()
+    mongo._prepare_for_bson = lambda d: d
+    mongo.db = MagicMock()
+    collection = MagicMock()
+    collection.insert_one = AsyncMock()
+    mongo.db.__getitem__.return_value = collection
+    db_manager.mongodb_adapter = mongo
+    return db_manager
+
+
+@pytest.fixture
+def decision_consumer(mock_nats_client_async, mock_db_manager):
+    return DecisionConsumer(
+        nats_client=mock_nats_client_async,
+        db_manager=mock_db_manager,
+        subject="signals.trading.>",
+    )
+
+
+def _decision_payload(**overrides):
+    base = {
+        "decision_id": "dec_20260518T120000000_xyz789",
+        "strategy_id": "strat_momentum_v1",
+        "timestamp": "2026-05-18T12:00:00+00:00",
+        "symbol": "BTCUSDT",
+        "action": "buy",
+        "price": 65000.0,
+        "current_price": 65000.0,
+        "quantity": 0.001,
+        "confidence": 0.9,
+        "source": "petrosa-cio",
+        "metadata": {
+            "correlation_id": "corr_abc",
+            "cio_justification": "Momentum + RSI confluence",
+            "thought_trace": [{"step": "momentum_check", "verdict": "bullish"}],
+        },
+        "extra_field": "preserved",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_decision_event_parses_valid_payload():
+    data = _decision_payload()
+    event = DecisionEvent.from_nats_message(
+        data, subject="signals.trading.strat_momentum_v1"
+    )
+    assert event is not None
+    assert event.decision_id == "dec_20260518T120000000_xyz789"
+    assert event.strategy_id == "strat_momentum_v1"
+    assert event.symbol == "BTCUSDT"
+    assert event.action == "buy"
+    assert event.price == 65000.0
+    assert event.quantity == 0.001
+    assert event.confidence == 0.9
+    assert event.source == "petrosa-cio"
+    assert event.subject == "signals.trading.strat_momentum_v1"
+    assert event.reasoning["correlation_id"] == "corr_abc"
+    assert event.reasoning["cio_justification"] == "Momentum + RSI confluence"
+    assert event.reasoning["thought_trace"][0]["verdict"] == "bullish"
+    assert event.payload == {"current_price": 65000.0, "extra_field": "preserved"}
+
+
+def test_decision_event_accepts_strategy_alias():
+    data = _decision_payload()
+    data.pop("strategy_id")
+    data["strategy"] = "strat_momentum_v1"
+    event = DecisionEvent.from_nats_message(data)
+    assert event is not None
+    assert event.strategy_id == "strat_momentum_v1"
+
+
+def test_decision_event_rejects_missing_required_fields():
+    assert DecisionEvent.from_nats_message({"decision_id": "x"}) is None
+    assert DecisionEvent.from_nats_message({"strategy_id": "s"}) is None
+    assert (
+        DecisionEvent.from_nats_message({"decision_id": "x", "strategy_id": "s"})
+        is None
+    )
+
+
+def test_decision_event_rejects_invalid_timestamp():
+    bad = _decision_payload(timestamp="not-a-date")
+    assert DecisionEvent.from_nats_message(bad) is None
+
+
+def test_decision_event_accepts_numeric_timestamp():
+    ts = datetime(2026, 5, 18, 12, 0, tzinfo=UTC)
+    epoch = ts.timestamp()
+    event = DecisionEvent.from_nats_message(_decision_payload(timestamp=epoch))
+    assert event is not None
+    assert event.timestamp == ts
+
+
+def test_decision_event_strips_trace_and_decision_context():
+    data = _decision_payload(
+        _trace_context={"traceparent": "00-..."},
+        _decision_context={"strategy_id": "x"},
+    )
+    event = DecisionEvent.from_nats_message(data)
+    assert event is not None
+    assert "_trace_context" not in event.payload
+    assert "_decision_context" not in event.payload
+
+
+def test_decision_event_handles_missing_metadata():
+    data = _decision_payload()
+    data.pop("metadata")
+    event = DecisionEvent.from_nats_message(data)
+    assert event is not None
+    assert event.reasoning == {}
+
+
+def _build_msg(payload, subject="signals.trading.strat_momentum_v1"):
+    msg = MagicMock()
+    msg.data.decode.return_value = json.dumps(payload)
+    msg.subject = subject
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_process_message_persists_decision(decision_consumer, mock_db_manager):
+    msg = _build_msg(_decision_payload())
+    await decision_consumer._process_message(msg)
+    collection = mock_db_manager.mongodb_adapter.db.__getitem__.return_value
+    collection.insert_one.assert_awaited_once()
+    inserted = collection.insert_one.await_args.args[0]
+    assert inserted["_id"] == "dec_20260518T120000000_xyz789"
+    assert inserted["decision_id"] == "dec_20260518T120000000_xyz789"
+    assert inserted["strategy_id"] == "strat_momentum_v1"
+    assert inserted["action"] == "buy"
+    assert inserted["reasoning"]["cio_justification"] == "Momentum + RSI confluence"
+
+
+@pytest.mark.asyncio
+async def test_process_message_skips_invalid_payload(
+    decision_consumer, mock_db_manager
+):
+    msg = _build_msg({"only": "garbage"})
+    await decision_consumer._process_message(msg)
+    collection = mock_db_manager.mongodb_adapter.db.__getitem__.return_value
+    collection.insert_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_message_handles_invalid_json(decision_consumer, mock_db_manager):
+    msg = MagicMock()
+    msg.data.decode.return_value = "{not-json}"
+    msg.subject = "signals.trading.strat_momentum_v1"
+    await decision_consumer._process_message(msg)
+    collection = mock_db_manager.mongodb_adapter.db.__getitem__.return_value
+    collection.insert_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_message_sets_decision_context_attrs(decision_consumer):
+    msg = _build_msg(_decision_payload())
+    with patch(
+        "data_manager.consumer.decision_consumer.set_decision_context"
+    ) as mock_set:
+        await decision_consumer._process_message(msg)
+    assert mock_set.called
+    _, kwargs = mock_set.call_args
+    assert kwargs["decision_id"] == "dec_20260518T120000000_xyz789"
+    assert kwargs["strategy_id"] == "strat_momentum_v1"
+    assert kwargs["symbol"] == "BTCUSDT"
+    assert kwargs["action"] == "buy"
+
+
+@pytest.mark.asyncio
+async def test_persist_tolerates_duplicate_key(decision_consumer, mock_db_manager):
+    collection = mock_db_manager.mongodb_adapter.db.__getitem__.return_value
+    try:
+        from pymongo.errors import DuplicateKeyError
+    except ImportError:
+        DuplicateKeyError = Exception  # type: ignore[assignment, misc]
+    collection.insert_one.side_effect = DuplicateKeyError("dup")
+    event = DecisionEvent.from_nats_message(_decision_payload())
+    assert event is not None
+    assert await decision_consumer._persist(event) is True
+
+
+@pytest.mark.asyncio
+async def test_persist_returns_false_without_adapter(decision_consumer):
+    decision_consumer.db_manager = None
+    event = DecisionEvent.from_nats_message(_decision_payload())
+    assert event is not None
+    assert await decision_consumer._persist(event) is False
+
+
+@pytest.mark.asyncio
+async def test_start_subscribes_to_configured_subject(
+    decision_consumer, mock_nats_client_async, mock_db_manager
+):
+    mock_nats_client_async.subscribe.return_value = MagicMock()
+    decision_consumer._owns_nats_client = False  # don't drive connect()
+    started = await decision_consumer.start()
+    assert started is True
+    assert (
+        mock_nats_client_async.subscribe.await_args.kwargs["subject"]
+        == "signals.trading.>"
+    )
+    mock_db_manager.mongodb_adapter.ensure_indexes.assert_awaited_once_with(
+        CIO_DECISIONS_COLLECTION
+    )
+    await decision_consumer.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_returns_false_when_subscribe_fails(
+    decision_consumer, mock_nats_client_async
+):
+    mock_nats_client_async.subscribe.return_value = None
+    decision_consumer._owns_nats_client = False
+    started = await decision_consumer.start()
+    assert started is False


### PR DESCRIPTION
## Summary

Implements **P0.2b** of the unified audit-trail epic (PetroSa2/petrosa_k8s#585): subscribe `signals.trading.>` into a new MongoDB `cio_decisions` collection, wired with the cross-service identifier contract and the FR27 reasoning-context capture.

- New `DecisionEvent` pydantic model parses NATS payloads (`decision_id` / `strategy_id` / `timestamp` required; CIO has already assigned `decision_id` before publishing onto `signals.trading.>`, so `decision_id` is the unique key)
- Lifts `metadata.cio_justification`, `metadata.thought_trace`, and `metadata.correlation_id` into a top-level `reasoning` field per FR27
- New `DecisionConsumer` mirrors `IntentConsumer` shape with its own prometheus counters / histogram, queue + worker pool, graceful shutdown
- Uses `petrosa_otel.set_decision_context()` + `extract_decision_context_from_nats()` to propagate `decision.*` OTel span attrs onto every persistence span
- `MongoDBAdapter.ensure_indexes` gains a `cio_decisions` branch with the 4 indexes required by the ticket: `decision_id` (unique), `strategy_id`, `timestamp`, `action`
- `main.py` wires `DecisionConsumer` into `DataManagerApp` lifecycle behind `ENABLE_DECISION_CONSUMER` (default true) with `NATS_DECISION_SUBJECT` (default `signals.trading.>`)
- `env.example` + `constants.py` updated

### Acceptance criteria (from PetroSa2/petrosa_k8s#585)

- [x] NATS subscription on `signals.trading.>` working — `DecisionConsumer.start()` subscribes with the canonical wildcard (bare `signals.trading` is not delivered per the publisher contract)
- [x] `cio_decisions` collection + indexes created — `ensure_indexes("cio_decisions")` runs on consumer start with the 4 required indexes (`decision_id` unique, `strategy_id`, `timestamp`, `action`)
- [x] Reasoning-context field captured per FR27 — `DecisionEvent.reasoning` lifts `cio_justification`, `thought_trace`, and `correlation_id` from `metadata`
- [x] OTel + structured-log fields set on every persistence span — `set_decision_context(span, decision_id=…, strategy_id=…, symbol=…, action=…)` plus structured `extra={…}` on log calls

## Test plan

- [x] 15 unit tests on `DecisionConsumer` cover happy path, missing required fields, invalid timestamp shapes, numeric timestamp coercion, trace/decision-context payload stripping, strategy alias (`strategy` vs `strategy_id`), missing metadata, MongoDB persistence with `_id == decision_id`, DuplicateKeyError tolerance, no-adapter no-op, subscription wiring, and subscribe-failure handling — all passing locally on Python 3.13
- [x] Existing `IntentConsumer`, `MongoDBAdapter`, and `DataManagerApp` test files still pass (no regressions in 36-test focused run; full suite 549 pass / 1 pre-existing `test_setup.py` failure unrelated to these changes — reproduces on `main`)
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)