### PR TITLE
feat(auditor): #595 - execution evaluator for order/fill/slippage/risk anomalies (P2.4)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -76,6 +76,15 @@ ENABLE_EXECUTION_EVENTS_CONSUMER = (
     os.getenv("ENABLE_EXECUTION_EVENTS_CONSUMER", "true").lower() == "true"
 )
 ENABLE_PNL_CONSUMER = os.getenv("ENABLE_PNL_CONSUMER", "true").lower() == "true"
+ENABLE_EXECUTION_EVALUATOR = (
+    os.getenv("ENABLE_EXECUTION_EVALUATOR", "true").lower() == "true"
+)
+# P2.4 evaluator tick cadence. Default ≈ half the error-rate window so a
+# committed-unhealthy verdict surfaces within roughly one detection-time
+# budget after the underlying anomaly begins.
+EXECUTION_EVALUATOR_TICK_INTERVAL = int(
+    os.getenv("EXECUTION_EVALUATOR_TICK_INTERVAL", "150")
+)
 
 # Scheduling Configuration
 AUDIT_INTERVAL = int(os.getenv("AUDIT_INTERVAL", "300"))  # 5 minutes

--- a/data_manager/auditor/execution_evaluator.py
+++ b/data_manager/auditor/execution_evaluator.py
@@ -1,0 +1,392 @@
+"""Execution evaluator — P2.4 (petrosa_k8s#595, FR21).
+
+Detects anomalies in execution telemetry persisted to the ``execution_events``
+audit-trail collection (P0.2c) and emits health verdicts on
+``evaluator.execution.verdict`` via the shared :mod:`petrosa_otel.evaluators`
+framework (P2.1, petrosa_k8s#592). Four detectors run on every tick:
+
+  * **Slippage** — rolling per-symbol z-score of fill prices over the
+    slippage window. A current fill that is >3σ from the trailing mean
+    (default window 1 h) trips the detector. This is a price-stability
+    proxy rather than a true ``realized vs. expected`` slippage; an
+    "expected price" field is not present on the persisted event today,
+    so the implementation flags abnormal fill-price excursions instead.
+    The detector is silent until enough samples are collected
+    (``MIN_SLIPPAGE_SAMPLES``).
+
+  * **Fill rate** — per (strategy_id, symbol) the ratio of ``filled``
+    events to ``placed`` events over the fill-rate window (default 1 h).
+    A current fill rate below ``MIN_FILL_RATE`` after the window has
+    accumulated at least ``MIN_FILL_RATE_PLACED_SAMPLES`` placed orders
+    trips the detector.
+
+  * **Risk-posture drift** — per strategy, the gross notional flow
+    over the recent window (default 1 h, ``risk_window_s``) divided
+    by the trailing 24 h gross notional median. When the multiple
+    exceeds ``RISK_VELOCITY_MULTIPLE`` (default 2×) the detector trips.
+
+  * **Exchange error rate** — share of ``rejected`` events over the
+    error-rate window (default 5 min). Above ``REJECT_RATE_BUDGET``
+    (default 5 %) the detector trips. Reasons starting with ``429`` /
+    ``rate_limit`` are additionally tracked separately and trip at the
+    tighter ``RATE_LIMIT_BUDGET`` (default 1 %).
+
+The evaluator owns no I/O directly — on each :meth:`evaluate` invocation
+it calls the injected ``event_provider`` (typically the MongoDB-backed
+default) for the last ``lookback`` of events and computes the four
+signals in one pass over the rows. Time is injected via ``time_source``
+so the unit tests stay deterministic.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import defaultdict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from petrosa_otel.evaluators import Evaluator
+
+if TYPE_CHECKING:
+    from petrosa_otel.evaluators.base import HysteresisPolicy
+    from petrosa_otel.evaluators.publisher import VerdictPublisher
+
+
+SUBSYSTEM = "execution"
+
+# Detection windows (seconds).
+DEFAULT_SLIPPAGE_WINDOW_S = 60 * 60  # 1 h
+DEFAULT_FILL_RATE_WINDOW_S = 60 * 60  # 1 h
+DEFAULT_RISK_WINDOW_S = 60 * 60  # 1 h
+DEFAULT_RISK_BASELINE_S = 24 * 60 * 60  # 24 h
+DEFAULT_ERROR_WINDOW_S = 5 * 60  # 5 min
+
+# Detector thresholds.
+DEFAULT_SLIPPAGE_Z_THRESHOLD = 3.0
+DEFAULT_MIN_FILL_RATE = 0.5
+DEFAULT_RISK_VELOCITY_MULTIPLE = 2.0
+DEFAULT_REJECT_RATE_BUDGET = 0.05
+DEFAULT_RATE_LIMIT_BUDGET = 0.01
+
+# Minimum samples before a detector is allowed to trip. Avoids
+# unstable verdicts on cold start or low-volume markets.
+MIN_SLIPPAGE_SAMPLES = 30
+MIN_FILL_RATE_PLACED_SAMPLES = 10
+MIN_RISK_BASELINE_SAMPLES = 10
+MIN_ERROR_RATE_TOTAL = 20
+
+# Reasons matching these case-insensitive substrings count as rate-limit
+# rejections separately from the broader 4xx bucket.
+RATE_LIMIT_REASON_MARKERS = ("429", "rate_limit", "rate-limit", "ratelimit")
+
+# Type aliases.
+EventProvider = Callable[[datetime, datetime], Awaitable[list[dict[str, Any]]]]
+
+
+@dataclass
+class _DetectorSignal:
+    """Result of one detector. ``tripped`` drives the verdict."""
+
+    tripped: bool
+    reason: str | None = None  # populated when tripped
+
+
+class ExecutionEvaluator(Evaluator):
+    """Subsystem evaluator for trade execution anomalies (P2.4)."""
+
+    def __init__(
+        self,
+        *,
+        event_provider: EventProvider,
+        publisher: VerdictPublisher | None = None,
+        hysteresis: HysteresisPolicy | None = None,
+        slippage_window_s: int = DEFAULT_SLIPPAGE_WINDOW_S,
+        fill_rate_window_s: int = DEFAULT_FILL_RATE_WINDOW_S,
+        risk_window_s: int = DEFAULT_RISK_WINDOW_S,
+        risk_baseline_s: int = DEFAULT_RISK_BASELINE_S,
+        error_window_s: int = DEFAULT_ERROR_WINDOW_S,
+        slippage_z_threshold: float = DEFAULT_SLIPPAGE_Z_THRESHOLD,
+        min_fill_rate: float = DEFAULT_MIN_FILL_RATE,
+        risk_velocity_multiple: float = DEFAULT_RISK_VELOCITY_MULTIPLE,
+        reject_rate_budget: float = DEFAULT_REJECT_RATE_BUDGET,
+        rate_limit_budget: float = DEFAULT_RATE_LIMIT_BUDGET,
+        time_source: Callable[[], datetime] | None = None,
+    ) -> None:
+        super().__init__(
+            subsystem=SUBSYSTEM,
+            publisher=publisher,
+            hysteresis=hysteresis,
+        )
+        self._event_provider = event_provider
+        self._slippage = timedelta(seconds=slippage_window_s)
+        self._fill_rate = timedelta(seconds=fill_rate_window_s)
+        self._risk = timedelta(seconds=risk_window_s)
+        self._risk_baseline = timedelta(seconds=risk_baseline_s)
+        self._error = timedelta(seconds=error_window_s)
+        self._slippage_z = slippage_z_threshold
+        self._min_fill_rate = min_fill_rate
+        self._risk_multiple = risk_velocity_multiple
+        self._reject_budget = reject_rate_budget
+        self._rate_limit_budget = rate_limit_budget
+        self._time = time_source or (lambda: datetime.now(UTC))
+
+    # ------------------------------------------------------------------
+    # Framework hook.
+    # ------------------------------------------------------------------
+
+    async def evaluate(self) -> tuple[str, str]:
+        """Compute the current (verdict, reason) sample.
+
+        Pulls the widest lookback window we need from the provider once
+        (max of the baseline windows) so all four detectors share a
+        single read. Returns the highest-priority unhealthy signal if
+        any; otherwise ``healthy``.
+        """
+        now = self._time()
+        lookback = max(
+            self._slippage, self._fill_rate, self._risk_baseline, self._error
+        )
+        try:
+            events = await self._event_provider(now - lookback, now)
+        except Exception as exc:  # pragma: no cover — defensive
+            return "unknown", f"event provider error: {type(exc).__name__}"
+
+        if not events:
+            return "unknown", "no execution events in lookback window"
+
+        # Detectors run in priority order — rate-limit and rejection
+        # rates first because they degrade trading immediately, then
+        # fill rate (placement reliability), then risk drift, then
+        # slippage (statistical, slowest).
+        for signal in (
+            self._exchange_error_rate(events, now),
+            self._fill_rate_signal(events, now),
+            self._risk_posture_drift(events, now),
+            self._slippage_signal(events, now),
+        ):
+            if signal.tripped:
+                return "unhealthy", signal.reason or "execution anomaly"
+
+        return "healthy", "no slippage, fill-rate, risk, or error anomalies"
+
+    # ------------------------------------------------------------------
+    # Detectors. Each consumes the shared event list once and returns
+    # a _DetectorSignal. Detectors are tolerant: missing fields cause
+    # the row to be skipped, not the whole tick to abort.
+    # ------------------------------------------------------------------
+
+    def _exchange_error_rate(
+        self, events: list[dict[str, Any]], now: datetime
+    ) -> _DetectorSignal:
+        cutoff = now - self._error
+        recent = [e for e in events if _event_ts(e) >= cutoff]
+        total = len(recent)
+        if total < MIN_ERROR_RATE_TOTAL:
+            return _DetectorSignal(False)
+
+        rejected = [e for e in recent if e.get("event_type") == "rejected"]
+        reject_rate = len(rejected) / total
+        rate_limited = [
+            e
+            for e in rejected
+            if _reason_matches(e.get("reason"), RATE_LIMIT_REASON_MARKERS)
+        ]
+        rate_limit_rate = len(rate_limited) / total
+
+        if rate_limit_rate > self._rate_limit_budget:
+            return _DetectorSignal(
+                True,
+                f"rate-limit rejections {rate_limit_rate:.2%} of {total} events "
+                f"in {int(self._error.total_seconds())}s "
+                f"(budget {self._rate_limit_budget:.2%})",
+            )
+        if reject_rate > self._reject_budget:
+            return _DetectorSignal(
+                True,
+                f"rejected {reject_rate:.2%} of {total} events in "
+                f"{int(self._error.total_seconds())}s "
+                f"(budget {self._reject_budget:.2%})",
+            )
+        return _DetectorSignal(False)
+
+    def _fill_rate_signal(
+        self, events: list[dict[str, Any]], now: datetime
+    ) -> _DetectorSignal:
+        cutoff = now - self._fill_rate
+        placed: dict[tuple[str, str], int] = defaultdict(int)
+        filled: dict[tuple[str, str], int] = defaultdict(int)
+        for e in events:
+            if _event_ts(e) < cutoff:
+                continue
+            sid = e.get("strategy_id")
+            sym = e.get("symbol")
+            if not sid or not sym:
+                continue
+            key = (sid, sym)
+            etype = e.get("event_type")
+            if etype == "placed":
+                placed[key] += 1
+            elif etype in {"filled", "partial_fill"}:
+                filled[key] += 1
+
+        worst_key: tuple[str, str] | None = None
+        worst_rate = 1.0
+        worst_placed = 0
+        for key, p in placed.items():
+            if p < MIN_FILL_RATE_PLACED_SAMPLES:
+                continue
+            rate = filled.get(key, 0) / p
+            if rate < worst_rate:
+                worst_rate = rate
+                worst_key = key
+                worst_placed = p
+
+        if worst_key is not None and worst_rate < self._min_fill_rate:
+            sid, sym = worst_key
+            return _DetectorSignal(
+                True,
+                f"fill rate {worst_rate:.0%} for {sid}/{sym} over "
+                f"{worst_placed} placed in {int(self._fill_rate.total_seconds())}s "
+                f"(min {self._min_fill_rate:.0%})",
+            )
+        return _DetectorSignal(False)
+
+    def _risk_posture_drift(
+        self, events: list[dict[str, Any]], now: datetime
+    ) -> _DetectorSignal:
+        recent_cut = now - self._risk
+        baseline_cut = now - self._risk_baseline
+        # Per-strategy gross notional (qty * price) for filled events.
+        recent: dict[str, float] = defaultdict(float)
+        baseline_buckets: dict[str, list[float]] = defaultdict(list)
+
+        # Bucket size for the trailing median = recent window, so we
+        # compare apples to apples (one "recent" bucket vs many baseline
+        # buckets of the same length).
+        bucket_size = self._risk
+        num_buckets = max(1, int(self._risk_baseline / bucket_size))
+
+        for e in events:
+            ts = _event_ts(e)
+            if ts < baseline_cut:
+                continue
+            if e.get("event_type") not in {"filled", "partial_fill"}:
+                continue
+            sid = e.get("strategy_id")
+            if not sid:
+                continue
+            qty = e.get("fill_qty") or e.get("qty")
+            price = e.get("price")
+            if qty is None or price is None:
+                continue
+            notional = abs(float(qty) * float(price))
+
+            if ts >= recent_cut:
+                recent[sid] += notional
+            else:
+                # Which historical bucket does this event belong to?
+                offset = int((now - ts) / bucket_size)
+                if 1 <= offset <= num_buckets:
+                    # Pad the per-strategy bucket list so the median has
+                    # entries for all baseline buckets (even zero-flow
+                    # ones — those count toward the median).
+                    if len(baseline_buckets[sid]) < num_buckets:
+                        baseline_buckets[sid].extend(
+                            [0.0] * (num_buckets - len(baseline_buckets[sid]))
+                        )
+                    baseline_buckets[sid][offset - 1] += notional
+
+        for sid, recent_flow in recent.items():
+            buckets = baseline_buckets.get(sid, [])
+            non_zero = [b for b in buckets if b > 0]
+            if len(non_zero) < MIN_RISK_BASELINE_SAMPLES:
+                continue
+            median_flow = statistics.median(non_zero)
+            if median_flow == 0:
+                continue
+            multiple = recent_flow / median_flow
+            if multiple > self._risk_multiple:
+                return _DetectorSignal(
+                    True,
+                    f"risk velocity {multiple:.1f}x median for {sid} over "
+                    f"{int(self._risk.total_seconds())}s "
+                    f"(threshold {self._risk_multiple:.1f}x)",
+                )
+        return _DetectorSignal(False)
+
+    def _slippage_signal(
+        self, events: list[dict[str, Any]], now: datetime
+    ) -> _DetectorSignal:
+        cutoff = now - self._slippage
+        # Per-symbol fill prices in the slippage window.
+        prices: dict[str, list[float]] = defaultdict(list)
+        latest_per_symbol: dict[str, tuple[datetime, float]] = {}
+        for e in events:
+            ts = _event_ts(e)
+            if ts < cutoff:
+                continue
+            if e.get("event_type") not in {"filled", "partial_fill"}:
+                continue
+            sym = e.get("symbol")
+            price = e.get("price")
+            if not sym or price is None:
+                continue
+            p = float(price)
+            prices[sym].append(p)
+            cur = latest_per_symbol.get(sym)
+            if cur is None or ts > cur[0]:
+                latest_per_symbol[sym] = (ts, p)
+
+        for sym, samples in prices.items():
+            if len(samples) < MIN_SLIPPAGE_SAMPLES:
+                continue
+            mean = statistics.fmean(samples)
+            stdev = statistics.pstdev(samples)
+            if stdev == 0:
+                continue
+            _, latest_price = latest_per_symbol[sym]
+            z = abs(latest_price - mean) / stdev
+            if z > self._slippage_z:
+                return _DetectorSignal(
+                    True,
+                    f"fill-price z={z:.1f} for {sym} over {len(samples)} fills "
+                    f"in {int(self._slippage.total_seconds())}s "
+                    f"(threshold {self._slippage_z:.1f}σ)",
+                )
+        return _DetectorSignal(False)
+
+
+# ----------------------------------------------------------------------
+# Helpers.
+# ----------------------------------------------------------------------
+
+
+def _event_ts(e: dict[str, Any]) -> datetime:
+    """Pull the event timestamp, normalising naive datetimes to UTC."""
+    ts = e.get("timestamp")
+    if isinstance(ts, datetime):
+        return ts if ts.tzinfo else ts.replace(tzinfo=UTC)
+    if isinstance(ts, str):
+        try:
+            parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+        except ValueError:
+            pass
+    # Unparseable rows sort to the epoch so they're outside every window.
+    return datetime.fromtimestamp(0, tz=UTC)
+
+
+def _reason_matches(reason: Any, markers: tuple[str, ...]) -> bool:
+    if not reason:
+        return False
+    lowered = str(reason).lower()
+    return any(m in lowered for m in markers)

--- a/data_manager/main.py
+++ b/data_manager/main.py
@@ -77,6 +77,7 @@ class DataManagerApp:
         self.leader_election: LeaderElectionManager | None = None
         self.backfill_orchestrator: BackfillOrchestrator | None = None
         self.ingest_evaluator = None  # P2.2 (#593) — set in start()
+        self.execution_evaluator = None  # P2.4 (#595) — set in start()
         self.running = False
         self._shutdown_event = asyncio.Event()
 
@@ -224,6 +225,39 @@ class DataManagerApp:
                 logger.info("Execution events consumer started successfully")
             else:
                 logger.error("Failed to start execution events consumer")
+
+        # Initialize and start execution evaluator (P2.4, #595). Runs over
+        # the `execution_events` collection persisted by the consumer above.
+        # The consumer is the precondition: without P0.2c traffic, the
+        # evaluator's provider returns no rows and it stays in "unknown".
+        if constants.ENABLE_EXECUTION_EVALUATOR and self.db_manager is not None:
+            from petrosa_otel.evaluators import NatsVerdictPublisher
+
+            from data_manager.auditor.execution_evaluator import (
+                ExecutionEvaluator,
+            )
+
+            mongodb_adapter = self.db_manager.mongodb_adapter
+
+            async def _execution_event_provider(start, end):
+                # Pulled via closure so the evaluator never needs to know
+                # about the database manager directly.
+                return await mongodb_adapter.query_range(
+                    "execution_events", start=start, end=end
+                )
+
+            self.execution_evaluator = ExecutionEvaluator(
+                event_provider=_execution_event_provider,
+                publisher=NatsVerdictPublisher(
+                    nats_client=_DeferredNatsClient(
+                        lambda: getattr(self.consumer.nats_client, "nc", None)
+                        if self.consumer is not None
+                        else None
+                    )
+                ),
+            )
+            asyncio.create_task(self._run_execution_evaluator_loop())
+            logger.info("Execution evaluator started successfully")
 
         # Initialize and start pnl events consumer (P0.2d). Subscriber-only
         # today; the publisher side ships with P4.1 P&L computation. The
@@ -456,6 +490,35 @@ class DataManagerApp:
             except Exception as exc:
                 logger.warning(f"Ingest evaluator tick failed: {exc}")
         logger.info("Ingest evaluator loop stopped")
+
+    async def _run_execution_evaluator_loop(self) -> None:
+        """Periodic tick loop for the P2.4 execution evaluator (#595).
+
+        Cadence is half of the error-rate window by default so a
+        committed-unhealthy verdict surfaces within roughly one
+        detection-time budget after the underlying anomaly begins.
+        """
+        interval = max(
+            5,
+            int(
+                getattr(
+                    constants,
+                    "EXECUTION_EVALUATOR_TICK_INTERVAL",
+                    150,
+                )
+            ),
+        )
+        logger.info(f"Execution evaluator loop started (interval={interval}s)")
+        while self.running:
+            try:
+                await asyncio.sleep(interval)
+                if self.execution_evaluator is not None:
+                    await self.execution_evaluator.tick()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.warning(f"Execution evaluator tick failed: {exc}")
+        logger.info("Execution evaluator loop stopped")
 
     async def _run_analytics(self) -> None:
         """Run analytics engine in background."""

--- a/tests/test_execution_evaluator.py
+++ b/tests/test_execution_evaluator.py
@@ -1,0 +1,606 @@
+"""Tests for the P2.4 ExecutionEvaluator (#595).
+
+Validates the four detectors (exchange error rate, fill rate, risk-posture
+drift, slippage) and the boundary cases. Events are injected directly via
+an in-memory ``event_provider`` and time is pinned via ``time_source`` so
+tests are deterministic and fast.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from data_manager.auditor.execution_evaluator import (
+    DEFAULT_ERROR_WINDOW_S,
+    DEFAULT_FILL_RATE_WINDOW_S,
+    DEFAULT_RISK_BASELINE_S,
+    DEFAULT_RISK_WINDOW_S,
+    DEFAULT_SLIPPAGE_WINDOW_S,
+    MIN_ERROR_RATE_TOTAL,
+    MIN_FILL_RATE_PLACED_SAMPLES,
+    MIN_RISK_BASELINE_SAMPLES,
+    MIN_SLIPPAGE_SAMPLES,
+    SUBSYSTEM,
+    ExecutionEvaluator,
+)
+
+T0 = datetime(2026, 5, 21, 12, 0, 0, tzinfo=UTC)
+
+
+class _Clock:
+    """Pinnable clock for deterministic tests."""
+
+    def __init__(self, start: datetime) -> None:
+        self.now = start
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now = self.now + timedelta(seconds=seconds)
+
+
+def _make_event(
+    *,
+    event_type: str,
+    ts: datetime,
+    strategy_id: str = "S1",
+    symbol: str = "BTCUSDT",
+    qty: float | None = 1.0,
+    fill_qty: float | None = None,
+    price: float | None = 100.0,
+    reason: str | None = None,
+    decision_id: str = "D1",
+    order_id: str = "O1",
+) -> dict[str, object]:
+    return {
+        "decision_id": decision_id,
+        "strategy_id": strategy_id,
+        "order_id": order_id,
+        "event_type": event_type,
+        "timestamp": ts,
+        "symbol": symbol,
+        "qty": qty,
+        "fill_qty": fill_qty,
+        "price": price,
+        "reason": reason,
+    }
+
+
+def _provider(
+    events: list[dict[str, object]],
+) -> Callable[[datetime, datetime], Awaitable[list[dict[str, object]]]]:
+    async def _p(start: datetime, end: datetime) -> list[dict[str, object]]:
+        return [e for e in events if start <= e["timestamp"] < end]
+
+    return _p
+
+
+def _make(
+    clock: _Clock,
+    events: list[dict[str, object]],
+    **overrides,
+) -> ExecutionEvaluator:
+    return ExecutionEvaluator(
+        event_provider=_provider(events),
+        time_source=clock,
+        **overrides,
+    )
+
+
+# ----------------------------------------------------------------------
+# Subsystem / boundary tests.
+# ----------------------------------------------------------------------
+
+
+def test_subsystem_constant_matches_contract():
+    assert SUBSYSTEM == "execution"
+
+
+@pytest.mark.asyncio
+async def test_no_events_returns_unknown():
+    clock = _Clock(T0)
+    ev = _make(clock, [])
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unknown"
+    assert "no execution events" in reason
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_all_detectors_silent():
+    clock = _Clock(T0)
+    # 20 fills spread over the slippage window at constant price.
+    events = [
+        _make_event(
+            event_type="filled",
+            ts=T0 - timedelta(seconds=60 * i),
+            price=100.0,
+            fill_qty=1.0,
+        )
+        for i in range(20)
+    ]
+    ev = _make(clock, events)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "healthy"
+    assert "no slippage" in reason
+
+
+# ----------------------------------------------------------------------
+# Exchange-error detector.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reject_rate_trips_at_budget():
+    clock = _Clock(T0)
+    events = []
+    # 80 placed + 20 rejected = ~20% rejection rate (budget 5%).
+    # Shift timestamps by 1s so none land exactly on T0 (provider uses
+    # half-open `[start, end)` so T0 itself is excluded).
+    for i in range(80):
+        events.append(
+            _make_event(
+                event_type="placed",
+                ts=T0 - timedelta(seconds=i + 1),
+                order_id=f"O{i}",
+            )
+        )
+    for i in range(20):
+        events.append(
+            _make_event(
+                event_type="rejected",
+                ts=T0 - timedelta(seconds=i + 90),
+                order_id=f"R{i}",
+                reason="balance_below_minimum",
+            )
+        )
+    ev = _make(clock, events)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "rejected" in reason
+    assert "20.00% of 100 events" in reason
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_rejections_trip_at_tighter_budget():
+    """rate-limit rejections fire at 1% even when overall rejects are healthy.
+
+    Build a fill stream so the fill-rate detector stays silent and the
+    error-rate detector is the only one in play; then mix in 2 of 200
+    rate-limit rejects (=1% — just over the 1% rate-limit budget).
+    """
+    clock = _Clock(T0)
+    events = []
+    # 198 placed + 198 filled = healthy fill rate, well above MIN_FILL_RATE.
+    for i in range(198):
+        events.append(
+            _make_event(
+                event_type="placed",
+                ts=T0 - timedelta(seconds=i + 1),
+                order_id=f"O{i}",
+            )
+        )
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=i + 2),
+                order_id=f"O{i}",
+                fill_qty=1.0,
+            )
+        )
+    # 2 of 200+ events in the 5-min window are 429 rate-limit rejections.
+    # We need rate-limit rate > 1%; the error detector window only sees
+    # events within the last 300s, so all events above are inside it.
+    # 2 rate-limit / (198 placed + 198 filled + 2 rejected) within 300s
+    # = 2/398 ≈ 0.5% — too low. Push the fill events past the error
+    # window so the error-detector denominator drops.
+    events = [e for e in events if e["event_type"] != "filled"]
+    for i in range(198):
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=DEFAULT_ERROR_WINDOW_S + 60 + i),
+                order_id=f"O{i}",
+                fill_qty=1.0,
+            )
+        )
+    # Now in the 300s error window: 198 placed + 0 filled + (we add) 3
+    # rate-limit rejects = 201 events. 3/201 ≈ 1.49% > 1% budget.
+    for i in range(3):
+        events.append(
+            _make_event(
+                event_type="rejected",
+                ts=T0 - timedelta(seconds=i + 100),
+                order_id=f"R{i}",
+                reason=f"429 too many requests #{i}",
+            )
+        )
+    ev = _make(clock, events)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "rate-limit" in reason
+
+
+@pytest.mark.asyncio
+async def test_error_detector_silent_below_sample_floor():
+    """Below the min-sample floor the detector should NOT trip."""
+    clock = _Clock(T0)
+    # 1 placed + 1 rejected. Total well under MIN_ERROR_RATE_TOTAL.
+    events = [
+        _make_event(event_type="placed", ts=T0 - timedelta(seconds=10)),
+        _make_event(
+            event_type="rejected",
+            ts=T0 - timedelta(seconds=15),
+            reason="429",
+        ),
+    ]
+    ev = _make(clock, events)
+    verdict, _ = await ev.evaluate()
+    # With only 2 events in the error window and no other detector data,
+    # we fall through to "healthy" — there is data in the lookback so
+    # we don't return "unknown".
+    assert verdict == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_old_rejections_outside_error_window_do_not_trip():
+    """Rejections older than the error-rate window must not contribute."""
+    clock = _Clock(T0)
+    events = []
+    # 30 ancient rejects (just inside the broader lookback so the
+    # provider returns them, but past the 5-min error window).
+    for i in range(30):
+        events.append(
+            _make_event(
+                event_type="rejected",
+                ts=T0 - timedelta(seconds=DEFAULT_ERROR_WINDOW_S + 60 + i),
+                order_id=f"R{i}",
+                reason="exchange_error",
+            )
+        )
+    # 5 recent placed orders within error window.
+    for i in range(5):
+        events.append(
+            _make_event(
+                event_type="placed",
+                ts=T0 - timedelta(seconds=10 + i),
+                order_id=f"O{i}",
+            )
+        )
+    ev = _make(clock, events)
+    verdict, _ = await ev.evaluate()
+    assert verdict == "healthy"
+
+
+# ----------------------------------------------------------------------
+# Fill-rate detector.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fill_rate_trips_when_below_minimum():
+    clock = _Clock(T0)
+    # 20 placed, only 5 filled = 25% fill rate, below default 50%.
+    events = []
+    for i in range(20):
+        events.append(
+            _make_event(
+                event_type="placed",
+                ts=T0 - timedelta(seconds=60 + i),
+                order_id=f"O{i}",
+            )
+        )
+    for i in range(5):
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=120 + i),
+                order_id=f"O{i}",
+                fill_qty=1.0,
+            )
+        )
+    ev = _make(clock, events)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "fill rate" in reason
+    assert "25%" in reason or "25.00%" in reason
+
+
+@pytest.mark.asyncio
+async def test_fill_rate_silent_with_few_placed():
+    """Should not trip until MIN_FILL_RATE_PLACED_SAMPLES placed orders accrue."""
+    clock = _Clock(T0)
+    events = []
+    # Only 3 placed orders, 0 filled — well below the sample floor.
+    for i in range(3):
+        events.append(
+            _make_event(
+                event_type="placed",
+                ts=T0 - timedelta(seconds=60 + i),
+                order_id=f"O{i}",
+            )
+        )
+    ev = _make(clock, events)
+    verdict, _ = await ev.evaluate()
+    assert verdict == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_fill_rate_isolates_to_strategy_symbol_pair():
+    """Healthy strategy/symbol shouldn't mask an unhealthy peer."""
+    clock = _Clock(T0)
+    events = []
+    # S1/BTCUSDT: 20 placed, 20 filled — healthy.
+    for i in range(20):
+        events.append(
+            _make_event(
+                event_type="placed",
+                ts=T0 - timedelta(seconds=60 + i),
+                strategy_id="S1",
+                symbol="BTCUSDT",
+                order_id=f"A{i}",
+            )
+        )
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=120 + i),
+                strategy_id="S1",
+                symbol="BTCUSDT",
+                order_id=f"A{i}",
+                fill_qty=1.0,
+            )
+        )
+    # S2/ETHUSDT: 15 placed, 2 filled = ~13% — should trip.
+    for i in range(15):
+        events.append(
+            _make_event(
+                event_type="placed",
+                ts=T0 - timedelta(seconds=60 + i),
+                strategy_id="S2",
+                symbol="ETHUSDT",
+                order_id=f"B{i}",
+            )
+        )
+    for i in range(2):
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=120 + i),
+                strategy_id="S2",
+                symbol="ETHUSDT",
+                order_id=f"B{i}",
+                fill_qty=1.0,
+            )
+        )
+    ev = _make(clock, events)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "S2/ETHUSDT" in reason
+
+
+# ----------------------------------------------------------------------
+# Risk-posture detector.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_risk_drift_trips_on_velocity_spike():
+    clock = _Clock(T0)
+    events = []
+    # Baseline: small steady flow across many baseline buckets.
+    num_baseline_buckets = DEFAULT_RISK_BASELINE_S // DEFAULT_RISK_WINDOW_S
+    for bucket in range(1, num_baseline_buckets + 1):
+        # Each baseline bucket has a single $100 notional fill.
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=bucket * DEFAULT_RISK_WINDOW_S + 60),
+                fill_qty=1.0,
+                price=100.0,
+            )
+        )
+    # Recent: massive spike — $1000 in recent window (10x median).
+    for i in range(10):
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=60 + i),
+                fill_qty=1.0,
+                price=100.0,
+                order_id=f"F{i}",
+            )
+        )
+    ev = _make(clock, events)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "risk velocity" in reason
+
+
+@pytest.mark.asyncio
+async def test_risk_drift_silent_without_baseline_samples():
+    """Should not trip when baseline has too few non-zero buckets."""
+    clock = _Clock(T0)
+    events = []
+    # Only a few baseline samples (below MIN_RISK_BASELINE_SAMPLES).
+    for bucket in range(1, MIN_RISK_BASELINE_SAMPLES - 1):
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=bucket * DEFAULT_RISK_WINDOW_S + 60),
+                fill_qty=1.0,
+                price=100.0,
+            )
+        )
+    # Recent spike.
+    for i in range(20):
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=60 + i),
+                fill_qty=1.0,
+                price=100.0,
+                order_id=f"F{i}",
+            )
+        )
+    ev = _make(clock, events)
+    verdict, _ = await ev.evaluate()
+    # Risk detector should be silent; slippage may or may not be —
+    # accept any non-unhealthy-risk verdict.
+    if verdict == "unhealthy":
+        assert "risk velocity" not in (await ev.evaluate())[1]
+
+
+# ----------------------------------------------------------------------
+# Slippage detector.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slippage_trips_on_outlier_price():
+    clock = _Clock(T0)
+    events = []
+    # 40 fills at $100 with tiny noise.
+    for i in range(40):
+        price = 100.0 + (0.01 if i % 2 else -0.01)
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=60 + i),
+                price=price,
+                fill_qty=1.0,
+                order_id=f"F{i}",
+            )
+        )
+    # Latest fill (most recent timestamp) is a massive outlier.
+    events.append(
+        _make_event(
+            event_type="filled",
+            ts=T0 - timedelta(seconds=1),
+            price=200.0,
+            fill_qty=1.0,
+            order_id="F-spike",
+        )
+    )
+    ev = _make(clock, events)
+    verdict, reason = await ev.evaluate()
+    # Could trip via slippage OR risk velocity (the outlier doubles notional).
+    # We accept either as long as the verdict is unhealthy.
+    assert verdict == "unhealthy"
+    assert "z=" in reason or "risk velocity" in reason
+
+
+@pytest.mark.asyncio
+async def test_slippage_silent_below_min_samples():
+    """Slippage detector must wait for MIN_SLIPPAGE_SAMPLES fills."""
+    clock = _Clock(T0)
+    events = []
+    # Only 5 fills (well below MIN_SLIPPAGE_SAMPLES of 30).
+    for i in range(5):
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=60 + i),
+                price=100.0 if i < 4 else 1000.0,
+                fill_qty=1.0,
+                order_id=f"F{i}",
+            )
+        )
+    ev = _make(clock, events)
+    verdict, _ = await ev.evaluate()
+    # Slippage detector silent; not enough other data to trip anything either.
+    assert verdict in {"healthy", "unknown"}
+
+
+# ----------------------------------------------------------------------
+# Detector priority — error-rate > fill-rate > risk > slippage.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_rate_wins_over_fill_rate_when_both_trip():
+    clock = _Clock(T0)
+    events = []
+    # Fill rate would trip: 20 placed, 5 filled in 1h.
+    for i in range(20):
+        events.append(
+            _make_event(
+                event_type="placed",
+                ts=T0 - timedelta(seconds=60 + i),
+                order_id=f"P{i}",
+            )
+        )
+    for i in range(5):
+        events.append(
+            _make_event(
+                event_type="filled",
+                ts=T0 - timedelta(seconds=120 + i),
+                order_id=f"P{i}",
+                fill_qty=1.0,
+            )
+        )
+    # Error rate also trips: 20 rejected in 5m window.
+    for i in range(20):
+        events.append(
+            _make_event(
+                event_type="rejected",
+                ts=T0 - timedelta(seconds=10 + i),
+                order_id=f"R{i}",
+                reason="balance_below_minimum",
+            )
+        )
+    ev = _make(clock, events)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    # Either rejected or rate-limit reason — both come from the error detector.
+    assert "rejected" in reason or "rate-limit" in reason
+
+
+# ----------------------------------------------------------------------
+# Provider edge-cases.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_exception_returns_unknown():
+    clock = _Clock(T0)
+
+    async def bad_provider(start: datetime, end: datetime) -> list[dict[str, object]]:
+        raise RuntimeError("mongo down")
+
+    ev = ExecutionEvaluator(event_provider=bad_provider, time_source=clock)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unknown"
+    assert "event provider error" in reason
+
+
+@pytest.mark.asyncio
+async def test_unparseable_timestamps_are_skipped():
+    """Rows with malformed timestamps shouldn't crash the detector."""
+    clock = _Clock(T0)
+    events = [
+        {
+            "decision_id": "D",
+            "strategy_id": "S",
+            "order_id": "O",
+            "event_type": "filled",
+            "timestamp": "not-a-date",
+            "symbol": "BTCUSDT",
+            "qty": 1.0,
+            "fill_qty": 1.0,
+            "price": 100.0,
+        },
+    ]
+
+    async def passthrough(start: datetime, end: datetime) -> list[dict[str, object]]:
+        return events
+
+    ev = ExecutionEvaluator(event_provider=passthrough, time_source=clock)
+    verdict, _ = await ev.evaluate()
+    # The single malformed row falls outside every detector window
+    # (its timestamp normalises to epoch). Provider returned 1 row so
+    # we don't return "unknown" — fall through to healthy.
+    assert verdict == "healthy"


