### PR TITLE
feat(data-manager): #605 - audit-trail filters on strategy/action/decision_id (P4.5)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -15,6 +15,7 @@ from data_manager.api.middleware import MetricsMiddleware, RequestLoggerMiddlewa
 from data_manager.api.routes import (
     analysis,
     anomalies,
+    audit,
     backfill,
     catalog,
     characterizations,
@@ -131,6 +132,8 @@ def create_app() -> FastAPI:
         tags=["Strategy Timeline"],
     )
     app.include_router(pnl.router, prefix="/api/v1", tags=["P&L"])
+    # Cross-service decision audit-trail (#605 P4.5).
+    app.include_router(audit.router, prefix="/api/v1", tags=["Audit Trail"])
 
     # New API routes
     app.include_router(generic.router, tags=["Generic CRUD"])

--- a/data_manager/api/routes/audit.py
+++ b/data_manager/api/routes/audit.py
@@ -1,0 +1,111 @@
+"""Audit-trail query endpoints (#605 P4.5).
+
+Exposes the cross-service decision audit-trail with composable filters
+on ``strategy_id``, CIO ``action`` category, ``decision_id``, ``symbol``,
+and time window. The underlying storage is the MongoDB
+``cio_decisions`` collection populated by ``DecisionConsumer``; indexes
+on each filter field exist already so any single filter or combination
+is index-served.
+
+See also: ``data_manager/db/repositories/audit_repository.py:query_decisions``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query
+
+import data_manager.api.app as api_module
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/audit/decisions")
+async def list_decision_audit_trail(
+    strategy_id: str | None = Query(None, description="Filter by strategy_id"),
+    action: str | None = Query(
+        None,
+        description=(
+            "Filter by CIO action verb (e.g. execute, admit, veto, "
+            "down_weight, fail_safe, skip). Lower-cased per the "
+            "petrosa-cio producer convention."
+        ),
+    ),
+    decision_id: str | None = Query(
+        None,
+        description=(
+            "Filter by a specific CIO decision_id. Cross-service "
+            "join key — matches execution_events.decision_id and "
+            "pnl_events.decision_id."
+        ),
+    ),
+    symbol: str | None = Query(None, description="Filter by trading pair symbol"),
+    from_time: datetime | None = Query(
+        None,
+        alias="from",
+        description="Inclusive start of the timestamp window (ISO 8601)",
+    ),
+    to_time: datetime | None = Query(
+        None,
+        alias="to",
+        description="Exclusive end of the timestamp window (ISO 8601)",
+    ),
+    limit: int = Query(
+        100,
+        ge=1,
+        le=1000,
+        description="Maximum number of decisions returned (default 100, max 1000)",
+    ),
+) -> dict:
+    """List CIO decision audit-trail rows filtered by any combination of
+    ``strategy_id`` / ``action`` / ``decision_id`` / ``symbol`` and an
+    optional time window. Results are newest-first.
+    """
+    if not api_module.db_manager or not api_module.db_manager.mongodb_adapter:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    try:
+        from data_manager.db.repositories import AuditRepository
+
+        audit_repo = AuditRepository(
+            api_module.db_manager.mysql_adapter,
+            api_module.db_manager.mongodb_adapter,
+        )
+
+        decisions = await audit_repo.query_decisions(
+            strategy_id=strategy_id,
+            action=action,
+            decision_id=decision_id,
+            symbol=symbol,
+            start=from_time,
+            end=to_time,
+            limit=limit,
+        )
+
+        return {
+            "count": len(decisions),
+            "filters": {
+                "strategy_id": strategy_id,
+                "action": action,
+                "decision_id": decision_id,
+                "symbol": symbol,
+                "from": from_time.isoformat() if from_time else None,
+                "to": to_time.isoformat() if to_time else None,
+            },
+            "limit": limit,
+            "decisions": decisions,
+        }
+
+    except Exception as e:
+        logger.error(
+            "audit_decisions_endpoint_failed",
+            extra={"error": str(e)},
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500, detail="Failed to query decision audit-trail"
+        ) from e

--- a/data_manager/db/mongodb_adapter.py
+++ b/data_manager/db/mongodb_adapter.py
@@ -206,6 +206,72 @@ class MongoDBAdapter(BaseAdapter):
         except PyMongoError as e:
             raise DatabaseError(f"Failed to query latest from {collection}: {e}") from e
 
+    async def find_filtered(
+        self,
+        collection: str,
+        *,
+        filters: dict[str, Any] | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        limit: int = 100,
+        sort_field: str = "timestamp",
+        sort_order: int = -1,
+    ) -> list[dict[str, Any]]:
+        """Query a collection with a composable equality + time-window filter.
+
+        The cross-service audit-trail surface (#605 P4.5) needs to filter
+        ``cio_decisions`` by arbitrary indexed fields (``strategy_id``,
+        ``action``, ``decision_id``) without bolting more named parameters
+        onto :meth:`query_latest`. ``filters`` accepts ``{column: value}``
+        pairs and is composed with the optional ``[start, end)``
+        time-window via Mongo's ``$gte`` / ``$lt`` operators.
+
+        Args:
+            collection: target collection name.
+            filters: equality filters as ``{field: value}``; ``None``
+                values are skipped so callers can pass through optional
+                request params without branching.
+            start: inclusive lower bound on ``sort_field`` (typically
+                ``timestamp``).
+            end: exclusive upper bound on ``sort_field``.
+            limit: hard cap on returned documents (caller enforces sanity).
+            sort_field: field to sort + window on (defaults to ``timestamp``).
+            sort_order: 1 (ASC) or -1 (DESC, default — newest first).
+        """
+        if not self._connected:
+            raise DatabaseError("Not connected to database")
+
+        try:
+            coll = self.db[collection]
+
+            query: dict[str, Any] = {}
+            if filters:
+                for field, value in filters.items():
+                    if value is None:
+                        continue
+                    query[field] = value
+            if start is not None or end is not None:
+                window: dict[str, Any] = {}
+                if start is not None:
+                    window["$gte"] = start
+                if end is not None:
+                    window["$lt"] = end
+                if window:
+                    query[sort_field] = window
+
+            cursor = coll.find(query).sort(sort_field, sort_order).limit(limit)
+            documents = await cursor.to_list(length=limit)
+
+            for doc in documents:
+                doc.pop("_id", None)
+
+            return documents
+
+        except PyMongoError as e:
+            raise DatabaseError(
+                f"Failed to query {collection} with filters: {e}"
+            ) from e
+
     async def get_record_count(
         self,
         collection: str,

--- a/data_manager/db/repositories/audit_repository.py
+++ b/data_manager/db/repositories/audit_repository.py
@@ -121,3 +121,74 @@ class AuditRepository(BaseRepository):
         except Exception as e:
             logger.error(f"Failed to get recent logs: {e}")
             return []
+
+    async def query_decisions(
+        self,
+        *,
+        strategy_id: str | None = None,
+        action: str | None = None,
+        decision_id: str | None = None,
+        symbol: str | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """Cross-service audit-trail query against the ``cio_decisions`` collection.
+
+        Per ticket #605 P4.5, callers (operators, dashboard, lifecycle
+        reader) need to slice the CIO decision audit-trail by
+        ``strategy_id``, CIO action category (ADMIT / EXECUTE / VETO /
+        …), and/or ``decision_id`` for cross-service joins back to
+        execution events and P&L. Time-window is composable on top.
+
+        The decisions live in MongoDB ``cio_decisions`` (persisted by
+        ``DecisionConsumer``) — indexes on every filter field already
+        exist (see ``MongoDBAdapter.ensure_indexes`` for the
+        ``cio_decisions`` block), so the query is index-served regardless
+        of which filter combination the caller picks.
+
+        Args:
+            strategy_id: filter by the strategy that produced the decision
+            action: filter by CIO action verb (matches stored payload — the
+                caller is responsible for casing; this matches the
+                producer convention in petrosa-cio where the wire-level
+                value is the lower-cased ``ActionType`` value)
+            decision_id: exact match — uniquely identifies one decision
+            symbol: filter by trading pair symbol
+            start: inclusive lower-bound on ``timestamp``
+            end: exclusive upper-bound on ``timestamp``
+            limit: hard cap on returned records (caller-side clamped)
+
+        Returns:
+            list of decision-event dicts, newest first, with the Mongo
+            ``_id`` stripped. Empty list on adapter failure (caller logs
+            already) so the HTTP layer can serve 200 with `[]` rather
+            than crashing on Mongo hiccups.
+        """
+        if self.mongodb is None:
+            logger.warning(
+                "audit_query_decisions_no_mongo",
+                extra={"strategy_id": strategy_id, "action": action},
+            )
+            return []
+        try:
+            return await self.mongodb.find_filtered(
+                "cio_decisions",
+                filters={
+                    "strategy_id": strategy_id,
+                    "action": action,
+                    "decision_id": decision_id,
+                    "symbol": symbol,
+                },
+                start=start,
+                end=end,
+                limit=limit,
+                sort_field="timestamp",
+                sort_order=-1,
+            )
+        except Exception as e:
+            logger.error(
+                "audit_query_decisions_failed",
+                extra={"error": str(e)},
+            )
+            return []

--- a/tests/test_audit_decision_filters.py
+++ b/tests/test_audit_decision_filters.py
@@ -1,0 +1,320 @@
+"""Tests for the #605 P4.5 audit-trail decision-filter surface.
+
+Covers:
+  * ``AuditRepository.query_decisions`` composes its filter arg correctly,
+    drops None values, threads time-window into ``find_filtered``, and
+    survives adapter failure with an empty list.
+  * ``MongoDBAdapter.find_filtered`` builds the right Mongo query for
+    each filter-combination + time-window shape and strips ``_id``.
+  * The ``GET /api/v1/audit/decisions`` route returns the AuditRepository
+    output, surfaces 503 when the adapter is missing, and respects the
+    filter query-params.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from data_manager.db.repositories.audit_repository import AuditRepository
+
+# ---------------------------------------------------------------------------
+# AuditRepository.query_decisions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_decisions_threads_all_filters_through():
+    """All optional filters propagate into find_filtered exactly once."""
+    mongo = AsyncMock()
+    mongo.find_filtered = AsyncMock(
+        return_value=[{"decision_id": "d-1", "strategy_id": "ta", "action": "execute"}]
+    )
+    repo = AuditRepository(mysql_adapter=None, mongodb_adapter=mongo)
+    start = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+    end = datetime(2026, 5, 21, 13, 0, tzinfo=UTC)
+
+    out = await repo.query_decisions(
+        strategy_id="ta-momentum",
+        action="execute",
+        decision_id="d-42",
+        symbol="BTCUSDT",
+        start=start,
+        end=end,
+        limit=25,
+    )
+
+    assert out[0]["decision_id"] == "d-1"
+    mongo.find_filtered.assert_awaited_once()
+    kwargs = mongo.find_filtered.call_args.kwargs
+    assert kwargs["filters"] == {
+        "strategy_id": "ta-momentum",
+        "action": "execute",
+        "decision_id": "d-42",
+        "symbol": "BTCUSDT",
+    }
+    assert kwargs["start"] == start
+    assert kwargs["end"] == end
+    assert kwargs["limit"] == 25
+    assert kwargs["sort_field"] == "timestamp"
+    assert kwargs["sort_order"] == -1
+
+
+@pytest.mark.asyncio
+async def test_query_decisions_with_only_strategy_id_filter():
+    """The minimum-filter case still threads correctly and doesn't
+    invent ``action`` / ``decision_id`` filters when callers omit them.
+    The adapter is responsible for skipping None values; the repo just
+    forwards them."""
+    mongo = AsyncMock()
+    mongo.find_filtered = AsyncMock(return_value=[])
+    repo = AuditRepository(mysql_adapter=None, mongodb_adapter=mongo)
+
+    await repo.query_decisions(strategy_id="ta-momentum")
+
+    kwargs = mongo.find_filtered.call_args.kwargs
+    assert kwargs["filters"]["strategy_id"] == "ta-momentum"
+    assert kwargs["filters"]["action"] is None
+    assert kwargs["filters"]["decision_id"] is None
+    assert kwargs["start"] is None
+    assert kwargs["end"] is None
+
+
+@pytest.mark.asyncio
+async def test_query_decisions_returns_empty_when_no_mongo_adapter():
+    """Repo must not crash when constructed without a MongoDB adapter —
+    that scenario shows up in tests and in degraded deployments where
+    Mongo is unreachable but MySQL still serves anomaly / gap audits."""
+    repo = AuditRepository(mysql_adapter=Mock(), mongodb_adapter=None)
+    assert await repo.query_decisions(strategy_id="ta") == []
+
+
+@pytest.mark.asyncio
+async def test_query_decisions_swallows_adapter_errors():
+    """A Mongo error must surface as an empty list so the HTTP layer
+    can serve 200 with an empty body — caller logs already capture the
+    underlying failure."""
+    mongo = AsyncMock()
+    mongo.find_filtered = AsyncMock(side_effect=RuntimeError("mongo down"))
+    repo = AuditRepository(mysql_adapter=None, mongodb_adapter=mongo)
+    assert await repo.query_decisions(strategy_id="ta") == []
+
+
+# ---------------------------------------------------------------------------
+# MongoDBAdapter.find_filtered
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    """Minimal stand-in for the Motor cursor chain used by find_filtered."""
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    def sort(self, *_args, **_kwargs):
+        return self
+
+    def limit(self, *_args, **_kwargs):
+        return self
+
+    async def to_list(self, length=None):
+        return self._docs
+
+
+def _adapter_with_collection(docs):
+    """Build a connected MongoDBAdapter with a stubbed collection whose
+    ``find()`` returns a fake cursor."""
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+    adapter = MongoDBAdapter.__new__(MongoDBAdapter)
+    adapter._connected = True
+    coll = MagicMock()
+    coll.find = MagicMock(return_value=_FakeCursor(docs))
+    db = MagicMock()
+    db.__getitem__ = MagicMock(return_value=coll)
+    adapter.db = db
+    return adapter, coll
+
+
+@pytest.mark.asyncio
+async def test_find_filtered_skips_none_filter_values():
+    """``None`` filters must not bleed into the Mongo query as literal
+    ``None`` comparisons (would never match)."""
+    adapter, coll = _adapter_with_collection([])
+    await adapter.find_filtered(
+        "cio_decisions",
+        filters={"strategy_id": "ta", "action": None, "decision_id": "d-1"},
+        limit=10,
+    )
+    coll.find.assert_called_once()
+    query = coll.find.call_args.args[0]
+    assert query == {"strategy_id": "ta", "decision_id": "d-1"}
+
+
+@pytest.mark.asyncio
+async def test_find_filtered_composes_time_window_with_filters():
+    adapter, coll = _adapter_with_collection([])
+    start = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+    end = datetime(2026, 5, 21, 13, 0, tzinfo=UTC)
+    await adapter.find_filtered(
+        "cio_decisions",
+        filters={"strategy_id": "ta"},
+        start=start,
+        end=end,
+        limit=10,
+    )
+    query = coll.find.call_args.args[0]
+    assert query["strategy_id"] == "ta"
+    assert query["timestamp"] == {"$gte": start, "$lt": end}
+
+
+@pytest.mark.asyncio
+async def test_find_filtered_strips_mongo_id_from_results():
+    adapter, _ = _adapter_with_collection(
+        [{"_id": "abc", "decision_id": "d-1"}, {"_id": "def", "decision_id": "d-2"}]
+    )
+    out = await adapter.find_filtered("cio_decisions", filters={}, limit=10)
+    assert all("_id" not in doc for doc in out)
+    assert [d["decision_id"] for d in out] == ["d-1", "d-2"]
+
+
+@pytest.mark.asyncio
+async def test_find_filtered_raises_when_not_connected():
+    from data_manager.db.base_adapter import DatabaseError
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+    adapter = MongoDBAdapter.__new__(MongoDBAdapter)
+    adapter._connected = False
+    with pytest.raises(DatabaseError):
+        await adapter.find_filtered("cio_decisions", filters={}, limit=10)
+
+
+# ---------------------------------------------------------------------------
+# HTTP route — GET /api/v1/audit/decisions
+# ---------------------------------------------------------------------------
+
+
+def _client_with_db(db_manager):
+    """Build a TestClient with the global api_module.db_manager patched."""
+    from fastapi.testclient import TestClient
+
+    import data_manager.api.app as api_module
+    from data_manager.api.app import create_app
+
+    api_module.db_manager = db_manager
+    return TestClient(create_app())
+
+
+def test_route_returns_503_when_db_manager_missing():
+    client = _client_with_db(None)
+    r = client.get("/api/v1/audit/decisions")
+    assert r.status_code == 503
+
+
+def test_route_returns_503_when_mongo_missing():
+    db = MagicMock()
+    db.mongodb_adapter = None
+    client = _client_with_db(db)
+    r = client.get("/api/v1/audit/decisions")
+    assert r.status_code == 503
+
+
+def test_route_returns_decisions_with_filters_threaded_through():
+    db = MagicMock()
+    db.mysql_adapter = MagicMock()
+    db.mongodb_adapter = MagicMock()
+
+    with patch(
+        "data_manager.db.repositories.audit_repository.AuditRepository.query_decisions",
+        new=AsyncMock(
+            return_value=[
+                {
+                    "decision_id": "d-1",
+                    "strategy_id": "ta-momentum",
+                    "action": "execute",
+                    "timestamp": "2026-05-21T12:00:00+00:00",
+                }
+            ]
+        ),
+    ) as mock_query:
+        client = _client_with_db(db)
+        r = client.get(
+            "/api/v1/audit/decisions",
+            params={
+                "strategy_id": "ta-momentum",
+                "action": "execute",
+                "limit": 50,
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 1
+    assert body["filters"]["strategy_id"] == "ta-momentum"
+    assert body["filters"]["action"] == "execute"
+    assert body["limit"] == 50
+    assert body["decisions"][0]["decision_id"] == "d-1"
+    mock_query.assert_awaited_once()
+    call_kwargs = mock_query.await_args.kwargs
+    assert call_kwargs["strategy_id"] == "ta-momentum"
+    assert call_kwargs["action"] == "execute"
+    assert call_kwargs["limit"] == 50
+
+
+def test_route_clamps_limit_to_allowed_range():
+    db = MagicMock()
+    db.mysql_adapter = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    client = _client_with_db(db)
+
+    # 0 is below the minimum (ge=1) → 422.
+    r = client.get("/api/v1/audit/decisions", params={"limit": 0})
+    assert r.status_code == 422
+
+    # 10000 is above the cap (le=1000) → 422.
+    r = client.get("/api/v1/audit/decisions", params={"limit": 10000})
+    assert r.status_code == 422
+
+
+def test_route_returns_500_when_query_raises():
+    db = MagicMock()
+    db.mysql_adapter = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    with patch(
+        "data_manager.db.repositories.audit_repository.AuditRepository.query_decisions",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        client = _client_with_db(db)
+        r = client.get("/api/v1/audit/decisions")
+    assert r.status_code == 500
+
+
+def test_route_accepts_time_window_via_from_to_aliases():
+    db = MagicMock()
+    db.mysql_adapter = MagicMock()
+    db.mongodb_adapter = MagicMock()
+
+    with patch(
+        "data_manager.db.repositories.audit_repository.AuditRepository.query_decisions",
+        new=AsyncMock(return_value=[]),
+    ) as mock_query:
+        client = _client_with_db(db)
+        r = client.get(
+            "/api/v1/audit/decisions",
+            params={
+                "from": "2026-05-21T12:00:00+00:00",
+                "to": "2026-05-21T13:00:00+00:00",
+            },
+        )
+    assert r.status_code == 200
+    kwargs = mock_query.await_args.kwargs
+    assert kwargs["start"] == datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+    assert kwargs["end"] == datetime(2026, 5, 21, 13, 0, tzinfo=UTC)


### PR DESCRIPTION
## Summary
- Extends the audit-query surface with composable filters on `strategy_id`, CIO `action` category, `decision_id`, `symbol`, and time window. Closes the FR28 audit-query gap.
- Reads the existing `cio_decisions` MongoDB collection (populated by `DecisionConsumer`) — indexes on every filter field already exist (`decision_id` unique, `strategy_id`, `timestamp`, `action`). No MySQL schema migration needed.

## Issue
Closes PetroSa2/petrosa_k8s#605 (P4.5).
FR28 — YELLOW → GREEN.

## Surface
- `MongoDBAdapter.find_filtered(collection, *, filters, start, end, limit, sort_field, sort_order)` — generic composable filter + time-window query; skips `None` filter values; strips Mongo `_id`.
- `AuditRepository.query_decisions(*, strategy_id, action, decision_id, symbol, start, end, limit)` — exposes the specific filter set the ticket calls for. Swallows adapter failures into `[]` so the HTTP layer can serve a stable 200 / empty body under Mongo hiccups.
- `GET /api/v1/audit/decisions` — FastAPI route with the filters as query params (`from` / `to` aliases for the time window per the existing anomalies route convention). Returns `{count, filters, limit, decisions}`.

## Design note: why MongoDB instead of MySQL audit_logs
The original Reality-Check note pointed at `audit_repository.py:105-123` (MySQL `get_recent_logs`), but the MySQL `audit_logs` schema has no `strategy_id` / `action` / `decision_id` columns — they would require a migration. Meanwhile `cio_decisions` already carries all three with appropriate indexes. Routing the query there is smaller blast-radius and gives Phase 2 (P4.3 lifecycle join, P4.4 \"why did portfolio do X at time T\") the same substrate to build on without backfilling.

## Test plan
- [x] `query_decisions` threads all filters through `find_filtered` correctly
- [x] Minimum-filter (single field) case works
- [x] No MongoDB adapter → empty list (degraded deployment guard)
- [x] Adapter error → empty list (Mongo hiccup guard)
- [x] `find_filtered` skips `None` filter values, composes time window, strips `_id`
- [x] `find_filtered` raises `DatabaseError` when not connected
- [x] HTTP route: 503 when db_manager missing, 503 when mongo missing
- [x] HTTP route: filters threaded through to repo, response shape verified
- [x] HTTP route: limit clamping (422 below 1 / above 1000)
- [x] HTTP route: 500 when query raises
- [x] HTTP route: `from` / `to` query-param aliases parsed into UTC datetimes

Pipeline: `make lint` clean, new tests + audit-repo extras 53/53 passing, full suite 712/713 with the lone failure being a pre-existing `test_setup.py` setuptools-missing error unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)