### PR TITLE
feat(nats): #586 - subscribe execution.events.> and persist into execution_events (AC3, AC5)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -20,6 +20,14 @@ NATS_CONSUMER_SUBJECT = os.getenv(
 # Audit-trail subscribers (cross-service identifier contract, P0.2 epic)
 NATS_INTENT_SUBJECT = os.getenv("NATS_INTENT_SUBJECT", "cio.intent.>")
 NATS_DECISION_SUBJECT = os.getenv("NATS_DECISION_SUBJECT", "signals.trading.>")
+# P0.2c: tradeengine publishes onto <prefix>.<strategy_id>; we subscribe
+# with the `>` wildcard. Prefix comes from petrosa-common-config.
+NATS_TOPIC_EXECUTION_EVENTS = os.getenv(
+    "NATS_TOPIC_EXECUTION_EVENTS", "execution.events"
+)
+NATS_EXECUTION_EVENTS_SUBJECT = os.getenv(
+    "NATS_EXECUTION_EVENTS_SUBJECT", f"{NATS_TOPIC_EXECUTION_EVENTS}.>"
+)
 NATS_CLIENT_NAME = f"{SERVICE_NAME}-consumer"
 NATS_CONNECT_TIMEOUT = int(os.getenv("NATS_CONNECT_TIMEOUT", "10"))
 NATS_MAX_RECONNECT_ATTEMPTS = int(os.getenv("NATS_MAX_RECONNECT_ATTEMPTS", "10"))
@@ -56,6 +64,9 @@ ENABLE_API = os.getenv("ENABLE_API", "true").lower() == "true"
 ENABLE_INTENT_CONSUMER = os.getenv("ENABLE_INTENT_CONSUMER", "true").lower() == "true"
 ENABLE_DECISION_CONSUMER = (
     os.getenv("ENABLE_DECISION_CONSUMER", "true").lower() == "true"
+)
+ENABLE_EXECUTION_EVENTS_CONSUMER = (
+    os.getenv("ENABLE_EXECUTION_EVENTS_CONSUMER", "true").lower() == "true"
 )
 
 # Scheduling Configuration