### PR DESCRIPTION
## Summary
Implements the **Execution Evaluator (P2.4, FR21)** subclassing the shared
`petrosa_otel.evaluators.Evaluator` framework. Detects four classes of
execution anomalies over the `execution_events` audit-trail collection
(P0.2c) and emits health verdicts on `evaluator.execution.verdict`.

- **Slippage** — per-symbol z-score of fill prices vs. rolling-window mean (default ≥3σ over 1h)
- **Fill rate** — per (strategy_id, symbol) `filled / placed` ratio (default <50% over 1h)
- **Risk-posture drift** — per-strategy gross notional recent vs. 24h median (default >2× multiple)
- **Exchange errors** — rejection rate (default >5%) with tighter 1% budget on 429/rate-limit rejections

Detectors run in priority order so the most actionable signal wins (errors → fill-rate → risk → slippage).

## Implementation notes
- New file: `data_manager/auditor/execution_evaluator.py` — 295 LoC, four detectors, configurable thresholds.
- Wired in `data_manager/main.py` after the existing execution-events consumer; periodic tick loop runs at half the error-rate window by default (operator-tunable via `EXECUTION_EVALUATOR_TICK_INTERVAL`).
- Two new constants in `constants.py`: `ENABLE_EXECUTION_EVALUATOR`, `EXECUTION_EVALUATOR_TICK_INTERVAL`.
- 17 unit tests in `tests/test_execution_evaluator.py` covering each detector, sample-floor silence, window boundaries, detector priority, and provider-error fallback. Deterministic via injected `time_source` + in-memory `event_provider`.

## Closes
Closes PetroSa2/petrosa_k8s#595.

## FR coverage
**FR21** — execution-side anomaly detection (RED → GREEN).

## Test plan
- [x] `tests/test_execution_evaluator.py` — 17 tests pass locally
- [x] `tests/test_ingest_evaluator.py` + `tests/test_auditor_evaluator.py` — no regressions (34 evaluator tests total)
- [x] Full unit suite — 613 passed (1 pre-existing setuptools-in-venv failure unrelated to this PR)
- [x] Ruff lint + format clean on new files
- [x] `data_manager.main` and `data_manager.auditor.execution_evaluator` import cleanly
- [ ] CI green on this PR