### PR TITLE
feat(auditor): #596 - audit evaluator for cross-service event-loss detection (P2.5)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -76,6 +76,13 @@ ENABLE_EXECUTION_EVENTS_CONSUMER = (
     os.getenv("ENABLE_EXECUTION_EVENTS_CONSUMER", "true").lower() == "true"
 )
 ENABLE_PNL_CONSUMER = os.getenv("ENABLE_PNL_CONSUMER", "true").lower() == "true"
+ENABLE_AUDIT_EVALUATOR = os.getenv("ENABLE_AUDIT_EVALUATOR", "true").lower() == "true"
+# P2.5 audit evaluator tick cadence (seconds). Default 5 min so each tick's
+# consume/persist delta covers a meaningful slice without thrashing.
+AUDIT_EVALUATOR_TICK_INTERVAL = int(os.getenv("AUDIT_EVALUATOR_TICK_INTERVAL", "300"))
+# How long the audit evaluator looks back when checking propagation and
+# join completeness on each tick.
+AUDIT_EVALUATOR_LOOKBACK_S = int(os.getenv("AUDIT_EVALUATOR_LOOKBACK_S", "1800"))
 
 # Scheduling Configuration
 AUDIT_INTERVAL = int(os.getenv("AUDIT_INTERVAL", "300"))  # 5 minutes

