### PR TITLE
feat(timeline): #600 - strategy lifecycle history endpoint (P3.3)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -24,6 +24,7 @@ from data_manager.api.routes import (
     health,
     raw,
     schemas,
+    strategy_timeline,
 )
 
 try:
@@ -122,6 +123,11 @@ def create_app() -> FastAPI:
         characterizations.router,
         prefix="/api/v1",
         tags=["Characterizations"],
+    )
+    app.include_router(
+        strategy_timeline.router,
+        prefix="/api/v1",
+        tags=["Strategy Timeline"],
     )
 
     # New API routes

--- a/data_manager/api/routes/strategy_timeline.py
+++ b/data_manager/api/routes/strategy_timeline.py
@@ -1,0 +1,97 @@
+"""Strategy lifecycle timeline endpoint (P3.3, petrosa_k8s#600)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Path, Query
+
+import data_manager.api.app as api_module
+from data_manager.db.repositories.strategy_timeline_repository import (
+    ALL_TYPES,
+    StrategyTimelineRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _repo() -> StrategyTimelineRepository | None:
+    if not api_module.db_manager:
+        return None
+    if not getattr(api_module.db_manager, "mongodb_adapter", None):
+        return None
+    return StrategyTimelineRepository(
+        mysql_adapter=api_module.db_manager.mysql_adapter,
+        mongodb_adapter=api_module.db_manager.mongodb_adapter,
+    )
+
+
+@router.get("/strategies/{strategy_id}/timeline")
+async def get_strategy_timeline(
+    strategy_id: str = Path(..., description="Strategy identifier"),
+    from_ts: datetime | None = Query(
+        None,
+        alias="from",
+        description="Start of the timeline window (UTC). Inclusive.",
+    ),
+    to_ts: datetime | None = Query(
+        None,
+        alias="to",
+        description="End of the timeline window (UTC). Exclusive.",
+    ),
+    types: str | None = Query(
+        None,
+        description=(
+            "Comma-separated list of event types to include. Defaults to "
+            f"all of: {sorted(ALL_TYPES)}"
+        ),
+    ),
+    limit: int = Query(
+        200,
+        ge=1,
+        le=1000,
+        description="Page size (1..1000, default 200)",
+    ),
+    cursor: str | None = Query(
+        None,
+        description=(
+            "Opaque cursor returned as `next_cursor` from a previous page. "
+            "Pass back verbatim to fetch the next page."
+        ),
+    ),
+) -> dict:
+    """Return a chronologically-merged timeline of events for one strategy.
+
+    Joins five sources (config audit, characterizations, lifecycle events,
+    intents, decisions, executions) into a single ``events`` list ordered
+    by ``(ts, event_id)``. Cursor pagination keeps order stable across
+    sources that share a millisecond.
+
+    Returns 503 when the database is unavailable.
+    """
+    repo = _repo()
+    if repo is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    type_list = [t.strip() for t in types.split(",") if t.strip()] if types else None
+
+    try:
+        return await repo.get_timeline(
+            strategy_id=strategy_id,
+            from_ts=from_ts,
+            to_ts=to_ts,
+            types=type_list,
+            limit=limit,
+            cursor=cursor,
+        )
+    except Exception as exc:
+        logger.error(
+            "timeline: query failed for %s: %s",
+            strategy_id,
+            exc,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="timeline query failed") from exc

--- a/data_manager/db/repositories/strategy_timeline_repository.py
+++ b/data_manager/db/repositories/strategy_timeline_repository.py
@@ -1,0 +1,242 @@
+"""Strategy timeline repository (P3.3, petrosa_k8s#600).
+
+Joins five per-strategy sources into a single chronological event list:
+
+  * ``strategy_config_audit`` — config-change rows persisted by
+    :class:`ConfigurationRepository.upsert_strategy_config`.
+  * ``characterizations`` — backtest characterization artifacts (P3.2,
+    #599). The ``created_at`` field is the timeline timestamp.
+  * ``strategy_lifecycle_events`` — CIO lifecycle events (ADMIT /
+    PROMOTE / DEMOTE / RETIRE). The writer ships with P1.2; this
+    repository reads the collection if it exists and returns empty
+    rows otherwise. No coupling to the writer is required.
+  * ``intents`` — CIO intent events.
+  * ``cio_decisions`` — CIO decision events.
+  * ``execution_events`` — order placements, fills, rejections.
+
+Pagination is cursor-based on the ``(event_ts, event_id)`` pair so the
+order is stable across heterogeneous sources. The cursor is an opaque
+string a caller passes back unmodified; the repository encodes /
+decodes it internally.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from data_manager.db.repositories.base_repository import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+# Public event-type tags — used by the API's `types` filter.
+TYPE_CONFIG = "config"
+TYPE_CHARACTERIZATION = "characterization"
+TYPE_LIFECYCLE = "lifecycle"
+TYPE_INTENT = "intent"
+TYPE_DECISION = "decision"
+TYPE_EXECUTION = "execution"
+
+ALL_TYPES = frozenset(
+    {
+        TYPE_CONFIG,
+        TYPE_CHARACTERIZATION,
+        TYPE_LIFECYCLE,
+        TYPE_INTENT,
+        TYPE_DECISION,
+        TYPE_EXECUTION,
+    }
+)
+
+# Internal map: type → (collection name, timestamp field, id field).
+_SOURCE_MAP: dict[str, tuple[str, str, str]] = {
+    TYPE_CONFIG: ("strategy_config_audit", "changed_at", "_id"),
+    TYPE_CHARACTERIZATION: ("characterizations", "created_at", "_id"),
+    TYPE_LIFECYCLE: ("strategy_lifecycle_events", "timestamp", "_id"),
+    TYPE_INTENT: ("intents", "timestamp", "intent_id"),
+    TYPE_DECISION: ("cio_decisions", "timestamp", "decision_id"),
+    TYPE_EXECUTION: ("execution_events", "timestamp", "order_id"),
+}
+
+
+class StrategyTimelineRepository(BaseRepository):
+    """Reads + merges per-strategy events across audit-trail collections."""
+
+    async def get_timeline(
+        self,
+        *,
+        strategy_id: str,
+        from_ts: datetime | None = None,
+        to_ts: datetime | None = None,
+        types: list[str] | None = None,
+        limit: int = 200,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """Return a chronologically-merged page of events for one strategy.
+
+        ``cursor`` (when present) is the value returned as ``next_cursor``
+        from the previous page; the caller passes it back verbatim.
+        ``limit`` is clamped to 1..1000.
+        """
+        limit = max(1, min(int(limit), 1000))
+        active_types = ALL_TYPES if not types else (set(types) & ALL_TYPES)
+        if not active_types:
+            return {"strategy_id": strategy_id, "events": [], "next_cursor": None}
+
+        cursor_dt, cursor_id = _decode_cursor(cursor)
+        if cursor_dt is not None:
+            # When paginating, the effective lower bound is the cursor's
+            # timestamp (we re-emit events strictly after `(cursor_dt, cursor_id)`).
+            from_ts = cursor_dt if from_ts is None or cursor_dt > from_ts else from_ts
+
+        # Fetch limit+2 per source so final-page detection survives the
+        # cursor's post-filter (which can drop the row that anchored the
+        # cursor when its ts is shared with other events).
+        fetch_n = limit + 2
+        collected: list[dict[str, Any]] = []
+        for type_tag in active_types:
+            rows = await self._fetch(type_tag, strategy_id, from_ts, to_ts, fetch_n)
+            for row in rows:
+                normalized = _normalise(type_tag, row)
+                if normalized is None:
+                    continue
+                collected.append(normalized)
+
+        # Sort by (ts asc, event_id asc) so the cursor walks forward
+        # deterministically even when multiple sources land on the same
+        # millisecond.
+        collected.sort(key=_sort_key)
+
+        # Skip past the cursor row if pagination was active.
+        if cursor_dt is not None and cursor_id is not None:
+            collected = [
+                e
+                for e in collected
+                if (_event_ts(e), e["event_id"]) > (cursor_dt, cursor_id)
+            ]
+
+        page = collected[:limit]
+        next_cursor = None
+        if len(collected) > limit and page:
+            last = page[-1]
+            next_cursor = _encode_cursor(_event_ts(last), last["event_id"])
+
+        return {
+            "strategy_id": strategy_id,
+            "events": page,
+            "next_cursor": next_cursor,
+        }
+
+    async def _fetch(
+        self,
+        type_tag: str,
+        strategy_id: str,
+        from_ts: datetime | None,
+        to_ts: datetime | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        if not self.mongodb or not getattr(self.mongodb, "db", None):
+            return []
+        collection_name, ts_field, _ = _SOURCE_MAP[type_tag]
+        query: dict[str, Any] = {"strategy_id": strategy_id}
+        ts_range: dict[str, Any] = {}
+        if from_ts is not None:
+            ts_range["$gte"] = from_ts
+        if to_ts is not None:
+            ts_range["$lt"] = to_ts
+        if ts_range:
+            query[ts_field] = ts_range
+
+        try:
+            # Both the collection lookup and the read happen inside the
+            # try block — a missing collection (or any adapter error) is
+            # treated as "no rows" rather than failing the whole page.
+            collection = self.mongodb.db[collection_name]
+            cursor = collection.find(query).sort(ts_field, 1).limit(limit)
+            return await cursor.to_list(length=limit)
+        except Exception as exc:
+            logger.debug(
+                "timeline: %s read failed (collection may not exist): %s",
+                collection_name,
+                exc,
+            )
+            return []
+
+
+# ----------------------------------------------------------------------
+# Normalisation + cursor helpers.
+# ----------------------------------------------------------------------
+
+
+def _normalise(type_tag: str, row: dict[str, Any]) -> dict[str, Any] | None:
+    """Project a raw collection row into the canonical timeline event shape."""
+    _, ts_field, id_field = _SOURCE_MAP[type_tag]
+    raw_ts = row.get(ts_field)
+    if raw_ts is None:
+        return None
+    ts = _coerce_ts(raw_ts)
+    if ts is None:
+        return None
+    event_id = row.get(id_field) or row.get("_id")
+    if event_id is None:
+        return None
+    # Pop the internal Mongo _id so the payload is JSON-safe.
+    payload = {k: v for k, v in row.items() if k != "_id"}
+    return {
+        "ts": ts.isoformat(),
+        "type": type_tag,
+        "source": _SOURCE_MAP[type_tag][0],
+        "event_id": str(event_id),
+        "payload": payload,
+    }
+
+
+def _coerce_ts(raw: Any) -> datetime | None:
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=UTC)
+    if isinstance(raw, str):
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+        except ValueError:
+            return None
+    return None
+
+
+def _event_ts(e: dict[str, Any]) -> datetime:
+    return _coerce_ts(e["ts"]) or datetime.fromtimestamp(0, tz=UTC)
+
+
+def _sort_key(e: dict[str, Any]) -> tuple[datetime, str]:
+    return (_event_ts(e), e["event_id"])
+
+
+def _encode_cursor(ts: datetime, event_id: str) -> str:
+    blob = json.dumps({"ts": ts.isoformat(), "event_id": event_id})
+    return base64.urlsafe_b64encode(blob.encode("utf-8")).decode("ascii")
+
+
+def _decode_cursor(cursor: str | None) -> tuple[datetime | None, str | None]:
+    if not cursor:
+        return None, None
+    try:
+        decoded = base64.urlsafe_b64decode(cursor.encode("ascii"))
+        payload = json.loads(decoded)
+        ts = _coerce_ts(payload.get("ts"))
+        event_id = payload.get("event_id")
+        return ts, event_id
+    except (ValueError, json.JSONDecodeError, KeyError):
+        # Malformed cursor: treat as if no cursor was provided. The
+        # caller probably hand-crafted it; we don't crash the page.
+        return None, None

--- a/tests/test_strategy_timeline.py
+++ b/tests/test_strategy_timeline.py
@@ -1,0 +1,414 @@
+"""Tests for the P3.3 strategy lifecycle timeline (#600).
+
+Covers the repository's merge + cursor logic with an in-memory MongoDB
+double and the API endpoint via FastAPI TestClient.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.api.app import create_app
+from data_manager.db.repositories.strategy_timeline_repository import (
+    StrategyTimelineRepository,
+)
+
+T0 = datetime(2026, 5, 21, 12, 0, 0, tzinfo=UTC)
+
+
+class _Collection:
+    """In-memory MongoDB collection double with the methods we touch."""
+
+    def __init__(self, docs: list[dict[str, Any]]) -> None:
+        self._docs = docs
+
+    def find(self, query: dict[str, Any]) -> _Cursor:
+        results = []
+        for doc in self._docs:
+            ok = True
+            for key, val in query.items():
+                if key == "strategy_id":
+                    if doc.get("strategy_id") != val:
+                        ok = False
+                        break
+                else:
+                    # Treat any other key as a ts-range field. Apply $gte / $lt.
+                    field_value = doc.get(key)
+                    if not isinstance(val, dict):
+                        if field_value != val:
+                            ok = False
+                            break
+                        continue
+                    if "$gte" in val and (
+                        field_value is None or field_value < val["$gte"]
+                    ):
+                        ok = False
+                        break
+                    if "$lt" in val and (
+                        field_value is None or field_value >= val["$lt"]
+                    ):
+                        ok = False
+                        break
+            if ok:
+                results.append(dict(doc))
+        return _Cursor(results)
+
+
+class _Cursor:
+    def __init__(self, docs: list[dict[str, Any]]) -> None:
+        self._docs = docs
+        self._sort: tuple[str, int] | None = None
+        self._limit: int | None = None
+
+    def sort(self, field: str, direction: int) -> _Cursor:
+        self._sort = (field, direction)
+        return self
+
+    def limit(self, n: int) -> _Cursor:
+        self._limit = n
+        return self
+
+    async def to_list(self, length: int | None = None) -> list[dict[str, Any]]:
+        docs = list(self._docs)
+        if self._sort is not None:
+            field, direction = self._sort
+            docs.sort(
+                key=lambda d: d.get(field) or datetime.min.replace(tzinfo=UTC),
+                reverse=direction == -1,
+            )
+        if self._limit is not None:
+            docs = docs[: self._limit]
+        if length is not None:
+            docs = docs[:length]
+        return docs
+
+
+class _DbDouble:
+    def __init__(self, collections: dict[str, list[dict[str, Any]]]) -> None:
+        self._collections = {
+            name: _Collection(rows) for name, rows in collections.items()
+        }
+
+    def __getitem__(self, name: str) -> _Collection:
+        # Unknown collections return an empty one rather than raising.
+        return self._collections.get(name, _Collection([]))
+
+
+def _mongo_adapter(
+    collections: dict[str, list[dict[str, Any]]],
+) -> MagicMock:
+    adapter = MagicMock()
+    adapter.db = _DbDouble(collections)
+    return adapter
+
+
+# ----------------------------------------------------------------------
+# Repository tests.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_collections_returns_empty_events():
+    repo = StrategyTimelineRepository(
+        mysql_adapter=None, mongodb_adapter=_mongo_adapter({})
+    )
+    result = await repo.get_timeline(strategy_id="s1")
+    assert result["events"] == []
+    assert result["next_cursor"] is None
+    assert result["strategy_id"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_merges_chronologically_across_sources():
+    collections = {
+        "strategy_config_audit": [
+            {
+                "strategy_id": "s1",
+                "_id": "cfg1",
+                "changed_at": T0 - timedelta(hours=3),
+            },
+        ],
+        "characterizations": [
+            {
+                "strategy_id": "s1",
+                "_id": "c1",
+                "created_at": T0 - timedelta(hours=2),
+            },
+        ],
+        "cio_decisions": [
+            {
+                "strategy_id": "s1",
+                "decision_id": "d1",
+                "timestamp": T0 - timedelta(hours=1),
+            },
+        ],
+    }
+    repo = StrategyTimelineRepository(
+        mysql_adapter=None, mongodb_adapter=_mongo_adapter(collections)
+    )
+    result = await repo.get_timeline(strategy_id="s1")
+    types = [e["type"] for e in result["events"]]
+    assert types == ["config", "characterization", "decision"]
+
+
+@pytest.mark.asyncio
+async def test_filters_by_type_list():
+    collections = {
+        "strategy_config_audit": [
+            {
+                "strategy_id": "s1",
+                "_id": "cfg1",
+                "changed_at": T0 - timedelta(hours=3),
+            },
+        ],
+        "characterizations": [
+            {
+                "strategy_id": "s1",
+                "_id": "c1",
+                "created_at": T0 - timedelta(hours=2),
+            },
+        ],
+        "cio_decisions": [
+            {
+                "strategy_id": "s1",
+                "decision_id": "d1",
+                "timestamp": T0 - timedelta(hours=1),
+            },
+        ],
+    }
+    repo = StrategyTimelineRepository(
+        mysql_adapter=None, mongodb_adapter=_mongo_adapter(collections)
+    )
+    result = await repo.get_timeline(
+        strategy_id="s1", types=["characterization", "decision"]
+    )
+    types = [e["type"] for e in result["events"]]
+    assert types == ["characterization", "decision"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_type_in_filter_is_silently_dropped():
+    repo = StrategyTimelineRepository(
+        mysql_adapter=None,
+        mongodb_adapter=_mongo_adapter(
+            {
+                "characterizations": [
+                    {
+                        "strategy_id": "s1",
+                        "_id": "c1",
+                        "created_at": T0 - timedelta(hours=2),
+                    },
+                ]
+            }
+        ),
+    )
+    result = await repo.get_timeline(
+        strategy_id="s1", types=["characterization", "totally-fake"]
+    )
+    assert [e["type"] for e in result["events"]] == ["characterization"]
+
+
+@pytest.mark.asyncio
+async def test_isolates_to_requested_strategy_id():
+    collections = {
+        "characterizations": [
+            {
+                "strategy_id": "s1",
+                "_id": "c1",
+                "created_at": T0 - timedelta(hours=1),
+            },
+            {
+                "strategy_id": "s2",
+                "_id": "c2",
+                "created_at": T0 - timedelta(hours=1),
+            },
+        ],
+    }
+    repo = StrategyTimelineRepository(
+        mysql_adapter=None, mongodb_adapter=_mongo_adapter(collections)
+    )
+    result = await repo.get_timeline(strategy_id="s1")
+    assert len(result["events"]) == 1
+    assert result["events"][0]["payload"]["strategy_id"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_cursor_pagination_walks_in_order():
+    rows = []
+    for i in range(5):
+        rows.append(
+            {
+                "strategy_id": "s1",
+                "decision_id": f"d{i}",
+                "timestamp": T0 - timedelta(minutes=10 - i),
+            }
+        )
+    repo = StrategyTimelineRepository(
+        mysql_adapter=None,
+        mongodb_adapter=_mongo_adapter({"cio_decisions": rows}),
+    )
+    page1 = await repo.get_timeline(strategy_id="s1", limit=2)
+    assert len(page1["events"]) == 2
+    assert page1["next_cursor"] is not None
+    seen_ids = {e["event_id"] for e in page1["events"]}
+
+    page2 = await repo.get_timeline(
+        strategy_id="s1", limit=2, cursor=page1["next_cursor"]
+    )
+    assert len(page2["events"]) == 2
+    for e in page2["events"]:
+        assert e["event_id"] not in seen_ids
+    seen_ids.update(e["event_id"] for e in page2["events"])
+
+    page3 = await repo.get_timeline(
+        strategy_id="s1", limit=2, cursor=page2["next_cursor"]
+    )
+    # 5 total / 2 per page → last page has 1 event and no next cursor.
+    assert len(page3["events"]) == 1
+    assert page3["next_cursor"] is None
+    seen_ids.add(page3["events"][0]["event_id"])
+    assert seen_ids == {"d0", "d1", "d2", "d3", "d4"}
+
+
+@pytest.mark.asyncio
+async def test_malformed_cursor_falls_back_to_first_page():
+    rows = [
+        {
+            "strategy_id": "s1",
+            "decision_id": "d1",
+            "timestamp": T0 - timedelta(minutes=5),
+        }
+    ]
+    repo = StrategyTimelineRepository(
+        mysql_adapter=None,
+        mongodb_adapter=_mongo_adapter({"cio_decisions": rows}),
+    )
+    result = await repo.get_timeline(strategy_id="s1", cursor="not-a-real-cursor")
+    # Malformed cursor decodes to (None, None) — caller still gets data.
+    assert len(result["events"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_lifecycle_collection_is_silently_empty():
+    """The strategy_lifecycle_events writer ships with P1.2 — until then,
+    a missing collection must not break the timeline."""
+    repo = StrategyTimelineRepository(
+        mysql_adapter=None,
+        mongodb_adapter=_mongo_adapter(
+            {
+                "characterizations": [
+                    {
+                        "strategy_id": "s1",
+                        "_id": "c1",
+                        "created_at": T0 - timedelta(hours=1),
+                    },
+                ]
+            }
+        ),
+    )
+    result = await repo.get_timeline(
+        strategy_id="s1", types=["lifecycle", "characterization"]
+    )
+    assert [e["type"] for e in result["events"]] == ["characterization"]
+
+
+@pytest.mark.asyncio
+async def test_limit_is_clamped_to_max():
+    rows = []
+    for i in range(2000):
+        rows.append(
+            {
+                "strategy_id": "s1",
+                "decision_id": f"d{i:04d}",
+                "timestamp": T0 - timedelta(seconds=2000 - i),
+            }
+        )
+    repo = StrategyTimelineRepository(
+        mysql_adapter=None,
+        mongodb_adapter=_mongo_adapter({"cio_decisions": rows}),
+    )
+    result = await repo.get_timeline(strategy_id="s1", limit=999999)
+    # The Mongo-side `.limit(limit)` cap is 1000, so the page returns at
+    # most 1000 rows from any single source.
+    assert len(result["events"]) <= 1000
+
+
+# ----------------------------------------------------------------------
+# API endpoint.
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client_with_events():
+    app = create_app()
+    db_manager_stub = MagicMock()
+    db_manager_stub.mongodb_adapter = _mongo_adapter(
+        {
+            "characterizations": [
+                {
+                    "strategy_id": "s1",
+                    "_id": "c1",
+                    "created_at": T0 - timedelta(hours=1),
+                }
+            ],
+            "cio_decisions": [
+                {
+                    "strategy_id": "s1",
+                    "decision_id": "d1",
+                    "timestamp": T0 - timedelta(minutes=30),
+                }
+            ],
+        }
+    )
+    db_manager_stub.mysql_adapter = None
+    api_module.db_manager = db_manager_stub
+    try:
+        yield TestClient(app)
+    finally:
+        api_module.db_manager = None
+
+
+def test_endpoint_returns_merged_events(client_with_events):
+    r = client_with_events.get("/api/v1/strategies/s1/timeline")
+    assert r.status_code == 200
+    body = r.json()
+    types = [e["type"] for e in body["events"]]
+    assert types == ["characterization", "decision"]
+    assert body["strategy_id"] == "s1"
+
+
+def test_endpoint_honors_types_query(client_with_events):
+    r = client_with_events.get(
+        "/api/v1/strategies/s1/timeline", params={"types": "decision"}
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert [e["type"] for e in body["events"]] == ["decision"]
+
+
+def test_endpoint_503_when_db_unavailable():
+    app = create_app()
+    api_module.db_manager = None
+    client = TestClient(app)
+    r = client.get("/api/v1/strategies/s1/timeline")
+    assert r.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_event_provider_exception_falls_back_to_empty():
+    """A failing adapter must not 500 the whole timeline page."""
+    bad_adapter = MagicMock()
+    bad_adapter.db = MagicMock()
+    bad_adapter.db.__getitem__ = MagicMock(
+        side_effect=Exception("collection unreachable")
+    )
+    repo = StrategyTimelineRepository(mysql_adapter=None, mongodb_adapter=bad_adapter)
+    result = await repo.get_timeline(strategy_id="s1")
+    # Every per-collection read failed; result is just empty rows.
+    assert result["events"] == []


### PR DESCRIPTION
## Summary
Implements the **Strategy Lifecycle History endpoint (P3.3, FR9)**:
`GET /api/v1/strategies/{strategy_id}/timeline` that joins six
per-strategy sources into a single chronological event list with cursor
pagination.

## Sources joined
1. `strategy_config_audit` — config-change rows
2. `characterizations` — backtest artifacts (P3.2, depends on #599 sibling PR)
3. `strategy_lifecycle_events` — CIO lifecycle events (ADMIT/PROMOTE/DEMOTE/RETIRE). Writer ships with P1.2; this repo reads the collection if present and returns empty otherwise — interface-ready ahead of P1.2.
4. `intents`, 5. `cio_decisions`, 6. `execution_events`

## What ships
- `data_manager/db/repositories/strategy_timeline_repository.py` — joiner with cursor pagination
- `data_manager/api/routes/strategy_timeline.py` — FastAPI route
- Wired in `data_manager/api/app.py`

## Implementation notes
- Cursor: base64-encoded JSON of `(ts, event_id)`. Malformed values fall back to the first page rather than 500ing.
- Per-source reads are fault-tolerant: a missing collection or any adapter error logs at debug and surfaces as zero rows.
- Each source is fetched with `limit + 2` so final-page detection survives the cursor's post-filter.

## Branch base
**Based on `feat/599-characterization-artifacts`** (PR #149) because this PR consumes the characterization collection introduced there. Merge ordering: #149 must merge first; once it does, please retarget this PR to `main`.

## Closes
Closes PetroSa2/petrosa_k8s#600.

## FR coverage
**FR9** — queryable strategy lifecycle history (RED → GREEN, partially gated on P1.2 lifecycle writer).

## Test plan
- [x] 13 unit tests in `tests/test_strategy_timeline.py` — all pass
- [x] Full unit suite — 628 passed (1 pre-existing setuptools-in-venv failure unrelated)
- [x] Ruff lint + format clean
- [ ] CI green on this PR
- [ ] Retarget to `main` after #149 merges