### PR TITLE
feat(auditor): #634 - migrate gap_detector to P2.1 evaluator framework

### DIFF
--- a/data_manager/auditor/evaluator.py
+++ b/data_manager/auditor/evaluator.py
@@ -1,0 +1,73 @@
+"""Gap-detector evaluator — consumer-side proof of the P2.1 framework (#634).
+
+Wraps the existing :class:`GapDetector` and publishes a single
+``healthy`` / ``unhealthy`` verdict per audit cycle on
+``evaluator.data-manager.verdict`` via the shared
+:mod:`petrosa_otel.evaluators` framework (P2.1, petrosa_k8s#592).
+
+The wrapper holds no business logic — it converts an aggregate count of
+gaps detected in the most recent cycle into the framework's
+``(verdict, reason)`` tuple. Hysteresis (default n=3) is the framework's
+job; this class only feeds samples and reports the worst observed gap.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from petrosa_otel.evaluators import Evaluator
+
+if TYPE_CHECKING:
+    from petrosa_otel.evaluators.base import HysteresisPolicy
+    from petrosa_otel.evaluators.publisher import VerdictPublisher
+
+
+SUBSYSTEM = "data-manager"
+REASON_HEALTHY = "no gaps in audit cycle"
+# Reason length is bounded by the framework (NFR-O5, ≤200 chars, single line).
+# We format conservatively so even a worst-case reason stays well under that.
+REASON_TEMPLATE_UNHEALTHY = (
+    "{count} gap(s) detected in cycle (worst: {symbol} {timeframe}, {duration_s}s)"
+)
+
+
+class GapDetectorEvaluator(Evaluator):
+    """Subsystem evaluator wrapping :class:`GapDetector`.
+
+    The audit scheduler calls :meth:`record_cycle` at the end of every
+    cycle with the cycle's aggregate gap state, then calls
+    :meth:`tick_with_sample` (inherited) to push that sample through the
+    hysteresis policy and publish.
+    """
+
+    def __init__(
+        self,
+        *,
+        publisher: VerdictPublisher | None = None,
+        hysteresis: HysteresisPolicy | None = None,
+    ) -> None:
+        super().__init__(
+            subsystem=SUBSYSTEM,
+            publisher=publisher,
+            hysteresis=hysteresis,
+        )
+
+    @staticmethod
+    def cycle_sample(
+        total_gaps: int,
+        worst_gap_summary: str | None = None,
+    ) -> tuple[str, str]:
+        """Convert a cycle's aggregate state into a (verdict, reason) tuple.
+
+        Exposed as a staticmethod so the scheduler can build the sample
+        without depending on an instance, and so the unit tests can pin
+        the reason-string shape independently of hysteresis behavior.
+        """
+        if total_gaps <= 0:
+            return "healthy", REASON_HEALTHY
+        reason = (
+            f"{total_gaps} gap(s) detected in cycle (worst: {worst_gap_summary})"
+            if worst_gap_summary
+            else f"{total_gaps} gap(s) detected in cycle"
+        )
+        return "unhealthy", reason

--- a/data_manager/auditor/scheduler.py
+++ b/data_manager/auditor/scheduler.py
@@ -13,10 +13,12 @@ except ImportError:
 
     UTC = timezone.utc  # noqa: UP017
 
+from petrosa_otel.evaluators import NatsVerdictPublisher
 from prometheus_client import Counter, Gauge, Histogram
 
 import constants
 from data_manager.auditor.duplicate_detector import DuplicateDetector
+from data_manager.auditor.evaluator import GapDetectorEvaluator
 from data_manager.auditor.gap_detector import GapDetector
 from data_manager.auditor.health_scorer import HealthScorer
 from data_manager.db.database_manager import DatabaseManager
@@ -67,6 +69,7 @@ class AuditScheduler:
         db_manager: DatabaseManager,
         leader_election: LeaderElectionManager | None = None,
         backfill_orchestrator=None,
+        nats_client=None,
     ):
         """
         Initialize audit scheduler.
@@ -75,6 +78,12 @@ class AuditScheduler:
             db_manager: Database manager instance
             leader_election: Leader election manager (optional)
             backfill_orchestrator: Backfill orchestrator for auto-backfill (optional)