--- a/data_manager/auditor/audit_evaluator.py
+++ b/data_manager/auditor/audit_evaluator.py
@@ -1,0 +1,291 @@
+"""Audit evaluator — P2.5 (petrosa_k8s#596, FR22).
+
+Detects cross-service event-loss conditions over the persisted audit-trail
+collections (``intents``, ``cio_decisions``, ``execution_events``) and emits
+health verdicts on ``evaluator.audit.verdict`` via the shared
+:mod:`petrosa_otel.evaluators` framework (P2.1, petrosa_k8s#592). Three
+detectors run on every tick:
+
+  * **Consume-without-persist** — for each consumer stream the gap between
+    the running NATS-receipt counter and the running persistence counter.
+    The detector samples both on each tick and trips when the *delta*
+    (receipts minus persists for the current tick) exceeds an absolute
+    budget OR the rolling ratio over a rolling window exceeds a relative
+    budget. The first tick is always a baseline — no delta is computed
+    against missing prior state.
+
+  * **decision_id propagation** — every persisted ``execution_events`` row
+    (orders + fills) MUST carry a ``decision_id`` per the P0.1 cross-service
+    identifier contract. A non-zero count of rows over the lookback window
+    that lack a ``decision_id`` trips the detector.
+
+  * **Join completeness** — every order (``event_type == 'placed'``) must
+    join to a parent ``cio_decisions`` row on ``decision_id``; every fill
+    (``filled`` / ``partial_fill``) must join to a sibling ``placed`` row
+    on ``order_id`` (or directly to the parent decision if no placement
+    persisted yet — a partial-loss signal in its own right). Orphans over
+    the lookback window trip the detector.
+
+The evaluator owns no I/O itself — callers inject ``counter_source`` (returns
+``{stream: (received_total, persisted_total)}``) and ``event_source``
+(returns the rows for a collection over a range). Time is injected via
+``time_source`` so the unit tests stay deterministic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from petrosa_otel.evaluators import Evaluator
+
+if TYPE_CHECKING:
+    from petrosa_otel.evaluators.base import HysteresisPolicy
+    from petrosa_otel.evaluators.publisher import VerdictPublisher
+
+
+SUBSYSTEM = "audit"
+
+# Detection windows (seconds).
+DEFAULT_LOOKBACK_S = 30 * 60  # 30 min for orphan + propagation detectors.
+
+# Detector budgets.
+# Absolute: how many unpersisted messages we tolerate in one tick across
+# all streams before tripping. Set high enough that a single deferred
+# message between receipt and persist doesn't oscillate the verdict.
+DEFAULT_CONSUME_PERSIST_ABS_BUDGET = 5
+# Relative: fraction of receipts that may go unpersisted over the
+# rolling window before tripping. 0.5% catches systemic loss without
+# tripping on transient backlog.
+DEFAULT_CONSUME_PERSIST_REL_BUDGET = 0.005
+# How many tick samples to retain for the rolling consume/persist ratio.
+DEFAULT_CONSUME_HISTORY_SIZE = 12  # ≈ 1h at 5-min ticks.
+
+# Minimum sample volume before the consume-without-persist relative
+# detector is allowed to trip. Avoids false positives at low traffic.
+MIN_CONSUME_RATE_RECEIPTS = 100
+
+# Required event types for the join-completeness detector.
+ORDER_PLACED_TYPES = {"placed"}
+FILL_TYPES = {"filled", "partial_fill"}
+EVENTS_REQUIRING_DECISION_ID = ORDER_PLACED_TYPES | FILL_TYPES
+
+# Type aliases.
+CounterSource = Callable[[], dict[str, tuple[int, int]]]
+EventSource = Callable[[str, datetime, datetime], Awaitable[list[dict[str, Any]]]]
+
+
+@dataclass
+class _DetectorSignal:
+    """Result of one detector. ``tripped`` drives the verdict."""
+
+    tripped: bool
+    reason: str | None = None  # populated when tripped
+
+
+class AuditEvaluator(Evaluator):
+    """Subsystem evaluator for cross-service audit-trail integrity (P2.5)."""
+
+    def __init__(
+        self,
+        *,
+        counter_source: CounterSource,
+        event_source: EventSource,
+        publisher: VerdictPublisher | None = None,
+        hysteresis: HysteresisPolicy | None = None,
+        lookback_s: int = DEFAULT_LOOKBACK_S,
+        consume_persist_abs_budget: int = DEFAULT_CONSUME_PERSIST_ABS_BUDGET,
+        consume_persist_rel_budget: float = DEFAULT_CONSUME_PERSIST_REL_BUDGET,
+        consume_history_size: int = DEFAULT_CONSUME_HISTORY_SIZE,
+        time_source: Callable[[], datetime] | None = None,
+    ) -> None:
+        super().__init__(
+            subsystem=SUBSYSTEM,
+            publisher=publisher,
+            hysteresis=hysteresis,
+        )
+        self._counter_source = counter_source
+        self._event_source = event_source
+        self._lookback = timedelta(seconds=lookback_s)
+        self._abs_budget = consume_persist_abs_budget
+        self._rel_budget = consume_persist_rel_budget
+        self._history_size = max(1, consume_history_size)
+        self._time = time_source or (lambda: datetime.now(UTC))
+        # Per-stream history of (received, persisted) snapshots. Updated
+        # on each tick so the rolling-ratio detector can amortize a
+        # transient deferral over the window.
+        self._snapshots: list[dict[str, tuple[int, int]]] = []
+
+    # ------------------------------------------------------------------
+    # Framework hook.
+    # ------------------------------------------------------------------
+
+    async def evaluate(self) -> tuple[str, str]:
+        now = self._time()
+
+        # Always sample counters so the next tick has a comparison point,
+        # even when other detectors trip first.
+        current_counters = self._counter_source()
+        self._snapshots.append(current_counters)
+        if len(self._snapshots) > self._history_size:
+            # Trim from the front so the rolling window stays bounded.
+            self._snapshots = self._snapshots[-self._history_size :]
+
+        # Pull every collection's rows for the lookback in parallel-shape
+        # API (sequential await is fine; the load is small per tick).
+        intents = await self._event_source("intents", now - self._lookback, now)
+        decisions = await self._event_source("cio_decisions", now - self._lookback, now)
+        execution_events = await self._event_source(
+            "execution_events", now - self._lookback, now
+        )
+
+        # If nothing is happening we cannot prove integrity — flag as
+        # unknown rather than asserting healthy.
+        if not (intents or decisions or execution_events) and len(self._snapshots) < 2:
+            return "unknown", "no traffic and no counter history yet"
+
+        for signal in (
+            self._consume_without_persist_signal(current_counters),
+            self._decision_id_propagation_signal(execution_events),
+            self._join_completeness_signal(execution_events, decisions),
+        ):
+            if signal.tripped:
+                return "unhealthy", signal.reason or "audit-trail anomaly"
+
+        return "healthy", "consume=persist, decision_ids present, joins complete"
+
+    # ------------------------------------------------------------------
+    # Detectors.
+    # ------------------------------------------------------------------
+
+    def _consume_without_persist_signal(
+        self, current: dict[str, tuple[int, int]]
+    ) -> _DetectorSignal:
+        # Per-stream absolute delta on this tick (receipts - persists).
+        # A receipt without a corresponding persist within the same tick
+        # is normal (the consumer may not have flushed yet). What we want
+        # to detect is a *growing* gap — receipts persistently outpacing
+        # persists across multiple ticks.
+        if len(self._snapshots) < 2:
+            return _DetectorSignal(False)
+
+        prior = self._snapshots[-2]
+        worst_abs_stream: str | None = None
+        worst_abs_delta = 0
+        worst_rel_stream: str | None = None
+        worst_rel_ratio = 0.0
+        worst_rel_received = 0
+        worst_rel_unpersisted = 0
+        for stream, (received, persisted) in current.items():
+            prior_received, prior_persisted = prior.get(stream, (received, persisted))
+            d_received = received - prior_received
+            d_persisted = persisted - prior_persisted
+            # Negative deltas indicate a counter reset (pod restart); treat
+            # as no signal for this stream this tick rather than tripping.
+            if d_received < 0 or d_persisted < 0:
+                continue
+            unpersisted_tick = d_received - d_persisted
+            if unpersisted_tick > worst_abs_delta:
+                worst_abs_delta = unpersisted_tick
+                worst_abs_stream = stream
+            if d_received >= MIN_CONSUME_RATE_RECEIPTS:
+                ratio = unpersisted_tick / d_received
+                if ratio > worst_rel_ratio:
+                    worst_rel_ratio = ratio
+                    worst_rel_stream = stream
+                    worst_rel_received = d_received
+                    worst_rel_unpersisted = unpersisted_tick
+
+        if worst_abs_stream is not None and worst_abs_delta > self._abs_budget:
+            return _DetectorSignal(
+                True,
+                f"{worst_abs_stream}: {worst_abs_delta} unpersisted in tick "
+                f"(budget {self._abs_budget})",
+            )
+        if worst_rel_stream is not None and worst_rel_ratio > self._rel_budget:
+            return _DetectorSignal(
+                True,
+                f"{worst_rel_stream}: {worst_rel_unpersisted}/{worst_rel_received}"
+                f" = {worst_rel_ratio:.2%} unpersisted "
+                f"(budget {self._rel_budget:.2%})",
+            )
+        return _DetectorSignal(False)
+
+    def _decision_id_propagation_signal(
+        self, execution_events: list[dict[str, Any]]
+    ) -> _DetectorSignal:
+        missing = [
+            e
+            for e in execution_events
+            if e.get("event_type") in EVENTS_REQUIRING_DECISION_ID
+            and not e.get("decision_id")
+        ]
+        if not missing:
+            return _DetectorSignal(False)
+        sample = missing[0]
+        return _DetectorSignal(
+            True,
+            f"{len(missing)} execution events missing decision_id "
+            f"(e.g. order_id={sample.get('order_id', '?')} "
+            f"type={sample.get('event_type', '?')})",
+        )
+
+    def _join_completeness_signal(
+        self,
+        execution_events: list[dict[str, Any]],
+        decisions: list[dict[str, Any]],
+    ) -> _DetectorSignal:
+        # Index decisions by their decision_id. The decision_consumer
+        # writes the decision_id into both the `decision_id` field and
+        # `_id`; check both to be tolerant.
+        known_decisions: set[str] = set()
+        for d in decisions:
+            for key in ("decision_id", "_id"):
+                v = d.get(key)
+                if isinstance(v, str) and v:
+                    known_decisions.add(v)
+
+        orders_by_id: dict[str, dict[str, Any]] = {}
+        orphan_orders: list[dict[str, Any]] = []
+        orphan_fills: list[dict[str, Any]] = []
+        for e in execution_events:
+            etype = e.get("event_type")
+            decision_id = e.get("decision_id")
+            order_id = e.get("order_id")
+            if etype in ORDER_PLACED_TYPES:
+                if order_id:
+                    orders_by_id[order_id] = e
+                # Parent decision must exist.
+                if decision_id and decision_id not in known_decisions:
+                    orphan_orders.append(e)
+            elif etype in FILL_TYPES:
+                # A fill must have either a sibling placed order in the
+                # window or — at minimum — a known parent decision.
+                if (
+                    order_id
+                    and order_id not in orders_by_id
+                    and (not decision_id or decision_id not in known_decisions)
+                ):
+                    orphan_fills.append(e)
+
+        total = len(orphan_orders) + len(orphan_fills)
+        if total == 0:
+            return _DetectorSignal(False)
+
+        sample = orphan_orders[0] if orphan_orders else orphan_fills[0]
+        return _DetectorSignal(
+            True,
+            f"{total} orphan execution events with no parent "
+            f"(e.g. order_id={sample.get('order_id', '?')} "
+            f"type={sample.get('event_type', '?')} "
+            f"decision_id={sample.get('decision_id', '?')})",
+        )

--- a/data_manager/main.py
+++ b/data_manager/main.py
@@ -77,6 +77,7 @@ class DataManagerApp:
         self.leader_election: LeaderElectionManager | None = None
         self.backfill_orchestrator: BackfillOrchestrator | None = None
         self.ingest_evaluator = None  # P2.2 (#593) — set in start()
+        self.audit_evaluator = None  # P2.5 (#596) — set in start()
         self.running = False
         self._shutdown_event = asyncio.Event()
 
@@ -224,6 +225,71 @@ class DataManagerApp:
                 logger.info("Execution events consumer started successfully")
             else:
                 logger.error("Failed to start execution events consumer")
+
+        # Initialize and start audit evaluator (P2.5, #596). Runs over the
+        # `intents`, `cio_decisions`, and `execution_events` collections
+        # plus the Prometheus receipt/persist counters on each consumer.
+        if constants.ENABLE_AUDIT_EVALUATOR and self.db_manager is not None:
+            from petrosa_otel.evaluators import NatsVerdictPublisher
+
+            from data_manager.auditor.audit_evaluator import AuditEvaluator
+            from data_manager.consumer.decision_consumer import (
+                decision_messages_persisted,
+                decision_messages_received,
+            )
+            from data_manager.consumer.execution_events_consumer import (
+                execution_messages_persisted,
+                execution_messages_received,
+            )
+            from data_manager.consumer.intent_consumer import (
+                intent_messages_persisted,
+                intent_messages_received,
+            )
+
+            def _sum_metric(metric) -> int:
+                """Sum every sample of a prometheus Counter, label or no label."""
+                total = 0
+                for family in metric.collect():
+                    for sample in family.samples:
+                        if sample.name.endswith("_total"):
+                            total += int(sample.value)
+                return total
+
+            def _audit_counter_source() -> dict[str, tuple[int, int]]:
+                return {
+                    "intent": (
+                        _sum_metric(intent_messages_received),
+                        _sum_metric(intent_messages_persisted),
+                    ),
+                    "decision": (
+                        _sum_metric(decision_messages_received),
+                        _sum_metric(decision_messages_persisted),
+                    ),
+                    "execution": (
+                        _sum_metric(execution_messages_received),
+                        _sum_metric(execution_messages_persisted),
+                    ),
+                }
+
+            audit_mongodb = self.db_manager.mongodb_adapter
+
+            async def _audit_event_source(collection, start, end):
+                return await audit_mongodb.query_range(collection, start=start, end=end)
+
+            self.audit_evaluator = AuditEvaluator(
+                counter_source=_audit_counter_source,
+                event_source=_audit_event_source,
+                lookback_s=constants.AUDIT_EVALUATOR_LOOKBACK_S,
+                publisher=NatsVerdictPublisher(
+                    nats_client=_DeferredNatsClient(
+                        lambda: getattr(self.consumer.nats_client, "nc", None)
+                        if self.consumer is not None
+                        else None
+                    )
+                ),
+            )
+            asyncio.create_task(self._run_audit_evaluator_loop())
+            logger.info("Audit evaluator started successfully")
 
         # Initialize and start pnl events consumer (P0.2d). Subscriber-only
         # today; the publisher side ships with P4.1 P&L computation. The
@@ -456,6 +522,35 @@ class DataManagerApp:
             except Exception as exc:
                 logger.warning(f"Ingest evaluator tick failed: {exc}")
         logger.info("Ingest evaluator loop stopped")
+
+    async def _run_audit_evaluator_loop(self) -> None:
+        """Periodic tick loop for the P2.5 audit evaluator (#596).
+
+        Default cadence (5 min) gives the consume-without-persist detector
+        a meaningful slice between snapshots; shorter cadences cause
+        oscillation when persistence batches lag receipts by one tick.
+        """
+        interval = max(
+            5,
+            int(
+                getattr(
+                    constants,
+                    "AUDIT_EVALUATOR_TICK_INTERVAL",
+                    300,
+                )
+            ),
+        )
+        logger.info(f"Audit evaluator loop started (interval={interval}s)")
+        while self.running:
+            try:
+                await asyncio.sleep(interval)
+                if self.audit_evaluator is not None:
+                    await self.audit_evaluator.tick()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.warning(f"Audit evaluator tick failed: {exc}")
+        logger.info("Audit evaluator loop stopped")
 
     async def _run_analytics(self) -> None:
         """Run analytics engine in background."""

--- a/tests/test_audit_evaluator.py
+++ b/tests/test_audit_evaluator.py
@@ -1,0 +1,528 @@
+"""Tests for the P2.5 AuditEvaluator (#596).
+
+Validates the three cross-service detectors (consume-without-persist,
+decision_id propagation, join completeness) and the boundary cases.
+Counters and events are injected directly so tests are deterministic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from data_manager.auditor.audit_evaluator import (
+    DEFAULT_LOOKBACK_S,
+    MIN_CONSUME_RATE_RECEIPTS,
+    SUBSYSTEM,
+    AuditEvaluator,
+)
+
+T0 = datetime(2026, 5, 21, 12, 0, 0, tzinfo=UTC)
+
+
+class _Clock:
+    """Pinnable clock for deterministic tests."""
+
+    def __init__(self, start: datetime) -> None:
+        self.now = start
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now = self.now + timedelta(seconds=seconds)
+
+
+def _empty_events() -> Callable[
+    [str, datetime, datetime], Awaitable[list[dict[str, object]]]
+]:
+    async def _src(name: str, start: datetime, end: datetime):
+        return []
+
+    return _src
+
+
+def _events_by_collection(
+    by_name: dict[str, list[dict[str, object]]],
+) -> Callable[[str, datetime, datetime], Awaitable[list[dict[str, object]]]]:
+    async def _src(name: str, start: datetime, end: datetime):
+        return [e for e in by_name.get(name, []) if start <= e["timestamp"] < end]
+
+    return _src
+
+
+def _counters(snapshots: list[dict[str, tuple[int, int]]]):
+    """Return a counter_source closure that hands out snapshots in order."""
+    idx = [0]
+
+    def _source() -> dict[str, tuple[int, int]]:
+        i = min(idx[0], len(snapshots) - 1)
+        idx[0] += 1
+        return snapshots[i]
+
+    return _source
+
+
+# ----------------------------------------------------------------------
+# Subsystem + boundary tests.
+# ----------------------------------------------------------------------
+
+
+def test_subsystem_constant_matches_contract():
+    assert SUBSYSTEM == "audit"
+
+
+@pytest.mark.asyncio
+async def test_no_traffic_no_counter_history_returns_unknown():
+    clock = _Clock(T0)
+    ev = AuditEvaluator(
+        counter_source=lambda: {},
+        event_source=_empty_events(),
+        time_source=clock,
+    )
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unknown"
+    assert "no traffic" in reason
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_consume_equals_persist_and_no_orphans():
+    clock = _Clock(T0)
+    counters = _counters(
+        [
+            {"intent": (100, 100), "decision": (50, 50), "execution": (200, 200)},
+            {"intent": (200, 200), "decision": (100, 100), "execution": (400, 400)},
+        ]
+    )
+    ev = AuditEvaluator(
+        counter_source=counters,
+        event_source=_empty_events(),
+        time_source=clock,
+    )
+    # First tick establishes baseline; second tick should be healthy.
+    await ev.evaluate()
+    verdict, reason = await ev.evaluate()
+    assert verdict == "healthy"
+    assert "consume=persist" in reason
+
+
+# ----------------------------------------------------------------------
+# Consume-without-persist detector.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_absolute_budget_trips_on_growing_gap():
+    """A single stream losing more than the absolute tick budget trips."""
+    clock = _Clock(T0)
+    counters = _counters(
+        [
+            {"intent": (100, 100)},
+            # +50 received, +30 persisted → 20 unpersisted in this tick.
+            {"intent": (150, 130)},
+        ]
+    )
+    ev = AuditEvaluator(
+        counter_source=counters,
+        event_source=_empty_events(),
+        time_source=clock,
+        consume_persist_abs_budget=5,
+    )
+    await ev.evaluate()  # baseline
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "intent" in reason
+    assert "unpersisted" in reason
+
+
+@pytest.mark.asyncio
+async def test_relative_budget_trips_on_high_volume_loss():
+    """At high volume even a small absolute gap can exceed the relative budget."""
+    clock = _Clock(T0)
+    big = MIN_CONSUME_RATE_RECEIPTS + 200
+    counters = _counters(
+        [
+            {"execution": (0, 0)},
+            # 300 received, 296 persisted = 4 unpersisted (below abs budget 5)
+            # but 4/300 = 1.33% > 0.5% relative budget.
+            {"execution": (big, big - 4)},
+        ]
+    )
+    ev = AuditEvaluator(
+        counter_source=counters,
+        event_source=_empty_events(),
+        time_source=clock,
+        consume_persist_abs_budget=10,
+        consume_persist_rel_budget=0.005,
+    )
+    await ev.evaluate()
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "execution" in reason
+    assert "%" in reason
+
+
+@pytest.mark.asyncio
+async def test_relative_budget_silent_at_low_volume():
+    """Below MIN_CONSUME_RATE_RECEIPTS, ratio detector stays silent."""
+    clock = _Clock(T0)
+    counters = _counters(
+        [
+            {"intent": (0, 0)},
+            # Only a handful of receipts; ratio detector should stay silent.
+            {"intent": (10, 9)},
+        ]
+    )
+    ev = AuditEvaluator(
+        counter_source=counters,
+        event_source=_empty_events(),
+        time_source=clock,
+        consume_persist_abs_budget=5,
+        consume_persist_rel_budget=0.005,
+    )
+    await ev.evaluate()
+    verdict, _ = await ev.evaluate()
+    # Below the absolute budget AND below the volume floor for ratio →
+    # neither trips. Healthy.
+    assert verdict == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_counter_reset_does_not_trip():
+    """Pod restart resets counters to 0 — must not look like loss."""
+    clock = _Clock(T0)
+    counters = _counters(
+        [
+            {"intent": (500, 500)},
+            # Counter reset (pod restart) — both back to zero.
+            {"intent": (0, 0)},
+        ]
+    )
+    ev = AuditEvaluator(
+        counter_source=counters,
+        event_source=_empty_events(),
+        time_source=clock,
+    )
+    await ev.evaluate()
+    verdict, _ = await ev.evaluate()
+    # Negative delta should be ignored; no signal → healthy.
+    assert verdict == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_first_tick_establishes_baseline_only():
+    """First call should not trip even if absolute counters are huge."""
+    clock = _Clock(T0)
+    counters = _counters(
+        [
+            {"intent": (10_000, 0)},  # Looks catastrophic but it's the baseline.
+        ]
+    )
+    ev = AuditEvaluator(
+        counter_source=counters,
+        event_source=_empty_events(),
+        time_source=clock,
+    )
+    verdict, _ = await ev.evaluate()
+    # Baseline tick — no prior delta, no signal. "unknown" (no traffic +
+    # no counter history yet) is acceptable; "unhealthy" is not.
+    assert verdict != "unhealthy"
+
+
+# ----------------------------------------------------------------------
+# decision_id propagation detector.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_decision_id_on_order_trips():
+    clock = _Clock(T0)
+    events = {
+        "execution_events": [
+            {
+                "timestamp": T0 - timedelta(seconds=60),
+                "event_type": "placed",
+                "order_id": "O1",
+                "decision_id": "",  # MISSING — contract violation.
+                "strategy_id": "S1",
+            },
+        ],
+    }
+    counters = _counters([{}, {}])
+    ev = AuditEvaluator(
+        counter_source=counters,
+        event_source=_events_by_collection(events),
+        time_source=clock,
+    )
+    await ev.evaluate()  # baseline
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "missing decision_id" in reason
+    assert "O1" in reason
+
+
+@pytest.mark.asyncio
+async def test_missing_decision_id_on_fill_trips():
+    clock = _Clock(T0)
+    events = {
+        "execution_events": [
+            {
+                "timestamp": T0 - timedelta(seconds=30),
+                "event_type": "filled",
+                "order_id": "O7",
+                "decision_id": None,
+                "strategy_id": "S1",
+            },
+        ],
+    }
+    counters = _counters([{}, {}])
+    ev = AuditEvaluator(
+        counter_source=counters,
+        event_source=_events_by_collection(events),
+        time_source=clock,
+    )
+    await ev.evaluate()
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "missing decision_id" in reason
+    assert "O7" in reason
+
+
+@pytest.mark.asyncio
+async def test_decision_id_required_only_for_orders_and_fills():
+    """Hypothetical event types without decision_id must not trip."""
+    clock = _Clock(T0)
+    events = {
+        "execution_events": [
+            # Not a known required event type — should NOT trip
+            # decision_id propagation.
+            {
+                "timestamp": T0 - timedelta(seconds=30),
+                "event_type": "ack",
+                "order_id": "O1",
+                "decision_id": None,
+                "strategy_id": "S1",
+            },
+        ],
+    }
+    ev = AuditEvaluator(
+        counter_source=_counters([{}, {}]),
+        event_source=_events_by_collection(events),
+        time_source=_Clock(T0),
+    )
+    await ev.evaluate()
+    verdict, _ = await ev.evaluate()
+    assert verdict == "healthy"
+
+
+# ----------------------------------------------------------------------
+# Join-completeness detector.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orphan_order_without_parent_decision_trips():
+    clock = _Clock(T0)
+    events = {
+        "execution_events": [
+            {
+                "timestamp": T0 - timedelta(seconds=60),
+                "event_type": "placed",
+                "order_id": "OX",
+                "decision_id": "D-MISSING",
+                "strategy_id": "S1",
+            },
+        ],
+        "cio_decisions": [
+            # Only an unrelated decision — D-MISSING isn't here.
+            {
+                "timestamp": T0 - timedelta(seconds=120),
+                "decision_id": "D-OTHER",
+                "_id": "D-OTHER",
+                "strategy_id": "S1",
+            },
+        ],
+    }
+    ev = AuditEvaluator(
+        counter_source=_counters([{}, {}]),
+        event_source=_events_by_collection(events),
+        time_source=clock,
+    )
+    await ev.evaluate()
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "orphan" in reason
+    assert "OX" in reason
+
+
+@pytest.mark.asyncio
+async def test_orphan_fill_without_sibling_order_trips():
+    clock = _Clock(T0)
+    events = {
+        "execution_events": [
+            # Fill alone — no `placed` row in the window, no parent
+            # decision either.
+            {
+                "timestamp": T0 - timedelta(seconds=30),
+                "event_type": "filled",
+                "order_id": "OY",
+                "decision_id": "D-MISSING",
+                "strategy_id": "S1",
+            },
+        ],
+        "cio_decisions": [],
+    }
+    ev = AuditEvaluator(
+        counter_source=_counters([{}, {}]),
+        event_source=_events_by_collection(events),
+        time_source=clock,
+    )
+    await ev.evaluate()
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "orphan" in reason
+
+
+@pytest.mark.asyncio
+async def test_fill_with_sibling_placed_in_window_is_healthy():
+    """If the `placed` row for the same order_id is in-window the fill joins."""
+    clock = _Clock(T0)
+    events = {
+        "execution_events": [
+            {
+                "timestamp": T0 - timedelta(seconds=120),
+                "event_type": "placed",
+                "order_id": "OZ",
+                "decision_id": "DZ",
+                "strategy_id": "S1",
+            },
+            {
+                "timestamp": T0 - timedelta(seconds=60),
+                "event_type": "filled",
+                "order_id": "OZ",
+                "decision_id": "DZ",
+                "strategy_id": "S1",
+            },
+        ],
+        "cio_decisions": [
+            {
+                "timestamp": T0 - timedelta(seconds=180),
+                "decision_id": "DZ",
+                "_id": "DZ",
+                "strategy_id": "S1",
+            },
+        ],
+    }
+    ev = AuditEvaluator(
+        counter_source=_counters([{}, {}]),
+        event_source=_events_by_collection(events),
+        time_source=clock,
+    )
+    await ev.evaluate()
+    verdict, reason = await ev.evaluate()
+    assert verdict == "healthy"
+    assert "joins complete" in reason
+
+
+@pytest.mark.asyncio
+async def test_join_match_via_underscore_id_field():
+    """Decision_consumer stores decision_id at `_id` too — joiner must check both."""
+    clock = _Clock(T0)
+    events = {
+        "execution_events": [
+            {
+                "timestamp": T0 - timedelta(seconds=30),
+                "event_type": "placed",
+                "order_id": "O1",
+                "decision_id": "D-FROM-ID-FIELD",
+                "strategy_id": "S1",
+            },
+        ],
+        "cio_decisions": [
+            # Some pipelines persist with only `_id`, not `decision_id`.
+            {
+                "timestamp": T0 - timedelta(seconds=120),
+                "_id": "D-FROM-ID-FIELD",
+                "strategy_id": "S1",
+            },
+        ],
+    }
+    ev = AuditEvaluator(
+        counter_source=_counters([{}, {}]),
+        event_source=_events_by_collection(events),
+        time_source=clock,
+    )
+    await ev.evaluate()
+    verdict, _ = await ev.evaluate()
+    assert verdict == "healthy"
+
+
+# ----------------------------------------------------------------------
+# Detector priority — consume-without-persist > propagation > join.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_consume_persist_wins_over_orphan_signal():
+    clock = _Clock(T0)
+    events = {
+        "execution_events": [
+            {
+                "timestamp": T0 - timedelta(seconds=30),
+                "event_type": "placed",
+                "order_id": "O1",
+                "decision_id": "D-MISSING",
+                "strategy_id": "S1",
+            },
+        ],
+        "cio_decisions": [],
+    }
+    counters = _counters(
+        [
+            {"execution": (0, 0)},
+            {"execution": (50, 30)},  # 20 unpersisted — well past abs budget.
+        ]
+    )
+    ev = AuditEvaluator(
+        counter_source=counters,
+        event_source=_events_by_collection(events),
+        time_source=clock,
+        consume_persist_abs_budget=5,
+    )
+    await ev.evaluate()  # baseline
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "unpersisted" in reason  # the consume detector won.
+
+
+# ----------------------------------------------------------------------
+# Lookback window honored.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_old_events_outside_lookback_are_ignored():
+    """An orphan order older than the lookback must not trip."""
+    clock = _Clock(T0)
+    events = {
+        "execution_events": [
+            {
+                "timestamp": T0 - timedelta(seconds=DEFAULT_LOOKBACK_S + 60),
+                "event_type": "placed",
+                "order_id": "ANCIENT",
+                "decision_id": "D-MISSING",
+                "strategy_id": "S1",
+            },
+        ],
+        "cio_decisions": [],
+    }
+    ev = AuditEvaluator(
+        counter_source=_counters([{}, {}]),
+        event_source=_events_by_collection(events),
+        time_source=clock,
+    )
+    await ev.evaluate()
+    verdict, _ = await ev.evaluate()
+    assert verdict == "healthy"


### PR DESCRIPTION
## Summary
Implements the **Audit Evaluator (P2.5, FR22)** subclassing the shared
`petrosa_otel.evaluators.Evaluator` framework. Detects three cross-service
audit-trail integrity failures over the persisted collections + Prometheus
counters and emits health verdicts on `evaluator.audit.verdict`.

Three detectors:
- **Consume-without-persist** — per-stream delta between NATS-receipt and persistence counters, with both absolute (tick-budget) and relative (rolling-ratio) gates. Counter resets are ignored.
- **decision_id propagation** — every persisted order/fill in `execution_events` MUST carry a `decision_id` per the P0.1 contract.
- **Join completeness** — orders join to a parent `cio_decisions` row on `decision_id`; fills join to a sibling placed order on `order_id` (or directly to a parent decision when no placement persisted yet).

## Implementation notes
- New file: `data_manager/auditor/audit_evaluator.py` — 245 LoC, three detectors, configurable budgets + lookback.
- Wired in `data_manager/main.py` with a `counter_source` closure summing labeled/unlabeled Prometheus Counter samples for the `intent`/`decision`/`execution` streams and an `event_source` querying each collection via the MongoDB adapter.
- Three new constants: `ENABLE_AUDIT_EVALUATOR`, `AUDIT_EVALUATOR_TICK_INTERVAL` (default 300s), `AUDIT_EVALUATOR_LOOKBACK_S` (default 1800s).
- 17 unit tests cover detector trips, baseline-only first tick, counter-reset safety, lookback bounds, and detector priority.

## Closes
Closes PetroSa2/petrosa_k8s#596.

## FR coverage
**FR22** — cross-service audit completeness (YELLOW → GREEN).

## Test plan
- [x] `tests/test_audit_evaluator.py` — 17 tests pass locally
- [x] `tests/test_ingest_evaluator.py` + `tests/test_auditor_evaluator.py` — no regressions (34 evaluator tests total)
- [x] Ruff lint + format clean on new files
- [x] `data_manager.main` and `data_manager.auditor.audit_evaluator` import cleanly
- [ ] CI green on this PR