--- a/data_manager/consumer/execution_events_consumer.py
+++ b/data_manager/consumer/execution_events_consumer.py
@@ -1,0 +1,287 @@
+"""Execution-events NATS consumer that persists into `execution_events` (P0.2c)."""
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from opentelemetry import trace
+from prometheus_client import Counter, Histogram
+
+try:
+    from petrosa_otel import (
+        extract_decision_context_from_nats,
+        set_decision_context,
+    )
+except ImportError:
+
+    def extract_decision_context_from_nats(message_dict: Any) -> dict[str, Any]:
+        return {}
+
+    def set_decision_context(span: Any, **attributes: Any) -> None:
+        return None
+
+
+import constants
+from data_manager.consumer.nats_client import NATSClient
+from data_manager.models.execution_event import ExecutionEvent
+from data_manager.utils.nats_trace_propagator import NATSTracePropagator
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+EXECUTION_EVENTS_COLLECTION = "execution_events"
+
+execution_messages_received = Counter(
+    "data_manager_execution_messages_received_total",
+    "Total execution-event messages received from NATS",
+    ["subject"],
+)
+execution_messages_persisted = Counter(
+    "data_manager_execution_messages_persisted_total",
+    "Total execution-event messages successfully persisted",
+)
+execution_messages_failed = Counter(
+    "data_manager_execution_messages_failed_total",
+    "Total execution-event messages that failed processing",
+    ["error_type"],
+)
+execution_processing_time = Histogram(
+    "data_manager_execution_processing_seconds",
+    "Execution-event message processing time in seconds",
+)
+
+
+class ExecutionEventsConsumer:
+    """Subscribes to `execution.events.>` and persists each event to MongoDB.
+
+    Mirrors `DecisionConsumer` / `IntentConsumer` exactly so that operational
+    behaviour (queue sizing, worker concurrency, OTel context propagation,
+    DuplicateKeyError tolerance) stays uniform across the four audit-trail
+    subscribers (P0.2a/b/c/d).
+    """
+
+    def __init__(
+        self,
+        nats_client: NATSClient | None = None,
+        db_manager: Any | None = None,
+        subject: str | None = None,
+    ) -> None:
+        self.nats_client = nats_client or NATSClient()
+        self.db_manager = db_manager
+        self.subject = subject or constants.NATS_EXECUTION_EVENTS_SUBJECT
+        self.running = False
+        self.subscription: Any = None
+        self._message_queue: asyncio.Queue = asyncio.Queue(
+            maxsize=constants.MESSAGE_QUEUE_SIZE
+        )
+        self._processing_tasks: list[asyncio.Task] = []
+        self._owns_nats_client = nats_client is None
+
+    async def start(self) -> bool:
+        try:
+            logger.info(
+                "Starting execution events consumer", extra={"subject": self.subject}
+            )
+
+            if self._owns_nats_client and not await self.nats_client.connect():
+                logger.error("Failed to connect to NATS for execution events consumer")
+                return False
+
+            await self._ensure_indexes()
+
+            self.subscription = await self.nats_client.subscribe(
+                subject=self.subject,
+                callback=self._on_message,
+            )
+            if not self.subscription:
+                logger.error(
+                    "Failed to subscribe to execution events subject",
+                    extra={"subject": self.subject},
+                )
+                return False
+
+            self.running = True
+            workers = min(constants.MAX_CONCURRENT_TASKS, 5)
+            for i in range(workers):
+                self._processing_tasks.append(asyncio.create_task(self._worker(i)))
+
+            logger.info(
+                "Execution events consumer started",
+                extra={"subject": self.subject, "workers": workers},
+            )
+            return True
+        except Exception as e:
+            logger.error(
+                f"Failed to start execution events consumer: {e}", exc_info=True
+            )
+            return False
+
+    async def stop(self) -> None:
+        logger.info("Stopping execution events consumer")
+        self.running = False
+
+        if self._processing_tasks:
+            for task in self._processing_tasks:
+                task.cancel()
+            await asyncio.gather(*self._processing_tasks, return_exceptions=True)
+
+        if self.subscription:
+            try:
+                await self.subscription.unsubscribe()
+            except Exception as e:
+                logger.warning(f"Error unsubscribing execution events consumer: {e}")
+
+        if self._owns_nats_client:
+            await self.nats_client.disconnect()
+
+        logger.info("Execution events consumer stopped")
+
+    async def _ensure_indexes(self) -> None:
+        if not self.db_manager or not getattr(self.db_manager, "mongodb_adapter", None):
+            logger.warning(
+                "Execution events consumer: MongoDB unavailable; persistence will no-op"
+            )
+            return
+        try:
+            await self.db_manager.mongodb_adapter.ensure_indexes(
+                EXECUTION_EVENTS_COLLECTION
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to ensure indexes for {EXECUTION_EVENTS_COLLECTION}: {e}"
+            )
+
+    async def _on_message(self, msg: Any) -> None:
+        try:
+            await self._message_queue.put(msg)
+        except asyncio.QueueFull:
+            logger.warning("Execution events queue full; dropping message")
+            execution_messages_failed.labels(error_type="queue_full").inc()
+
+    async def _worker(self, worker_id: int) -> None:
+        logger.info(f"Execution events worker {worker_id} started")
+        try:
+            while self.running:
+                try:
+                    msg = await asyncio.wait_for(self._message_queue.get(), timeout=1.0)
+                except TimeoutError:
+                    continue
+                try:
+                    await self._process_message(msg)
+                except Exception as e:
+                    logger.error(
+                        f"Error in execution events worker {worker_id}: {e}",
+                        exc_info=True,
+                    )
+                    execution_messages_failed.labels(error_type="processing").inc()
+        except asyncio.CancelledError:
+            pass
+        logger.info(f"Execution events worker {worker_id} stopped")
+
+    async def _process_message(self, msg: Any) -> None:
+        start_time = asyncio.get_event_loop().time()
+        subject = getattr(msg, "subject", self.subject)
+
+        try:
+            data = json.loads(msg.data.decode())
+        except (json.JSONDecodeError, AttributeError) as e:
+            logger.error(f"Failed to decode execution event message: {e}")
+            execution_messages_failed.labels(error_type="json_decode").inc()
+            return
+
+        execution_messages_received.labels(subject=subject).inc()
+
+        with NATSTracePropagator.create_span_from_message(
+            tracer,
+            data,
+            "persist_execution_event",
+            span_kind=trace.SpanKind.CONSUMER,
+        ) as span:
+            span.set_attribute("messaging.destination", subject)
+
+            event = ExecutionEvent.from_nats_message(data, subject=subject)
+            if event is None:
+                span.set_attribute("message.invalid", True)
+                logger.warning(
+                    "invalid_execution_event_received",
+                    extra={"subject": subject, "raw_data": data},
+                )
+                execution_messages_failed.labels(error_type="invalid_payload").inc()
+                return
+
+            # Span attribute names match the cross-service identifier contract;
+            # `execution.event_type` is consumed by the audit evaluator (FR22).
+            span.set_attribute("decision.decision_id", event.decision_id)
+            span.set_attribute("execution.event_type", event.event_type)
+            span.set_attribute("execution.order_id", event.order_id)
+
+            decision_attrs: dict[str, Any] = {
+                "decision_id": event.decision_id,
+                "strategy_id": event.strategy_id,
+            }
+            if event.symbol:
+                decision_attrs["symbol"] = event.symbol
+            embedded_ctx = extract_decision_context_from_nats(data)
+            for k, v in embedded_ctx.items():
+                decision_attrs.setdefault(k, v)
+            set_decision_context(span, **decision_attrs)
+
+            log_extra = {
+                "subject": subject,
+                "decision_id": event.decision_id,
+                "strategy_id": event.strategy_id,
+                "order_id": event.order_id,
+                "event_type": event.event_type,
+            }
+
+            persisted = await self._persist(event)
+            if persisted:
+                execution_messages_persisted.inc()
+                logger.info("execution_event_persisted", extra=log_extra)
+                span.set_status(trace.Status(trace.StatusCode.OK))
+            else:
+                execution_messages_failed.labels(error_type="persistence").inc()
+                logger.warning("execution_event_persistence_skipped", extra=log_extra)
+                span.set_attribute("persistence.skipped", True)
+
+            execution_processing_time.observe(
+                asyncio.get_event_loop().time() - start_time
+            )
+
+    async def _persist(self, event: ExecutionEvent) -> bool:
+        adapter = (
+            getattr(self.db_manager, "mongodb_adapter", None)
+            if self.db_manager
+            else None
+        )
+        if adapter is None or getattr(adapter, "db", None) is None:
+            return False
+        try:
+            doc = event.model_dump(exclude_none=True)
+            # Unique key combines order_id + event_type — the same order produces
+            # multiple events (placed, then filled, etc.) and each must persist.
+            doc["_id"] = f"{event.order_id}:{event.event_type}"
+            doc = adapter._prepare_for_bson(doc)
+            try:
+                from pymongo.errors import DuplicateKeyError
+            except ImportError:  # pragma: no cover - pymongo ships with motor
+                DuplicateKeyError = Exception  # type: ignore[assignment, misc]
+            try:
+                await adapter.db[EXECUTION_EVENTS_COLLECTION].insert_one(doc)
+                return True
+            except DuplicateKeyError:
+                logger.debug(
+                    "execution_event_already_persisted",
+                    extra={
+                        "order_id": event.order_id,
+                        "event_type": event.event_type,
+                    },
+                )
+                return True
+        except Exception as e:
+            logger.error(
+                f"Failed to persist execution event "
+                f"{event.order_id}:{event.event_type}: {e}"
+            )
+            return False