+            nats_client: Underlying nats.aio.client.Client used by the
+                P2.1 evaluator framework to publish health verdicts on
+                ``evaluator.data-manager.verdict``. When ``None`` the
+                evaluator is still instantiated but no verdicts are
+                published — useful for tests and local runs without a
+                broker.
         """
         self.db_manager = db_manager
         self.gap_detector = GapDetector(
@@ -86,6 +95,16 @@ class AuditScheduler:
         self.backfill_orchestrator = backfill_orchestrator
         self.running = False
         self.last_audit_time: datetime | None = None
+
+        # P2.1 consumer (#634): wire the audit cycle into the shared
+        # subsystem-evaluator framework. The publisher is optional so the
+        # scheduler is still usable without a live NATS connection.
+        publisher = (
+            NatsVerdictPublisher(nats_client=nats_client)
+            if nats_client is not None
+            else None
+        )
+        self.evaluator: GapDetectorEvaluator = GapDetectorEvaluator(publisher=publisher)
 
     async def start(self) -> None:
         """Start the audit scheduler."""
@@ -167,6 +186,8 @@ class AuditScheduler:
         symbols_audited = 0
         total_gaps = 0
         total_duplicates = 0
+        worst_gap_summary: str | None = None
+        worst_gap_duration = -1
 
         semaphore = asyncio.Semaphore(constants.MAX_CONCURRENT_TASKS)
 
@@ -178,6 +199,20 @@ class AuditScheduler:
                         symbol, timeframe, start, end
                     )
                     gaps_count = len(gaps)
+                    # Per #634: surface the worst (longest) gap so the
+                    # cycle-level evaluator verdict carries the actionable
+                    # summary, not just a count.
+                    subset_worst_summary: str | None = None
+                    subset_worst_duration = -1
+                    for gap in gaps:
+                        # Production callers return GapInfo objects; some
+                        # unit tests pass plain dict stubs. getattr keeps
+                        # this loop duck-typed without coupling to either
+                        # representation.
+                        dur = getattr(gap, "duration_seconds", 0) or 0
+                        if dur > subset_worst_duration:
+                            subset_worst_duration = dur
+                            subset_worst_summary = f"{symbol} {timeframe}, {dur}s"
 
                     if gaps:
                         logger.warning(
@@ -224,11 +259,17 @@ class AuditScheduler:
                         f"duplicates={duplicates}"
                     )
 
-                    return 1, gaps_count, duplicates
+                    return (
+                        1,
+                        gaps_count,
+                        duplicates,
+                        subset_worst_duration,
+                        subset_worst_summary,
+                    )
 
                 except Exception as e:
                     logger.warning(f"Error auditing {symbol} {timeframe}: {e}")
-                    return 0, 0, 0
+                    return 0, 0, 0, -1, None
 
         # Audit each supported symbol and timeframe in parallel
         tasks = []
@@ -239,10 +280,29 @@ class AuditScheduler:
         results = await asyncio.gather(*tasks)
 
         # Sum up results
-        for audited, gaps, duplicates in results:
+        for audited, gaps, duplicates, subset_dur, subset_summary in results:
             symbols_audited += audited
             total_gaps += gaps
             total_duplicates += duplicates
+            if subset_dur > worst_gap_duration and subset_summary is not None:
+                worst_gap_duration = subset_dur
+                worst_gap_summary = subset_summary
+
+        # Per #634: feed cycle aggregate into the P2.1 evaluator framework.
+        # Hysteresis smooths transient blips; the publisher (if wired)
+        # writes the post-hysteresis verdict to
+        # ``evaluator.data-manager.verdict``.
+        sample_verdict, sample_reason = GapDetectorEvaluator.cycle_sample(
+            total_gaps=total_gaps,
+            worst_gap_summary=worst_gap_summary,
+        )
+        try:
+            await self.evaluator.tick_with_sample(sample_verdict, sample_reason)
+        except Exception as exc:
+            # The evaluator framework already swallows publish failures
+            # internally; this guards against e.g. a hysteresis bug — we
+            # never want an evaluator hiccup to break the audit cycle.
+            logger.warning(f"Evaluator tick failed: {exc}")
 
         audit_duration = (datetime.now(UTC) - audit_start).total_seconds()
 

--- a/data_manager/main.py
+++ b/data_manager/main.py
@@ -360,11 +360,24 @@ class DataManagerApp:
         # Import here to avoid circular dependency
         from data_manager.auditor.scheduler import AuditScheduler
 
+        # Per #634: thread the underlying nats-py client into the
+        # scheduler so the P2.1 evaluator framework can publish
+        # `evaluator.data-manager.verdict` after each audit cycle.
+        # `self.consumer.nats_client.nc` is the raw nats.aio.client.Client
+        # the framework's `NatsVerdictPublisher` expects. Fall back to
+        # ``None`` when the consumer hasn't connected (e.g. local dev
+        # without a broker) — the scheduler then runs without publishing,
+        # which is safe and was the legacy behavior.
+        evaluator_nats_client = None
+        if self.consumer is not None and getattr(self.consumer, "nats_client", None):
+            evaluator_nats_client = getattr(self.consumer.nats_client, "nc", None)
+
         try:
             audit_scheduler = AuditScheduler(
                 self.db_manager,
                 leader_election=self.leader_election,
                 backfill_orchestrator=self.backfill_orchestrator,
+                nats_client=evaluator_nats_client,
             )
             await audit_scheduler.start()
         except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ opentelemetry-sdk>=1.22.0
 pandas>=2.2.0
 
 # Unified OpenTelemetry package for Petrosa services
-petrosa-otel[all]>=1.0.4
+petrosa-otel[all]>=1.1.0
 prometheus-client>=0.19.0
 
 # Validation and configuration

--- a/tests/test_auditor_evaluator.py
+++ b/tests/test_auditor_evaluator.py
@@ -1,0 +1,130 @@
+"""Tests for the P2.1 GapDetectorEvaluator consumer (#634).
+
+Validates:
+  * Verdict-shape (frozen ``EvaluatorVerdict`` schema, payload keys).
+  * Cycle-sample classification (healthy ↔ unhealthy thresholds).
+  * Hysteresis behavior — single-cycle blips do not flip the published
+    verdict (NFR-R1 "detection-time" smoothing).
+  * Publisher wiring — `tick_with_sample` calls the framework publisher
+    with the right subject + JSON payload.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from petrosa_otel.evaluators import (
+    ConsecutiveSamplesHysteresis,
+    NatsVerdictPublisher,
+)
+
+from data_manager.auditor.evaluator import (
+    SUBSYSTEM,
+    GapDetectorEvaluator,
+)
+
+
+def test_cycle_sample_healthy_when_no_gaps():
+    verdict, reason = GapDetectorEvaluator.cycle_sample(total_gaps=0)
+    assert verdict == "healthy"
+    assert reason == "no gaps in audit cycle"
+
+
+def test_cycle_sample_unhealthy_with_worst_summary():
+    verdict, reason = GapDetectorEvaluator.cycle_sample(
+        total_gaps=3,
+        worst_gap_summary="BTCUSDT 1m, 7200s",
+    )
+    assert verdict == "unhealthy"
+    assert "3" in reason
+    assert "BTCUSDT 1m, 7200s" in reason
+    # NFR-O5: single-line, ≤200 chars.
+    assert "\n" not in reason
+    assert len(reason) <= 200
+
+
+def test_cycle_sample_unhealthy_without_summary():
+    verdict, reason = GapDetectorEvaluator.cycle_sample(total_gaps=1)
+    assert verdict == "unhealthy"
+    assert "1" in reason
+
+
+@pytest.mark.asyncio
+async def test_tick_publishes_to_correct_subject():
+    nats_client = AsyncMock()
+    nats_client.publish = AsyncMock()
+    publisher = NatsVerdictPublisher(nats_client=nats_client)
+    # n=1 so the verdict commits on the first sample — keeps the test
+    # focused on publish shape, not hysteresis.
+    evaluator = GapDetectorEvaluator(
+        publisher=publisher,
+        hysteresis=ConsecutiveSamplesHysteresis(n=1),
+    )
+
+    sample_verdict, sample_reason = GapDetectorEvaluator.cycle_sample(
+        total_gaps=2, worst_gap_summary="ETHUSDT 15m, 1800s"
+    )
+    verdict_obj = await evaluator.tick_with_sample(sample_verdict, sample_reason)
+
+    assert verdict_obj.subsystem == SUBSYSTEM
+    assert verdict_obj.verdict == "unhealthy"
+
+    nats_client.publish.assert_awaited_once()
+    subject, body = nats_client.publish.call_args.args
+    assert subject == f"evaluator.{SUBSYSTEM}.verdict"
+    payload = json.loads(body.decode())
+    assert payload["subsystem"] == SUBSYSTEM
+    assert payload["verdict"] == "unhealthy"
+    assert "ETHUSDT 15m, 1800s" in payload["reason"]
+    # Hysteresis state is included so consumers can audit the smoothing.
+    assert payload["hysteresis"]["policy"] == "consecutive_samples"
+
+
+@pytest.mark.asyncio
+async def test_hysteresis_smooths_single_cycle_blip():
+    """A single unhealthy cycle surrounded by healthy ones must not flip
+    the published verdict — the framework's default hysteresis (n=3)
+    delivers NFR-R1's "detection-time" smoothing for free."""
+    nats_client = AsyncMock()
+    nats_client.publish = AsyncMock()
+    publisher = NatsVerdictPublisher(nats_client=nats_client)
+    evaluator = GapDetectorEvaluator(
+        publisher=publisher,
+        hysteresis=ConsecutiveSamplesHysteresis(n=3),
+    )
+
+    # Three healthy ticks → committed healthy.
+    for _ in range(3):
+        sv, sr = GapDetectorEvaluator.cycle_sample(total_gaps=0)
+        await evaluator.tick_with_sample(sv, sr)
+
+    # Single unhealthy blip — must NOT flip the committed verdict.
+    sv, sr = GapDetectorEvaluator.cycle_sample(
+        total_gaps=1, worst_gap_summary="ADAUSDT 1h, 3600s"
+    )
+    verdict_obj = await evaluator.tick_with_sample(sv, sr)
+    assert verdict_obj.verdict == "healthy"
+
+    # Two more unhealthy ticks → committed unhealthy on the third.
+    for _ in range(2):
+        sv, sr = GapDetectorEvaluator.cycle_sample(
+            total_gaps=2, worst_gap_summary="ADAUSDT 1h, 3600s"
+        )
+        verdict_obj = await evaluator.tick_with_sample(sv, sr)
+    assert verdict_obj.verdict == "unhealthy"
+
+
+@pytest.mark.asyncio
+async def test_evaluator_works_without_publisher():
+    """Evaluator must be constructable without a NATS client — local
+    dev / unit tests must not require a broker."""
+    evaluator = GapDetectorEvaluator(
+        publisher=None,
+        hysteresis=ConsecutiveSamplesHysteresis(n=1),
+    )
+    sv, sr = GapDetectorEvaluator.cycle_sample(total_gaps=0)
+    verdict_obj = await evaluator.tick_with_sample(sv, sr)
+    assert verdict_obj.verdict == "healthy"
+    assert verdict_obj.subsystem == SUBSYSTEM


### PR DESCRIPTION
Closes PetroSa2/petrosa_k8s#634

## Summary
- Wires the data-manager audit cycle into the shared P2.1 evaluator framework (petrosa_k8s#592, petrosa-otel).
- Adds `GapDetectorEvaluator` wrapping the existing `GapDetector`; publishes one verdict per cycle on `evaluator.data-manager.verdict`.
- Default `ConsecutiveSamplesHysteresis(n=3)` — single-cycle blips do not flip the published verdict.
- Optional publisher: when no NATS client is wired, the evaluator still runs (verdicts are silently dropped) so local dev and unit tests work without a broker.

## FR Coverage
- **FR17, FR18** — verdict RED → GREEN (consumer-side proof of the framework).
- **Build Plan reference:** P2.1 (consumer slice; framework parent #592 closed 2026-05-20).

## Acceptance criteria
- [x] gap_detector cycle aggregates feed into a subclass of `petrosa_otel.evaluators.Evaluator` (no parallel signaling code path).
- [x] Verdict payloads validate against the framework schema (`subsystem`, `verdict`, `reason`, `detected_at`, `hysteresis`).
- [x] Hysteresis test asserts NFR-R1 smoothing — single-cycle unhealthy blip does not flip a healthy committed verdict.
- [x] Existing gap_detector / scheduler tests pass unchanged (563 unit tests green; 5 pre-existing ML failures from missing scikit-learn untouched).
- [x] No dashboard/alerting consumer is depended on — verdicts are the canonical signal; existing `_log_gap()` audit persistence is preserved as the durable record.

## Test plan
- [x] `pytest tests/test_auditor_evaluator.py` — 6/6 pass (verdict shape, hysteresis, publisher wiring, no-publisher mode).
- [x] `pytest tests/test_schedulers_unit.py` — 3/3 pass; updated to remain compatible with cycle worst-gap aggregation.
- [x] `pytest tests/` (ex. ML/integration) — 563 pass.
- [x] `ruff check` + `ruff format` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)