### PR TITLE
feat(characterizations): #599 - persisted reproducible characterization artifacts (P3.2)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -17,6 +17,7 @@ from data_manager.api.routes import (
     anomalies,
     backfill,
     catalog,
+    characterizations,
     config,
     data,
     generic,
@@ -117,6 +118,11 @@ def create_app() -> FastAPI:
     app.include_router(catalog.router, prefix="/catalog", tags=["Catalog"])
     app.include_router(backfill.router, prefix="/backfill", tags=["Backfill"])
     app.include_router(anomalies.router, prefix="/anomalies", tags=["Anomalies"])
+    app.include_router(
+        characterizations.router,
+        prefix="/api/v1",
+        tags=["Characterizations"],
+    )
 
     # New API routes
     app.include_router(generic.router, tags=["Generic CRUD"])

--- a/data_manager/api/routes/characterizations.py
+++ b/data_manager/api/routes/characterizations.py
@@ -1,0 +1,81 @@
+"""Characterization API endpoints (P3.2, petrosa_k8s#599)."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Query
+
+import data_manager.api.app as api_module
+from data_manager.db.repositories.characterization_repository import (
+    CharacterizationRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _repo() -> CharacterizationRepository | None:
+    """Build a CharacterizationRepository or return None if DB is unavailable."""
+    if not api_module.db_manager:
+        return None
+    if not getattr(api_module.db_manager, "mongodb_adapter", None):
+        return None
+    return CharacterizationRepository(
+        mysql_adapter=api_module.db_manager.mysql_adapter,
+        mongodb_adapter=api_module.db_manager.mongodb_adapter,
+    )
+
+
+@router.get("/characterizations")
+async def get_characterization(
+    strategy_id: str = Query(..., description="Strategy identifier"),
+    version: str | None = Query(
+        None,
+        description=(
+            "Exact strategy version to fetch. When omitted, returns the most "
+            "recent characterization for the strategy."
+        ),
+    ),
+) -> dict:
+    """Return one characterization for the given strategy.
+
+    Lookup semantics:
+      - With ``version``: exact (strategy_id, version) row, or 404.
+      - Without ``version``: most recently persisted row for the strategy.
+
+    The endpoint never returns a list; callers wanting multiple versions
+    should call this endpoint per version, or extend the API in a
+    follow-up ticket.
+    """
+    repo = _repo()
+    if repo is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    try:
+        artifact = (
+            await repo.get_version(strategy_id, version)
+            if version
+            else await repo.get_latest(strategy_id)
+        )
+    except Exception as exc:
+        logger.error(
+            "characterizations: lookup failed for %s/%s: %s",
+            strategy_id,
+            version,
+            exc,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="lookup failed") from exc
+
+    if artifact is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"no characterization for strategy_id={strategy_id}"
+                + (f", version={version}" if version else "")
+            ),
+        )
+
+    return artifact.model_dump(mode="json")

--- a/data_manager/db/repositories/characterization_repository.py
+++ b/data_manager/db/repositories/characterization_repository.py
@@ -1,0 +1,107 @@
+"""Repository for the `characterizations` collection (P3.2, petrosa_k8s#599).
+
+Persists :class:`data_manager.models.characterization.Characterization`
+documents in MongoDB and exposes lookup primitives:
+
+  * :meth:`upsert` — write-or-replace by (strategy_id, strategy_version)
+  * :meth:`get_latest` — most recent characterization for a strategy
+  * :meth:`get_version` — exact (strategy_id, strategy_version) lookup
+
+`upsert` uses the deterministic ``(strategy_id, strategy_version)`` pair
+as the unique key; a re-run with the same inputs replaces the row in
+place rather than appending a new one. Two strategies sharing a version
+string is intentional: the version is the unit of reproducibility.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from data_manager.db.repositories.base_repository import BaseRepository
+from data_manager.models.characterization import Characterization
+
+if TYPE_CHECKING:
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+    from data_manager.db.mysql_adapter import MySQLAdapter
+
+logger = logging.getLogger(__name__)
+
+CHARACTERIZATIONS_COLLECTION = "characterizations"
+
+
+class CharacterizationRepository(BaseRepository):
+    """MongoDB-backed repository for characterization artifacts."""
+
+    def __init__(
+        self,
+        mysql_adapter: MySQLAdapter | None,
+        mongodb_adapter: MongoDBAdapter | None,
+    ) -> None:
+        super().__init__(mysql_adapter, mongodb_adapter)
+
+    async def upsert(self, artifact: Characterization) -> bool:
+        """Persist (or replace) a characterization keyed by (strategy_id, version).
+
+        Returns True iff the write succeeded. Re-running with identical
+        inputs replaces the document in place — reproducible runs do not
+        bloat the collection. The caller is responsible for verifying
+        that ``inputs_hash`` and ``metrics`` match across runs.
+        """
+        if not self.mongodb or not getattr(self.mongodb, "db", None):
+            logger.warning("characterizations: mongodb not available; skipping write")
+            return False
+
+        artifact.validate_required_metrics()
+        doc = artifact.model_dump()
+        # Re-derive _id from the deterministic key so the unique index
+        # exists without a separate ensure_indexes call.
+        doc["_id"] = f"{artifact.strategy_id}::{artifact.strategy_version}"
+        try:
+            await self.mongodb.db[CHARACTERIZATIONS_COLLECTION].replace_one(
+                {"_id": doc["_id"]},
+                doc,
+                upsert=True,
+            )
+            return True
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.error(
+                "characterizations: failed to persist artifact: %s", exc, exc_info=True
+            )
+            return False
+
+    async def get_version(
+        self, strategy_id: str, strategy_version: str
+    ) -> Characterization | None:
+        """Look up a characterization by exact (strategy_id, strategy_version)."""
+        if not self.mongodb or not getattr(self.mongodb, "db", None):
+            return None
+        doc = await self.mongodb.db[CHARACTERIZATIONS_COLLECTION].find_one(
+            {"strategy_id": strategy_id, "strategy_version": strategy_version}
+        )
+        return _document_to_artifact(doc)
+
+    async def get_latest(self, strategy_id: str) -> Characterization | None:
+        """Return the most recent characterization for a strategy."""
+        if not self.mongodb or not getattr(self.mongodb, "db", None):
+            return None
+        cursor = (
+            self.mongodb.db[CHARACTERIZATIONS_COLLECTION]
+            .find({"strategy_id": strategy_id})
+            .sort("created_at", -1)
+            .limit(1)
+        )
+        docs = await cursor.to_list(length=1)
+        return _document_to_artifact(docs[0]) if docs else None
+
+
+def _document_to_artifact(doc: dict[str, Any] | None) -> Characterization | None:
+    """Convert a stored Mongo document back to a `Characterization`.
+
+    Drops the internal `_id` field; Pydantic does not own it.
+    """
+    if doc is None:
+        return None
+    doc = dict(doc)
+    doc.pop("_id", None)
+    return Characterization(**doc)

--- a/data_manager/models/characterization.py
+++ b/data_manager/models/characterization.py
@@ -1,0 +1,157 @@
+"""Characterization artifact model (P3.2, petrosa_k8s#599).
+
+A characterization is a structured, byte-reproducible snapshot of a
+strategy's expected behavior over a frozen data window: edge metrics,
+drawdown envelope, parameter sensitivities, and the exact inputs that
+produced them. The reproducibility property is the point — running the
+backtest again against the same `inputs_hash` MUST yield the same
+metrics, byte for byte.
+
+The persistence schema is intentionally additive: new metric fields may
+be appended to `metrics` without breaking older readers, and
+`param_sensitivities` is an open dict so each strategy can describe its
+own grid shape.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from pydantic import BaseModel, Field
+
+REQUIRED_METRIC_KEYS = ("sharpe", "win_rate", "mean_return")
+
+
+class Characterization(BaseModel):
+    """A single backtest characterization persisted in `characterizations`."""
+
+    strategy_id: str = Field(..., description="Strategy identifier")
+    strategy_version: str = Field(..., description="Strategy version tag")
+    data_window_from: datetime = Field(..., description="Backtest window start (UTC)")
+    data_window_to: datetime = Field(..., description="Backtest window end (UTC)")
+    seed: int = Field(..., description="Deterministic RNG seed used for the run")
+    metrics: dict[str, float] = Field(
+        ...,
+        description=(
+            "Expected edge metrics. Must include sharpe, win_rate, mean_return; "
+            "extra keys are accepted and round-tripped"
+        ),
+    )
+    drawdown_envelope: list[float] = Field(
+        ...,
+        description=(
+            "Percentile distribution of drawdowns over the run, expressed as a "
+            "list of percentile values (e.g., [p50, p90, p99, p100])"
+        ),
+    )
+    param_sensitivities: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Small grid of parameter sensitivities around production params",
+    )
+    inputs_hash: str = Field(
+        ...,
+        description=(
+            "Hex SHA-256 of the deterministic inputs (strategy_id, version, "
+            "window bounds, seed, params). Reproducibility key."
+        ),
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="When this characterization was persisted",
+    )
+
+    def validate_required_metrics(self) -> None:
+        """Raise ValueError if metrics is missing any required key.
+
+        Pydantic accepts arbitrary dicts; the schema-level constraint
+        that `sharpe`, `win_rate`, and `mean_return` must be present is
+        enforced separately so external callers can reuse the helper.
+        """
+        missing = [k for k in REQUIRED_METRIC_KEYS if k not in self.metrics]
+        if missing:
+            raise ValueError(
+                f"metrics is missing required key(s): {', '.join(missing)}"
+            )
+
+
+def compute_inputs_hash(
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    data_window_from: datetime,
+    data_window_to: datetime,
+    seed: int,
+    params: dict[str, Any] | None = None,
+) -> str:
+    """Compute the canonical SHA-256 hash of a characterization's inputs.
+
+    Inputs are normalised to a deterministic JSON document so two callers
+    that build the same characterization produce the same hash regardless
+    of dict ordering or timezone naive-vs-aware datetimes.
+    """
+
+    def _iso(dt: datetime) -> str:
+        # Naive datetimes are assumed UTC so the hash stays stable when a
+        # caller forgets to tag tzinfo.
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC).isoformat()
+
+    payload = {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "data_window_from": _iso(data_window_from),
+        "data_window_to": _iso(data_window_to),
+        "seed": int(seed),
+        "params": params or {},
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def verify_characterization(
+    artifact: Characterization,
+    recompute_fn,
+) -> bool:
+    """Re-run the backtest and assert the recomputed characterization matches.
+
+    `recompute_fn` is expected to be a callable that takes the
+    deterministic inputs and returns a new ``Characterization`` instance.
+    The two artifacts compare equal iff every byte of the canonical
+    metric blob matches.
+
+    The check is intentionally strict — partial matches that "drift"
+    over time would defeat the reproducibility property. Callers that
+    want a softer check should wrap this helper with their own tolerance.
+    """
+    recomputed = recompute_fn(
+        strategy_id=artifact.strategy_id,
+        strategy_version=artifact.strategy_version,
+        data_window_from=artifact.data_window_from,
+        data_window_to=artifact.data_window_to,
+        seed=artifact.seed,
+    )
+
+    def _blob(c: Characterization) -> bytes:
+        return json.dumps(
+            {
+                "metrics": c.metrics,
+                "drawdown_envelope": c.drawdown_envelope,
+                "param_sensitivities": c.param_sensitivities,
+                "inputs_hash": c.inputs_hash,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+    return _blob(artifact) == _blob(recomputed)

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -1,0 +1,366 @@
+"""Tests for the P3.2 characterization model + repository + API (#599)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.api.app import create_app
+from data_manager.db.repositories.characterization_repository import (
+    CHARACTERIZATIONS_COLLECTION,
+    CharacterizationRepository,
+)
+from data_manager.models.characterization import (
+    Characterization,
+    compute_inputs_hash,
+    verify_characterization,
+)
+
+T0 = datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC)
+T1 = datetime(2026, 5, 21, 0, 0, 0, tzinfo=UTC)
+
+
+def _make_artifact(
+    *,
+    strategy_id: str = "s1",
+    strategy_version: str = "v1",
+    seed: int = 42,
+    metrics: dict[str, float] | None = None,
+    drawdown_envelope: list[float] | None = None,
+    param_sensitivities: dict[str, object] | None = None,
+    inputs_hash: str | None = None,
+) -> Characterization:
+    return Characterization(
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        data_window_from=T0,
+        data_window_to=T1,
+        seed=seed,
+        metrics=metrics or {"sharpe": 1.5, "win_rate": 0.55, "mean_return": 0.0012},
+        drawdown_envelope=drawdown_envelope or [-0.01, -0.05, -0.1, -0.2],
+        param_sensitivities=param_sensitivities or {"window": [10, 20, 30]},
+        inputs_hash=inputs_hash
+        or compute_inputs_hash(
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            data_window_from=T0,
+            data_window_to=T1,
+            seed=seed,
+        ),
+    )
+
+
+# ----------------------------------------------------------------------
+# Model + helpers.
+# ----------------------------------------------------------------------
+
+
+def test_artifact_round_trips_through_model_dump():
+    artifact = _make_artifact()
+    dumped = artifact.model_dump()
+    rebuilt = Characterization(**dumped)
+    assert rebuilt.model_dump() == dumped
+
+
+def test_validate_required_metrics_raises_on_missing_key():
+    artifact = _make_artifact(
+        metrics={"sharpe": 1.0, "win_rate": 0.5}
+    )  # no mean_return
+    with pytest.raises(ValueError, match="mean_return") as exc_info:
+        artifact.validate_required_metrics()
+    assert "mean_return" in str(exc_info.value)
+
+
+def test_validate_required_metrics_accepts_extra_keys():
+    """Extra metric keys are tolerated and round-tripped."""
+    artifact = _make_artifact(
+        metrics={
+            "sharpe": 1.0,
+            "win_rate": 0.5,
+            "mean_return": 0.001,
+            "calmar": 0.4,  # extra metric, no error
+        }
+    )
+    artifact.validate_required_metrics()  # should not raise
+    assert artifact.metrics["calmar"] == 0.4
+
+
+def test_compute_inputs_hash_is_stable_across_dict_orderings():
+    h1 = compute_inputs_hash(
+        strategy_id="s1",
+        strategy_version="v1",
+        data_window_from=T0,
+        data_window_to=T1,
+        seed=42,
+        params={"a": 1, "b": 2},
+    )
+    h2 = compute_inputs_hash(
+        strategy_id="s1",
+        strategy_version="v1",
+        data_window_from=T0,
+        data_window_to=T1,
+        seed=42,
+        params={"b": 2, "a": 1},
+    )
+    assert h1 == h2
+
+
+def test_compute_inputs_hash_changes_with_seed():
+    h1 = compute_inputs_hash(
+        strategy_id="s1",
+        strategy_version="v1",
+        data_window_from=T0,
+        data_window_to=T1,
+        seed=42,
+    )
+    h2 = compute_inputs_hash(
+        strategy_id="s1",
+        strategy_version="v1",
+        data_window_from=T0,
+        data_window_to=T1,
+        seed=43,
+    )
+    assert h1 != h2
+
+
+def test_compute_inputs_hash_treats_naive_as_utc():
+    """Naive datetimes are assumed UTC so hashes stay stable."""
+    naive = T0.replace(tzinfo=None)
+    h_aware = compute_inputs_hash(
+        strategy_id="s",
+        strategy_version="v",
+        data_window_from=T0,
+        data_window_to=T1,
+        seed=1,
+    )
+    h_naive = compute_inputs_hash(
+        strategy_id="s",
+        strategy_version="v",
+        data_window_from=naive,
+        data_window_to=T1,
+        seed=1,
+    )
+    assert h_aware == h_naive
+
+
+def test_verify_characterization_passes_when_recompute_matches():
+    artifact = _make_artifact()
+
+    def _recompute(**kwargs):
+        # Return an artifact with identical metrics + envelope + sensitivities.
+        return _make_artifact()
+
+    assert verify_characterization(artifact, _recompute) is True
+
+
+def test_verify_characterization_fails_when_metric_drifts():
+    artifact = _make_artifact()
+
+    def _recompute(**kwargs):
+        # Tiny drift in sharpe — must not pass.
+        return _make_artifact(
+            metrics={
+                "sharpe": 1.5000001,
+                "win_rate": 0.55,
+                "mean_return": 0.0012,
+            }
+        )
+
+    assert verify_characterization(artifact, _recompute) is False
+
+
+def test_verify_characterization_fails_when_inputs_hash_differs():
+    artifact = _make_artifact()
+
+    def _recompute(**kwargs):
+        return _make_artifact(inputs_hash="0" * 64)
+
+    assert verify_characterization(artifact, _recompute) is False
+
+
+# ----------------------------------------------------------------------
+# Repository (mocked mongo).
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repo_upsert_uses_deterministic_id():
+    mongo = MagicMock()
+    coll = MagicMock()
+    coll.replace_one = AsyncMock()
+    mongo.db = {CHARACTERIZATIONS_COLLECTION: coll}
+    repo = CharacterizationRepository(mysql_adapter=None, mongodb_adapter=mongo)
+
+    artifact = _make_artifact(strategy_id="alpha", strategy_version="v3")
+    assert await repo.upsert(artifact) is True
+
+    coll.replace_one.assert_awaited_once()
+    args, kwargs = coll.replace_one.call_args
+    filt, doc = args[0], args[1]
+    assert filt == {"_id": "alpha::v3"}
+    assert doc["_id"] == "alpha::v3"
+    assert doc["strategy_id"] == "alpha"
+    assert kwargs.get("upsert") is True
+
+
+@pytest.mark.asyncio
+async def test_repo_upsert_raises_on_missing_required_metric():
+    mongo = MagicMock()
+    coll = MagicMock()
+    coll.replace_one = AsyncMock()
+    mongo.db = {CHARACTERIZATIONS_COLLECTION: coll}
+    repo = CharacterizationRepository(mysql_adapter=None, mongodb_adapter=mongo)
+
+    artifact = _make_artifact(metrics={"sharpe": 1.0, "win_rate": 0.5})
+    with pytest.raises(ValueError):
+        await repo.upsert(artifact)
+
+
+@pytest.mark.asyncio
+async def test_repo_upsert_returns_false_when_mongo_missing():
+    repo = CharacterizationRepository(mysql_adapter=None, mongodb_adapter=None)
+    assert await repo.upsert(_make_artifact()) is False
+
+
+@pytest.mark.asyncio
+async def test_repo_get_version_round_trips():
+    mongo = MagicMock()
+    coll = MagicMock()
+    artifact = _make_artifact()
+    stored = artifact.model_dump()
+    stored["_id"] = "s1::v1"
+    coll.find_one = AsyncMock(return_value=stored)
+    mongo.db = {CHARACTERIZATIONS_COLLECTION: coll}
+    repo = CharacterizationRepository(mysql_adapter=None, mongodb_adapter=mongo)
+
+    result = await repo.get_version("s1", "v1")
+    assert result is not None
+    assert result.strategy_id == "s1"
+    assert result.strategy_version == "v1"
+
+
+@pytest.mark.asyncio
+async def test_repo_get_version_returns_none_when_missing():
+    mongo = MagicMock()
+    coll = MagicMock()
+    coll.find_one = AsyncMock(return_value=None)
+    mongo.db = {CHARACTERIZATIONS_COLLECTION: coll}
+    repo = CharacterizationRepository(mysql_adapter=None, mongodb_adapter=mongo)
+    assert await repo.get_version("missing", "v9") is None
+
+
+@pytest.mark.asyncio
+async def test_repo_get_latest_uses_sort_and_limit():
+    mongo = MagicMock()
+    coll = MagicMock()
+    artifact = _make_artifact()
+    stored = artifact.model_dump()
+    stored["_id"] = "s1::v1"
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.to_list = AsyncMock(return_value=[stored])
+    coll.find = MagicMock(return_value=cursor)
+    mongo.db = {CHARACTERIZATIONS_COLLECTION: coll}
+    repo = CharacterizationRepository(mysql_adapter=None, mongodb_adapter=mongo)
+
+    result = await repo.get_latest("s1")
+    assert result is not None
+    cursor.sort.assert_called_once_with("created_at", -1)
+    cursor.limit.assert_called_once_with(1)
+
+
+# ----------------------------------------------------------------------
+# API endpoint (FastAPI TestClient).
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client_with_artifact():
+    """FastAPI TestClient with a stub db_manager wired to deterministic data."""
+    app = create_app()
+    artifact = _make_artifact()
+
+    mongo = MagicMock()
+    coll = MagicMock()
+    stored = artifact.model_dump()
+    stored["_id"] = f"{artifact.strategy_id}::{artifact.strategy_version}"
+
+    # find_one returns the stored doc when (strategy_id, version) matches,
+    # None otherwise.
+    async def _find_one(filt):
+        if (
+            filt.get("strategy_id") == artifact.strategy_id
+            and filt.get("strategy_version") == artifact.strategy_version
+        ):
+            return stored
+        return None
+
+    coll.find_one = AsyncMock(side_effect=_find_one)
+
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.to_list = AsyncMock(return_value=[stored])
+    coll.find = MagicMock(return_value=cursor)
+
+    mongo.db = {CHARACTERIZATIONS_COLLECTION: coll}
+
+    db_manager_stub = MagicMock()
+    db_manager_stub.mongodb_adapter = mongo
+    db_manager_stub.mysql_adapter = None
+
+    api_module.db_manager = db_manager_stub
+    try:
+        yield TestClient(app), artifact
+    finally:
+        api_module.db_manager = None
+
+
+def test_endpoint_returns_artifact_by_version(client_with_artifact):
+    client, artifact = client_with_artifact
+    r = client.get(
+        "/api/v1/characterizations",
+        params={
+            "strategy_id": artifact.strategy_id,
+            "version": artifact.strategy_version,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["strategy_id"] == artifact.strategy_id
+    assert body["strategy_version"] == artifact.strategy_version
+    assert body["metrics"]["sharpe"] == artifact.metrics["sharpe"]
+
+
+def test_endpoint_returns_latest_when_no_version(client_with_artifact):
+    client, artifact = client_with_artifact
+    r = client.get(
+        "/api/v1/characterizations",
+        params={"strategy_id": artifact.strategy_id},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["strategy_id"] == artifact.strategy_id
+
+
+def test_endpoint_404_when_version_missing(client_with_artifact):
+    client, artifact = client_with_artifact
+    r = client.get(
+        "/api/v1/characterizations",
+        params={"strategy_id": artifact.strategy_id, "version": "nope"},
+    )
+    assert r.status_code == 404
+    assert "no characterization" in r.json()["detail"]
+
+
+def test_endpoint_503_when_db_unavailable():
+    app = create_app()
+    api_module.db_manager = None
+    client = TestClient(app)
+    r = client.get("/api/v1/characterizations", params={"strategy_id": "any"})
+    assert r.status_code == 503


### PR DESCRIPTION
## Summary
Implements the **Characterization persistence + query layer (P3.2, FR3 + FR4)** in petrosa-data-manager: a Pydantic model, MongoDB-backed repository, query API endpoint, and reproducibility helpers.

A characterization is a byte-reproducible snapshot of a strategy's expected behavior over a frozen data window: edge metrics (sharpe / win_rate / mean_return + extras), drawdown envelope, parameter sensitivities, and the deterministic inputs that produced them.

## What ships
- `data_manager/models/characterization.py`
  - `Characterization` Pydantic model with required + optional fields.
  - `compute_inputs_hash(...)` — canonical SHA-256 of inputs, stable across dict ordering and naive-vs-aware datetimes.
  - `verify_characterization(artifact, recompute_fn) -> bool` — strict byte-level equality check.
- `data_manager/db/repositories/characterization_repository.py`
  - MongoDB repo. Deterministic `_id = "{strategy_id}::{version}"` so reproducible re-runs replace in place.
  - `upsert`, `get_version`, `get_latest`.
- `data_manager/api/routes/characterizations.py`
  - `GET /api/v1/characterizations?strategy_id=<id>[&version=<v>]`. Latest when version omitted; 404 when missing; 503 when DB unavailable.
- Wired in `data_manager/api/app.py`.

## Out of scope (per enrichment)
- Backtest CLI / k8s job that *writes* characterizations — belongs in a P3.1 consumer slice or a follow-up P3.2-writer ticket.
- Operator dashboard view of characterizations — P5 territory.

## Closes
Closes PetroSa2/petrosa_k8s#599.

## FR coverage
**FR3** (characterization artifact, RED → GREEN), **FR4** (reproducibility, YELLOW → GREEN).

## Test plan
- [x] 19 unit tests in `tests/test_characterization.py` — all pass
- [x] Full unit suite — 615 passed (1 pre-existing setuptools-in-venv failure unrelated)
- [x] Ruff lint + format clean
- [x] FastAPI app boots, router included
- [ ] CI green on this PR