--- a/data_manager/db/mongodb_adapter.py
+++ b/data_manager/db/mongodb_adapter.py
@@ -275,6 +275,19 @@ class MongoDBAdapter(BaseAdapter):
                     IndexModel([("timestamp", ASCENDING)]),
                     IndexModel([("action", ASCENDING)]),
                 ]
+            elif collection == "execution_events":
+                # Cross-service identifier contract (P0.2c): `execution_events` collection
+                # The same order_id emits multiple events (placed → filled, etc.)
+                # so neither order_id alone nor decision_id alone is unique;
+                # uniqueness is enforced via the synthesized `_id`
+                # (order_id:event_type) on insert.
+                indexes = [
+                    IndexModel([("decision_id", ASCENDING)]),
+                    IndexModel([("order_id", ASCENDING)]),
+                    IndexModel([("strategy_id", ASCENDING)]),
+                    IndexModel([("timestamp", ASCENDING)]),
+                    IndexModel([("event_type", ASCENDING)]),
+                ]
             else:
                 # Default time-series indexes
                 indexes = [

--- a/data_manager/main.py
+++ b/data_manager/main.py
@@ -26,6 +26,7 @@ from prometheus_client import start_http_server
 import constants
 from data_manager.api.app import create_app
 from data_manager.consumer.decision_consumer import DecisionConsumer
+from data_manager.consumer.execution_events_consumer import ExecutionEventsConsumer
 from data_manager.consumer.intent_consumer import IntentConsumer
 from data_manager.consumer.market_data_consumer import MarketDataConsumer
 from data_manager.db.database_manager import DatabaseManager
@@ -69,6 +70,7 @@ class DataManagerApp:
         self.consumer: MarketDataConsumer | None = None
         self.intent_consumer: IntentConsumer | None = None
         self.decision_consumer: DecisionConsumer | None = None
+        self.execution_events_consumer: ExecutionEventsConsumer | None = None
         self.api_server_task: asyncio.Task | None = None
         self.leader_election: LeaderElectionManager | None = None
         self.backfill_orchestrator: BackfillOrchestrator | None = None
@@ -172,6 +174,16 @@ class DataManagerApp:
             else:
                 logger.error("Failed to start decision consumer")
 
+        # Initialize and start execution events consumer (P0.2c)
+        if constants.ENABLE_EXECUTION_EVENTS_CONSUMER:
+            self.execution_events_consumer = ExecutionEventsConsumer(
+                db_manager=self.db_manager
+            )
+            if await self.execution_events_consumer.start():
+                logger.info("Execution events consumer started successfully")
+            else:
+                logger.error("Failed to start execution events consumer")
+
         # Initialize backfill orchestrator
         if self.db_manager and constants.ENABLE_BACKFILLER:
             from data_manager.backfiller.orchestrator import BackfillOrchestrator
@@ -224,6 +236,11 @@ class DataManagerApp:
         if self.decision_consumer:
             await self.decision_consumer.stop()
             logger.info("Decision consumer stopped")
+
+        # Stop execution events consumer
+        if self.execution_events_consumer:
+            await self.execution_events_consumer.stop()
+            logger.info("Execution events consumer stopped")
 
         # Stop API server
         if self.api_server_task:

--- a/data_manager/models/execution_event.py
+++ b/data_manager/models/execution_event.py
@@ -1,0 +1,129 @@
+"""Execution event model persisted to the `execution_events` audit-trail collection (P0.2c)."""
+
+from datetime import datetime
+from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from pydantic import BaseModel, Field
+
+# `event_type` must match the publisher contract — kept as a constant set so
+# we can validate without coupling to an Enum (publishers may add new ones).
+KNOWN_EVENT_TYPES = {"placed", "filled", "rejected", "partial_fill"}
+
+
+class ExecutionEvent(BaseModel):
+    """An `execution.events.*` NATS message persisted into `execution_events`.
+
+    Publisher is `petrosa-tradeengine`. Aligns with the cross-service
+    identifier contract (petrosa_k8s/docs/cross-service-identifier-contract.md):
+    `decision_id` is required so that order outcomes can be joined back to
+    the CIO decision that produced them. `order_id` and `event_type` are
+    also required for the audit-trail to be meaningful.
+    """
+
+    decision_id: str = Field(..., description="CIO decision identifier")
+    strategy_id: str = Field(..., description="Strategy that produced the decision")
+    order_id: str = Field(..., description="Exchange / engine order identifier")
+    event_type: str = Field(
+        ..., description="placed | filled | rejected | partial_fill"
+    )
+    timestamp: datetime = Field(..., description="Event timestamp from publisher")
+    reason: str | None = Field(
+        default=None, description="Structured reason (esp. for rejected / partial_fill)"
+    )
+    symbol: str | None = Field(default=None, description="Trading pair symbol")
+    side: str | None = Field(default=None, description="buy / sell")
+    qty: float | None = Field(default=None, description="Requested order quantity")
+    fill_qty: float | None = Field(
+        default=None, description="Filled quantity (present on filled / partial_fill)"
+    )
+    price: float | None = Field(default=None, description="Reference / fill price")
+    subject: str | None = Field(default=None, description="Originating NATS subject")
+    payload: dict[str, Any] = Field(
+        default_factory=dict, description="Full message body (post-trace-strip)"
+    )
+    received_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="Subscriber persistence timestamp",
+    )
+
+    @staticmethod
+    def from_nats_message(
+        msg_data: dict[str, Any], subject: str | None = None
+    ) -> "ExecutionEvent | None":
+        """Parse a NATS JSON body into an ExecutionEvent. Returns None if invalid.
+
+        Required: `decision_id`, `strategy_id`, `order_id`, `event_type`,
+        `timestamp`. All others are best-effort.
+        """
+        decision_id = msg_data.get("decision_id")
+        strategy_id = msg_data.get("strategy_id") or msg_data.get("strategy")
+        order_id = msg_data.get("order_id")
+        event_type = msg_data.get("event_type")
+        raw_ts = msg_data.get("timestamp")
+
+        if not decision_id or not strategy_id or not order_id or not event_type:
+            return None
+        if not raw_ts:
+            return None
+
+        try:
+            if isinstance(raw_ts, datetime):
+                ts = raw_ts if raw_ts.tzinfo else raw_ts.replace(tzinfo=UTC)
+            elif isinstance(raw_ts, int | float):
+                ts = datetime.fromtimestamp(float(raw_ts), tz=UTC)
+            else:
+                ts = datetime.fromisoformat(str(raw_ts).replace("Z", "+00:00"))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            return None
+
+        def _maybe_float(v: Any) -> float | None:
+            if v is None:
+                return None
+            try:
+                return float(v)
+            except (ValueError, TypeError):
+                return None
+
+        canonical = {
+            "decision_id",
+            "strategy_id",
+            "strategy",
+            "order_id",
+            "event_type",
+            "timestamp",
+            "reason",
+            "symbol",
+            "side",
+            "qty",
+            "fill_qty",
+            "price",
+            "_trace_context",
+            "_decision_context",
+            "_otel_trace_headers",
+        }
+        payload = {k: v for k, v in msg_data.items() if k not in canonical}
+
+        return ExecutionEvent(
+            decision_id=str(decision_id),
+            strategy_id=str(strategy_id),
+            order_id=str(order_id),
+            event_type=str(event_type),
+            timestamp=ts,
+            reason=(str(msg_data["reason"]) if msg_data.get("reason") else None),
+            symbol=(str(msg_data["symbol"]) if msg_data.get("symbol") else None),
+            side=(str(msg_data["side"]) if msg_data.get("side") else None),
+            qty=_maybe_float(msg_data.get("qty")),
+            fill_qty=_maybe_float(msg_data.get("fill_qty")),
+            price=_maybe_float(msg_data.get("price")),
+            subject=subject,
+            payload=payload,
+        )

--- a/tests/test_execution_events_consumer.py
+++ b/tests/test_execution_events_consumer.py
@@ -1,0 +1,286 @@
+"""Tests for the execution events consumer (P0.2c)."""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from data_manager.consumer.execution_events_consumer import (
+    EXECUTION_EVENTS_COLLECTION,
+    ExecutionEventsConsumer,
+)
+from data_manager.consumer.nats_client import NATSClient
+from data_manager.models.execution_event import ExecutionEvent
+
+try:
+    from datetime import UTC
+except ImportError:
+    UTC = timezone.utc  # noqa: UP017
+
+
+@pytest.fixture
+def mock_nats_client_async():
+    return AsyncMock(spec=NATSClient)
+
+
+@pytest.fixture
+def mock_db_manager():
+    db_manager = MagicMock()
+    mongo = MagicMock()
+    mongo.ensure_indexes = AsyncMock()
+    mongo._prepare_for_bson = lambda d: d
+    mongo.db = MagicMock()
+    collection = MagicMock()
+    collection.insert_one = AsyncMock()
+    mongo.db.__getitem__.return_value = collection
+    db_manager.mongodb_adapter = mongo
+    return db_manager
+
+
+@pytest.fixture
+def execution_events_consumer(mock_nats_client_async, mock_db_manager):
+    return ExecutionEventsConsumer(
+        nats_client=mock_nats_client_async,
+        db_manager=mock_db_manager,
+        subject="execution.events.>",
+    )
+
+
+def _exec_payload(**overrides):
+    base = {
+        "decision_id": "dec_20260518T120000000_xyz789",
+        "strategy_id": "strat_momentum_v1",
+        "order_id": "ord_abc123",
+        "event_type": "filled",
+        "timestamp": "2026-05-18T12:00:01+00:00",
+        "reason": "fully filled at market",
+        "symbol": "BTCUSDT",
+        "side": "buy",
+        "qty": 0.001,
+        "fill_qty": 0.001,
+        "price": 65010.0,
+        "exchange_order_id": "binance-9988",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_execution_event_parses_valid_payload():
+    data = _exec_payload()
+    event = ExecutionEvent.from_nats_message(
+        data, subject="execution.events.strat_momentum_v1"
+    )
+    assert event is not None
+    assert event.decision_id == "dec_20260518T120000000_xyz789"
+    assert event.strategy_id == "strat_momentum_v1"
+    assert event.order_id == "ord_abc123"
+    assert event.event_type == "filled"
+    assert event.symbol == "BTCUSDT"
+    assert event.side == "buy"
+    assert event.qty == 0.001
+    assert event.fill_qty == 0.001
+    assert event.price == 65010.0
+    assert event.reason == "fully filled at market"
+    assert event.subject == "execution.events.strat_momentum_v1"
+    assert event.payload == {"exchange_order_id": "binance-9988"}
+
+
+def test_execution_event_accepts_strategy_alias():
+    data = _exec_payload()
+    data.pop("strategy_id")
+    data["strategy"] = "strat_momentum_v1"
+    event = ExecutionEvent.from_nats_message(data)
+    assert event is not None
+    assert event.strategy_id == "strat_momentum_v1"
+
+
+def test_execution_event_rejects_missing_required_fields():
+    assert ExecutionEvent.from_nats_message({"decision_id": "x"}) is None
+    base = _exec_payload()
+    for field in ("decision_id", "strategy_id", "order_id", "event_type", "timestamp"):
+        payload = dict(base)
+        payload.pop(field)
+        assert ExecutionEvent.from_nats_message(payload) is None, (
+            f"Expected None when {field} missing"
+        )
+
+
+def test_execution_event_rejects_invalid_timestamp():
+    bad = _exec_payload(timestamp="not-a-date")
+    assert ExecutionEvent.from_nats_message(bad) is None
+
+
+def test_execution_event_accepts_numeric_timestamp():
+    ts = datetime(2026, 5, 18, 12, 0, tzinfo=UTC)
+    epoch = ts.timestamp()
+    event = ExecutionEvent.from_nats_message(_exec_payload(timestamp=epoch))
+    assert event is not None
+    assert event.timestamp == ts
+
+
+def test_execution_event_strips_trace_and_decision_context():
+    data = _exec_payload(
+        _trace_context={"traceparent": "00-..."},
+        _decision_context={"strategy_id": "x"},
+        _otel_trace_headers={"traceparent": "00-..."},
+    )
+    event = ExecutionEvent.from_nats_message(data)
+    assert event is not None
+    assert "_trace_context" not in event.payload
+    assert "_decision_context" not in event.payload
+    assert "_otel_trace_headers" not in event.payload
+
+
+def _build_msg(payload, subject="execution.events.strat_momentum_v1"):
+    msg = MagicMock()
+    msg.data.decode.return_value = json.dumps(payload)
+    msg.subject = subject
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_process_message_persists_execution_event(
+    execution_events_consumer, mock_db_manager
+):
+    msg = _build_msg(_exec_payload())
+    await execution_events_consumer._process_message(msg)
+    collection = mock_db_manager.mongodb_adapter.db.__getitem__.return_value
+    collection.insert_one.assert_awaited_once()
+    inserted = collection.insert_one.await_args.args[0]
+    # Synthesized _id keeps multi-event-per-order persistence idempotent.
+    assert inserted["_id"] == "ord_abc123:filled"
+    assert inserted["decision_id"] == "dec_20260518T120000000_xyz789"
+    assert inserted["order_id"] == "ord_abc123"
+    assert inserted["event_type"] == "filled"
+    assert inserted["fill_qty"] == 0.001
+
+
+@pytest.mark.asyncio
+async def test_process_message_skips_invalid_payload(
+    execution_events_consumer, mock_db_manager
+):
+    msg = _build_msg({"only": "garbage"})
+    await execution_events_consumer._process_message(msg)
+    collection = mock_db_manager.mongodb_adapter.db.__getitem__.return_value
+    collection.insert_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_message_handles_invalid_json(
+    execution_events_consumer, mock_db_manager
+):
+    msg = MagicMock()
+    msg.data.decode.return_value = "{not-json}"
+    msg.subject = "execution.events.strat_momentum_v1"
+    await execution_events_consumer._process_message(msg)
+    collection = mock_db_manager.mongodb_adapter.db.__getitem__.return_value
+    collection.insert_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_message_sets_decision_context_attrs(execution_events_consumer):
+    msg = _build_msg(_exec_payload())
+    with patch(
+        "data_manager.consumer.execution_events_consumer.set_decision_context"
+    ) as mock_set:
+        await execution_events_consumer._process_message(msg)
+    assert mock_set.called
+    _, kwargs = mock_set.call_args
+    assert kwargs["decision_id"] == "dec_20260518T120000000_xyz789"
+    assert kwargs["strategy_id"] == "strat_momentum_v1"
+    assert kwargs["symbol"] == "BTCUSDT"
+
+
+@pytest.mark.asyncio
+async def test_persist_tolerates_duplicate_key(
+    execution_events_consumer, mock_db_manager
+):
+    collection = mock_db_manager.mongodb_adapter.db.__getitem__.return_value
+    try:
+        from pymongo.errors import DuplicateKeyError
+    except ImportError:
+        DuplicateKeyError = Exception  # type: ignore[assignment, misc]
+    collection.insert_one.side_effect = DuplicateKeyError("dup")
+    event = ExecutionEvent.from_nats_message(_exec_payload())
+    assert event is not None
+    assert await execution_events_consumer._persist(event) is True
+
+
+@pytest.mark.asyncio
+async def test_persist_returns_false_without_adapter(execution_events_consumer):
+    execution_events_consumer.db_manager = None
+    event = ExecutionEvent.from_nats_message(_exec_payload())
+    assert event is not None
+    assert await execution_events_consumer._persist(event) is False
+
+
+@pytest.mark.asyncio
+async def test_start_subscribes_to_configured_subject(
+    execution_events_consumer, mock_nats_client_async, mock_db_manager
+):
+    mock_nats_client_async.subscribe.return_value = MagicMock()
+    execution_events_consumer._owns_nats_client = False
+    started = await execution_events_consumer.start()
+    assert started is True
+    assert (
+        mock_nats_client_async.subscribe.await_args.kwargs["subject"]
+        == "execution.events.>"
+    )
+    mock_db_manager.mongodb_adapter.ensure_indexes.assert_awaited_once_with(
+        EXECUTION_EVENTS_COLLECTION
+    )
+    await execution_events_consumer.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_returns_false_when_subscribe_fails(
+    execution_events_consumer, mock_nats_client_async
+):
+    mock_nats_client_async.subscribe.return_value = None
+    execution_events_consumer._owns_nats_client = False
+    started = await execution_events_consumer.start()
+    assert started is False
+
+
+def test_default_subject_uses_constants_topic_env(monkeypatch):
+    """Subscriber MUST read the prefix from NATS_TOPIC_EXECUTION_EVENTS."""
+    # The constant is resolved at import time, so assert the default form.
+    import constants
+
+    assert constants.NATS_TOPIC_EXECUTION_EVENTS == "execution.events"
+    assert constants.NATS_EXECUTION_EVENTS_SUBJECT.endswith(".>")
+    assert constants.NATS_EXECUTION_EVENTS_SUBJECT.startswith(
+        constants.NATS_TOPIC_EXECUTION_EVENTS
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_message_sets_otel_span_attributes(execution_events_consumer):
+    """Span MUST carry decision.decision_id + execution.event_type per AC."""
+    msg = _build_msg(_exec_payload())
+    captured = {}
+
+    class _FakeSpan:
+        def set_attribute(self, k, v):
+            captured[k] = v
+
+        def set_status(self, *_a, **_kw):
+            pass
+
+    class _FakeCtxMgr:
+        def __enter__(self_inner):
+            return _FakeSpan()
+
+        def __exit__(self_inner, *a):
+            return False
+
+    with patch(
+        "data_manager.consumer.execution_events_consumer.NATSTracePropagator.create_span_from_message",
+        return_value=_FakeCtxMgr(),
+    ):
+        await execution_events_consumer._process_message(msg)
+
+    assert captured.get("decision.decision_id") == "dec_20260518T120000000_xyz789"
+    assert captured.get("execution.event_type") == "filled"
+    assert captured.get("execution.order_id") == "ord_abc123"


### PR DESCRIPTION
## Summary

- New `ExecutionEventsConsumer` subscribes to `<NATS_TOPIC_EXECUTION_EVENTS>.>` (default `execution.events.>`) and persists each `placed | filled | rejected | partial_fill` event into a new MongoDB `execution_events` collection.
- Indexes on `decision_id`, `order_id`, `strategy_id`, `timestamp`, `event_type` are created at startup via the existing `mongodb_adapter.ensure_indexes` pattern (idempotent). Unique `_id` is synthesized as `order_id:event_type` so the multi-event-per-order lifecycle is captured without false duplicates.
- OTel trace context is extracted from each NATS message and the consumer span carries `decision.decision_id`, `execution.event_type`, and `execution.order_id` so the audit evaluator (FR22) can join order outcomes back to the originating CIO decision.

## References

- petrosa_k8s PR: https://github.com/PetroSa2/petrosa_k8s/pull/628 (adds `NATS_TOPIC_EXECUTION_EVENTS` to `petrosa-common-config`)
- tradeengine publisher PR: `<tradeengine-publisher-pr>`
- Parent issue: PetroSa2/petrosa_k8s#586

## Test plan

- [x] Unit tests for `ExecutionEvent` model: required-field validation, `strategy`/`strategy_id` alias, numeric & ISO timestamp parsing, trace-header stripping
- [x] Unit tests for `ExecutionEventsConsumer._process_message`: happy-path persistence with synthesized `_id`, invalid payload skip, invalid JSON skip, `set_decision_context` attrs, span attribute assertions for `decision.decision_id` + `execution.event_type`
- [x] Unit tests for lifecycle: `ensure_indexes` called for `execution_events`, subscribe subject = `execution.events.>`, subscribe failure handled, DuplicateKeyError tolerated
- [x] Full suite locally: 565 passed, 1 pre-existing unrelated failure (`test_setup_py_imports_are_valid` — missing `setuptools` in venv on `main`)
- [ ] Deploy → manually publish a sample `execution.events.<strategy>` message and confirm a doc appears in `execution_events` with correct indexes

Refs PetroSa2/petrosa_k8s#586 (AC3, AC5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)