### PR TITLE
feat(data-manager): #602 - portfolio drawdown vs characterized envelope (P4.2)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -21,6 +21,7 @@ from data_manager.api.routes import (
     characterizations,
     config,
     data,
+    drawdown,
     generic,
     health,
     lifecycle,
@@ -137,6 +138,8 @@ def create_app() -> FastAPI:
     app.include_router(audit.router, prefix="/api/v1", tags=["Audit Trail"])
     # Lifecycle reconstruction join (#603 P4.3).
     app.include_router(lifecycle.router, prefix="/api/v1", tags=["Lifecycle"])
+    # Portfolio drawdown vs characterization envelope (#602 P4.2).
+    app.include_router(drawdown.router, prefix="/api/v1", tags=["Portfolio"])
 
     # New API routes
     app.include_router(generic.router, tags=["Generic CRUD"])

--- a/data_manager/api/routes/drawdown.py
+++ b/data_manager/api/routes/drawdown.py
@@ -1,0 +1,72 @@
+"""Portfolio drawdown query endpoint (P4.2, #602).
+
+Exposes :class:`DrawdownService.compute` over HTTP so operators can poll
+the current drawdown / envelope state on demand, alongside the
+periodic NATS breach surface. The endpoint deliberately mirrors the
+shape of ``DrawdownResult.to_dict()`` — dashboards consume the same
+payload from both the HTTP route and the
+``portfolio.drawdown.breach.>`` NATS subject.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query
+
+import data_manager.api.app as api_module
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/portfolio/drawdown")
+async def get_strategy_drawdown(
+    strategy_id: str = Query(..., description="Strategy identifier to evaluate"),
+    from_time: datetime | None = Query(
+        None,
+        alias="from",
+        description=(
+            "Inclusive lower bound of the PnL evaluation window (ISO 8601). "
+            "Omit to use the full available history."
+        ),
+    ),
+    to_time: datetime | None = Query(
+        None,
+        alias="to",
+        description="Exclusive upper bound of the PnL evaluation window (ISO 8601)",
+    ),
+) -> dict:
+    """Compute current drawdown for ``strategy_id`` vs its characterization envelope."""
+    if not api_module.db_manager or not api_module.db_manager.mongodb_adapter:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    try:
+        from data_manager.db.repositories.characterization_repository import (
+            CharacterizationRepository,
+        )
+        from data_manager.portfolio.drawdown_service import DrawdownService
+
+        char_repo = CharacterizationRepository(
+            api_module.db_manager.mysql_adapter,
+            api_module.db_manager.mongodb_adapter,
+        )
+        service = DrawdownService(
+            mongodb_adapter=api_module.db_manager.mongodb_adapter,
+            characterization_repository=char_repo,
+        )
+        result = await service.compute(
+            strategy_id=strategy_id,
+            start=from_time,
+            end=to_time,
+        )
+        return result.to_dict()
+    except Exception as e:
+        logger.error(
+            "drawdown_endpoint_failed",
+            extra={"strategy_id": strategy_id, "error": str(e)},
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Failed to compute drawdown") from e

--- a/data_manager/portfolio/__init__.py
+++ b/data_manager/portfolio/__init__.py
@@ -1,0 +1,8 @@
+"""Portfolio-level analytics: drawdown vs characterization envelope (P4.2, #602)."""
+
+from data_manager.portfolio.drawdown_service import (
+    DrawdownResult,
+    DrawdownService,
+)
+
+__all__ = ["DrawdownResult", "DrawdownService"]

--- a/data_manager/portfolio/drawdown_publisher.py
+++ b/data_manager/portfolio/drawdown_publisher.py
@@ -1,0 +1,67 @@
+"""NATS breach publisher for portfolio drawdown (P4.2, #602).
+
+Publishes envelope-breach events on
+``portfolio.drawdown.breach.{strategy_id}`` so CIO can subscribe and
+intervene per FR30. The payload is the verbatim ``DrawdownResult``
+``to_dict()`` so consumers can read the same shape the HTTP endpoint
+returns.
+
+The publisher is intentionally narrow: ``maybe_publish`` only fires
+when ``result.breached`` is True. Healthy ticks are NOT published —
+that would flood NATS at the scheduler's cadence × number of
+strategies and provide no signal beyond "still healthy".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from data_manager.consumer.nats_client import NATSClient
+    from data_manager.portfolio.drawdown_service import DrawdownResult
+
+logger = logging.getLogger(__name__)
+
+
+BREACH_SUBJECT_PREFIX = "portfolio.drawdown.breach"
+
+
+class DrawdownBreachPublisher:
+    """Publishes envelope-breach events on ``portfolio.drawdown.breach.>``."""
+
+    def __init__(self, nats_client: NATSClient) -> None:
+        self._nc = nats_client
+
+    async def maybe_publish(self, result: DrawdownResult) -> bool:
+        """Publish a breach event iff ``result.breached`` is True.
+
+        Returns True iff a publish was attempted (the underlying client
+        may still drop on disconnect; that's logged but not raised so
+        the scheduler loop survives transient NATS issues).
+        """
+        if not result.breached:
+            return False
+        subject = f"{BREACH_SUBJECT_PREFIX}.{result.strategy_id}"
+        payload = result.to_dict()
+        try:
+            data = json.dumps(payload).encode()
+            await self._nc.publish(subject, data)
+            logger.info(
+                "drawdown_breach_published",
+                extra={
+                    "subject": subject,
+                    "strategy_id": result.strategy_id,
+                    "drawdown_pct": result.current_drawdown_pct,
+                    "threshold_pct": result.envelope_threshold_pct,
+                    "percentile": result.breach_percentile,
+                },
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 — never crash the scheduler
+            logger.error(
+                "drawdown_breach_publish_failed",
+                extra={"subject": subject, "error": str(exc)},
+            )
+            return False

--- a/data_manager/portfolio/drawdown_scheduler.py
+++ b/data_manager/portfolio/drawdown_scheduler.py
@@ -1,0 +1,115 @@
+"""Periodic drawdown-vs-envelope check (P4.2, #602).
+
+Iterates known strategies on each tick, runs ``DrawdownService.compute``
+for each, and emits a breach event via ``DrawdownBreachPublisher`` when
+the envelope is exceeded.
+
+Strategy discovery: by default the scheduler asks the MongoDB adapter
+for ``list_all_strategy_ids`` (already exists at
+``mongodb_adapter.py:638``). Callers can inject a static list for
+testing or when the scheduler should be scoped to a subset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from data_manager.consumer.nats_client import NATSClient
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+    from data_manager.db.repositories.characterization_repository import (
+        CharacterizationRepository,
+    )
+
+from data_manager.portfolio.drawdown_publisher import DrawdownBreachPublisher
+from data_manager.portfolio.drawdown_service import DrawdownResult, DrawdownService
+
+logger = logging.getLogger(__name__)
+
+
+class DrawdownScheduler:
+    """Periodic loop that checks every strategy and publishes breaches."""
+
+    def __init__(
+        self,
+        *,
+        mongodb_adapter: MongoDBAdapter,
+        characterization_repository: CharacterizationRepository,
+        nats_client: NATSClient,
+        interval_seconds: int = 300,
+        strategy_ids: list[str] | None = None,
+    ) -> None:
+        self._mongo = mongodb_adapter
+        self._char_repo = characterization_repository
+        self._service = DrawdownService(
+            mongodb_adapter=mongodb_adapter,
+            characterization_repository=characterization_repository,
+        )
+        self._publisher = DrawdownBreachPublisher(nats_client=nats_client)
+        self._interval = max(1, interval_seconds)
+        self._static_strategy_ids = strategy_ids
+        self._task: asyncio.Task | None = None
+        self._running = False
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info(
+            "drawdown_scheduler_started",
+            extra={"interval_seconds": self._interval},
+        )
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._task = None
+
+    async def _loop(self) -> None:
+        while self._running:
+            try:
+                await self.run_cycle()
+            except Exception as exc:  # noqa: BLE001 — never crash the loop
+                logger.error(
+                    "drawdown_scheduler_cycle_failed", extra={"error": str(exc)}
+                )
+            await asyncio.sleep(self._interval)
+
+    async def run_cycle(self) -> list[DrawdownResult]:
+        """One scan of all strategies. Returns the results for testability."""
+        strategy_ids = await self._discover_strategies()
+        results: list[DrawdownResult] = []
+        for sid in strategy_ids:
+            try:
+                result = await self._service.compute(sid)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "drawdown_cycle_strategy_failed",
+                    extra={"strategy_id": sid, "error": str(exc)},
+                )
+                continue
+            results.append(result)
+            if result.breached:
+                await self._publisher.maybe_publish(result)
+        return results
+
+    async def _discover_strategies(self) -> list[str]:
+        if self._static_strategy_ids is not None:
+            return list(self._static_strategy_ids)
+        # `list_all_strategy_ids` is async on the MongoDB adapter.
+        try:
+            return await self._mongo.list_all_strategy_ids()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "drawdown_scheduler_discovery_failed",
+                extra={"error": str(exc)},
+            )
+            return []

--- a/data_manager/portfolio/drawdown_service.py
+++ b/data_manager/portfolio/drawdown_service.py
@@ -1,0 +1,300 @@
+"""Portfolio drawdown vs characterization envelope (P4.2, #602).
+
+Computes peak-to-current equity drawdown for a strategy from the
+``pnl_events`` stream that P4.1 (#601) persists, then compares the
+current drawdown to the percentile distribution captured in the
+strategy's most recent characterization (``drawdown_envelope``,
+populated by P3.2).
+
+Breach semantics (from FR30):
+  * "envelope breach" = current drawdown exceeds the configured
+    envelope percentile (default ``p99`` — the second-to-last entry of
+    a 4-percentile envelope ``[p50, p90, p99, p100]``).
+  * The breach payload carries enough context for CIO to act: the
+    strategy, the current drawdown %, the breached threshold %, the
+    percentile label, and equity snapshots.
+
+The service is a pure compute layer — wiring the periodic check + NATS
+publish lives in ``DrawdownScheduler``. The HTTP endpoint
+(``/api/v1/portfolio/drawdown``) calls compute directly so operators
+can poll on-demand without waiting for the next scheduler tick.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from data_manager.db.repositories.characterization_repository import (
+    CharacterizationRepository,
+)
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+if TYPE_CHECKING:
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+logger = logging.getLogger(__name__)
+
+
+PNL_EVENTS_COLLECTION = "pnl_events"
+
+# Default percentile to use as the breach threshold. The characterization
+# envelope is stored as ``[p50, p90, p99, p100]`` per the P3.2 schema —
+# index 2 = p99 (single-worst-case threshold). Operators can override
+# via env / scheduler config.
+DEFAULT_BREACH_PERCENTILE_INDEX = 2
+DEFAULT_BREACH_PERCENTILE_LABEL = "p99"
+
+
+@dataclass(slots=True)
+class DrawdownResult:
+    """Outcome of one drawdown evaluation cycle.
+
+    All percentages are positive numbers in [0, 100] (drawdowns are
+    expressed as "% loss from peak", not signed P&L). Equity values are
+    in USD per the PnlEvent schema.
+    """
+
+    strategy_id: str
+    current_drawdown_pct: float
+    envelope_threshold_pct: float | None
+    breach_percentile: str | None
+    breached: bool
+    peak_equity_usd: float
+    current_equity_usd: float
+    events_evaluated: int
+    timestamp: datetime
+    reason: str
+    # The full envelope is included for transparency — the dashboard
+    # surfaces the whole percentile band, not just the threshold the
+    # service compared against.
+    envelope: list[float] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "strategy_id": self.strategy_id,
+            "current_drawdown_pct": self.current_drawdown_pct,
+            "envelope_threshold_pct": self.envelope_threshold_pct,
+            "breach_percentile": self.breach_percentile,
+            "breached": self.breached,
+            "peak_equity_usd": self.peak_equity_usd,
+            "current_equity_usd": self.current_equity_usd,
+            "events_evaluated": self.events_evaluated,
+            "timestamp": self.timestamp.isoformat(),
+            "reason": self.reason,
+            "envelope": self.envelope,
+        }
+
+
+class DrawdownService:
+    """Compute strategy-scoped drawdown and compare to the envelope.
+
+    The service is stateless — every call queries fresh PnL events
+    from MongoDB. Callers that need cached results should layer that
+    on top.
+    """
+
+    def __init__(
+        self,
+        mongodb_adapter: MongoDBAdapter,
+        characterization_repository: CharacterizationRepository | None = None,
+        *,
+        breach_percentile_index: int = DEFAULT_BREACH_PERCENTILE_INDEX,
+        breach_percentile_label: str = DEFAULT_BREACH_PERCENTILE_LABEL,
+    ) -> None:
+        self._mongo = mongodb_adapter
+        self._char_repo = characterization_repository
+        self._breach_index = breach_percentile_index
+        self._breach_label = breach_percentile_label
+
+    async def compute(
+        self,
+        strategy_id: str,
+        *,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> DrawdownResult:
+        """Compute peak-to-current drawdown for one strategy.
+
+        The equity series is reconstructed event-by-event:
+
+        * ``pnl_kind == "closed"`` events contribute ``realized_pnl_usd``
+          cumulatively (closed positions are realized once).
+        * ``pnl_kind == "mark_to_market"`` events SET the unrealized
+          component to ``unrealized_pnl_usd`` at that point (subsequent
+          mark-to-market events overwrite — they're snapshots, not
+          deltas).
+        * ``pnl_kind == "aggregate"`` events are folded into realized
+          (data_manager already pre-aggregated; trust the sum).
+
+        ``equity_at(t) = cumulative_realized(t) + latest_unrealized(t)``
+
+        Drawdown = ``(peak_equity - current_equity) / peak_equity * 100``
+        when ``peak_equity > 0``; clamped to 0 otherwise (no
+        meaningful drawdown when equity has never been positive).
+        """
+        events = await self._fetch_events(strategy_id, start=start, end=end)
+        now = datetime.now(UTC)
+
+        if not events:
+            return DrawdownResult(
+                strategy_id=strategy_id,
+                current_drawdown_pct=0.0,
+                envelope_threshold_pct=None,
+                breach_percentile=None,
+                breached=False,
+                peak_equity_usd=0.0,
+                current_equity_usd=0.0,
+                events_evaluated=0,
+                timestamp=now,
+                reason="no pnl events in window",
+                envelope=await self._fetch_envelope(strategy_id),
+            )
+
+        cumulative_realized = 0.0
+        latest_unrealized = 0.0
+        peak_equity = 0.0
+        current_equity = 0.0
+
+        for ev in events:
+            kind = (ev.get("pnl_kind") or "").lower()
+            realized = float(ev.get("realized_pnl_usd") or 0.0)
+            unrealized = float(ev.get("unrealized_pnl_usd") or 0.0)
+            if kind == "closed":
+                cumulative_realized += realized
+            elif kind == "mark_to_market":
+                latest_unrealized = unrealized
+            elif kind == "aggregate":
+                # Aggregate rows carry pre-summed totals; trust them.
+                cumulative_realized += realized
+                if unrealized != 0.0:
+                    latest_unrealized = unrealized
+            else:
+                # Unknown pnl_kind: fall back to whichever field is set.
+                if realized:
+                    cumulative_realized += realized
+                if unrealized:
+                    latest_unrealized = unrealized
+
+            equity = cumulative_realized + latest_unrealized
+            current_equity = equity
+            if equity > peak_equity:
+                peak_equity = equity
+
+        drawdown_pct = 0.0
+        if peak_equity > 0:
+            drawdown_pct = max(
+                0.0,
+                (peak_equity - current_equity) / peak_equity * 100.0,
+            )
+
+        envelope = await self._fetch_envelope(strategy_id)
+        threshold_pct, label = self._select_threshold(envelope)
+
+        breached = threshold_pct is not None and drawdown_pct > threshold_pct
+        if breached:
+            reason = (
+                f"current drawdown {drawdown_pct:.2f}% exceeds "
+                f"envelope {label} threshold {threshold_pct:.2f}%"
+            )
+        elif threshold_pct is None:
+            reason = (
+                f"current drawdown {drawdown_pct:.2f}% — no envelope "
+                "available for breach comparison"
+            )
+        else:
+            reason = (
+                f"current drawdown {drawdown_pct:.2f}% within envelope "
+                f"{label} threshold {threshold_pct:.2f}%"
+            )
+
+        return DrawdownResult(
+            strategy_id=strategy_id,
+            current_drawdown_pct=drawdown_pct,
+            envelope_threshold_pct=threshold_pct,
+            breach_percentile=label if threshold_pct is not None else None,
+            breached=breached,
+            peak_equity_usd=peak_equity,
+            current_equity_usd=current_equity,
+            events_evaluated=len(events),
+            timestamp=now,
+            reason=reason,
+            envelope=envelope,
+        )
+
+    async def _fetch_events(
+        self,
+        strategy_id: str,
+        *,
+        start: datetime | None,
+        end: datetime | None,
+    ) -> list[dict]:
+        """Pull PnL events for one strategy, oldest first.
+
+        Newest-first ordering would break the cumulative replay — we
+        sort by timestamp ASC explicitly even though MongoDB defaults
+        vary by index direction.
+        """
+        if self._mongo is None or not getattr(self._mongo, "_connected", False):
+            return []
+        try:
+            query: dict[str, Any] = {"strategy_id": strategy_id}
+            if start is not None or end is not None:
+                window: dict[str, Any] = {}
+                if start is not None:
+                    window["$gte"] = start
+                if end is not None:
+                    window["$lt"] = end
+                query["timestamp"] = window
+            coll = self._mongo.db[PNL_EVENTS_COLLECTION]
+            cursor = coll.find(query).sort("timestamp", 1)
+            docs = await cursor.to_list(length=None)
+            for d in docs:
+                d.pop("_id", None)
+            return docs
+        except Exception as e:  # noqa: BLE001 — surface failures as empty + log
+            logger.error(
+                "drawdown_pnl_fetch_failed",
+                extra={"strategy_id": strategy_id, "error": str(e)},
+            )
+            return []
+
+    async def _fetch_envelope(self, strategy_id: str) -> list[float] | None:
+        if self._char_repo is None:
+            return None
+        artifact = await self._char_repo.get_latest(strategy_id)
+        if artifact is None:
+            return None
+        # Defensive copy; the dashboard surfaces this directly.
+        return list(artifact.drawdown_envelope)
+
+    def _select_threshold(
+        self, envelope: list[float] | None
+    ) -> tuple[float | None, str]:
+        """Pick the threshold percentile value from the envelope.
+
+        Returns ``(threshold_pct, label)`` — ``threshold_pct`` is ``None``
+        when no envelope is available or the configured index is out of
+        range. Label is the percentile name (e.g., ``"p99"``).
+        """
+        if not envelope:
+            return None, self._breach_label
+        idx = self._breach_index
+        if idx < 0 or idx >= len(envelope):
+            # Fall back to the last (worst-case) percentile if the
+            # configured index doesn't fit. The envelope length varies
+            # across characterizations, so a hard out-of-range error
+            # would just disable breach checks for non-standard runs.
+            idx = len(envelope) - 1
+            label = f"p[{idx}]"
+        else:
+            label = self._breach_label
+        return float(envelope[idx]), label

--- a/tests/test_portfolio_drawdown.py
+++ b/tests/test_portfolio_drawdown.py
@@ -1,0 +1,503 @@
+"""Tests for the portfolio drawdown vs characterization envelope (#602 P4.2).
+
+Covers:
+  * ``DrawdownService.compute`` — peak/current reconstruction across the
+    realized/mark_to_market/aggregate pnl_kind variants, drawdown_pct
+    math, no-events early return, breach detection vs envelope, and the
+    "unknown pnl_kind" fallback.
+  * ``DrawdownBreachPublisher.maybe_publish`` — only fires when
+    ``result.breached`` is True; failures don't raise.
+  * ``DrawdownScheduler.run_cycle`` — iterates discovered strategies,
+    publishes breach for breached results, skips healthy ones, and
+    survives per-strategy compute failures.
+  * ``GET /api/v1/portfolio/drawdown`` — 503 / 500 / 200 paths, query
+    threading.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from data_manager.models.characterization import Characterization
+from data_manager.portfolio.drawdown_publisher import DrawdownBreachPublisher
+from data_manager.portfolio.drawdown_scheduler import DrawdownScheduler
+from data_manager.portfolio.drawdown_service import DrawdownResult, DrawdownService
+
+NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ev(
+    kind: str, *, realized=0.0, unrealized=0.0, offset_s=0, strategy_id="ta-momentum"
+):
+    return {
+        "pnl_kind": kind,
+        "realized_pnl_usd": realized,
+        "unrealized_pnl_usd": unrealized,
+        "timestamp": NOW + timedelta(seconds=offset_s),
+        "strategy_id": strategy_id,
+    }
+
+
+class _FakeCursor:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def sort(self, *_args, **_kwargs):
+        return self
+
+    async def to_list(self, length=None):
+        return self._docs
+
+
+def _adapter_with_events(events):
+    """Build a stub MongoDB adapter that returns ``events`` for any find()."""
+    coll = MagicMock()
+    coll.find = MagicMock(return_value=_FakeCursor(events))
+    db = MagicMock()
+    db.__getitem__ = MagicMock(return_value=coll)
+    adapter = MagicMock()
+    adapter._connected = True
+    adapter.db = db
+    return adapter, coll
+
+
+def _char_repo_stub(envelope):
+    """A stub characterization_repository with a single envelope."""
+    repo = AsyncMock()
+    if envelope is None:
+        repo.get_latest = AsyncMock(return_value=None)
+    else:
+        repo.get_latest = AsyncMock(
+            return_value=Characterization(
+                strategy_id="ta-momentum",
+                strategy_version="v1",
+                data_window_from=NOW - timedelta(days=30),
+                data_window_to=NOW - timedelta(days=1),
+                seed=42,
+                metrics={"sharpe": 1.2, "win_rate": 0.55, "mean_return": 0.001},
+                drawdown_envelope=envelope,
+                inputs_hash="abc123",
+            )
+        )
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# DrawdownService.compute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_events_returns_zero_drawdown():
+    adapter, _ = _adapter_with_events([])
+    repo = _char_repo_stub(envelope=[5.0, 10.0, 20.0, 30.0])
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    assert result.events_evaluated == 0
+    assert result.current_drawdown_pct == 0.0
+    assert result.breached is False
+    assert result.envelope == [5.0, 10.0, 20.0, 30.0]
+    assert "no pnl events" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_monotonic_growth_yields_no_drawdown():
+    events = [
+        _ev("closed", realized=100.0, offset_s=0),
+        _ev("closed", realized=50.0, offset_s=10),
+        _ev("closed", realized=75.0, offset_s=20),
+    ]
+    adapter, _ = _adapter_with_events(events)
+    repo = _char_repo_stub(envelope=[5.0, 10.0, 20.0, 30.0])
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    assert result.peak_equity_usd == pytest.approx(225.0)
+    assert result.current_equity_usd == pytest.approx(225.0)
+    assert result.current_drawdown_pct == pytest.approx(0.0)
+    assert result.breached is False
+
+
+@pytest.mark.asyncio
+async def test_peak_then_loss_detects_drawdown():
+    # Peak at 200, then loss back to 150 → drawdown 25%.
+    events = [
+        _ev("closed", realized=100.0, offset_s=0),
+        _ev("closed", realized=100.0, offset_s=10),
+        _ev("closed", realized=-50.0, offset_s=20),
+    ]
+    adapter, _ = _adapter_with_events(events)
+    # Envelope p99 = 20% → 25% drawdown exceeds it.
+    repo = _char_repo_stub(envelope=[5.0, 10.0, 20.0, 30.0])
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    assert result.peak_equity_usd == pytest.approx(200.0)
+    assert result.current_equity_usd == pytest.approx(150.0)
+    assert result.current_drawdown_pct == pytest.approx(25.0)
+    assert result.envelope_threshold_pct == pytest.approx(20.0)
+    assert result.breach_percentile == "p99"
+    assert result.breached is True
+    assert "exceeds" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_mark_to_market_snapshots_overwrite_unrealized():
+    # Realized closes accumulate; m2m overwrites the unrealized component.
+    events = [
+        _ev("closed", realized=100.0, offset_s=0),
+        _ev("mark_to_market", unrealized=50.0, offset_s=10),  # equity = 100 + 50 = 150
+        _ev("mark_to_market", unrealized=20.0, offset_s=20),  # equity = 100 + 20 = 120
+        _ev("mark_to_market", unrealized=-30.0, offset_s=30),  # equity = 100 + -30 = 70
+    ]
+    adapter, _ = _adapter_with_events(events)
+    repo = _char_repo_stub(envelope=[5.0, 10.0, 30.0, 60.0])
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    assert result.peak_equity_usd == pytest.approx(150.0)
+    assert result.current_equity_usd == pytest.approx(70.0)
+    # (150 - 70) / 150 = 0.5333... → 53.33%
+    assert result.current_drawdown_pct == pytest.approx((150 - 70) / 150 * 100)
+    assert result.breached is True  # 53.33% > p99=30%
+
+
+@pytest.mark.asyncio
+async def test_drawdown_clamped_when_peak_never_positive():
+    # Strategy is underwater from the first event — peak_equity stays 0,
+    # so drawdown_pct must clamp to 0 (no meaningful drawdown when
+    # equity never went positive).
+    events = [
+        _ev("closed", realized=-100.0, offset_s=0),
+        _ev("closed", realized=-50.0, offset_s=10),
+    ]
+    adapter, _ = _adapter_with_events(events)
+    repo = _char_repo_stub(envelope=[5.0, 10.0, 20.0, 30.0])
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    assert result.peak_equity_usd == 0.0
+    assert result.current_equity_usd == pytest.approx(-150.0)
+    assert result.current_drawdown_pct == 0.0
+    assert result.breached is False
+
+
+@pytest.mark.asyncio
+async def test_aggregate_pnl_kind_folds_into_realized():
+    events = [
+        _ev("aggregate", realized=200.0, unrealized=10.0, offset_s=0),
+        _ev("closed", realized=-100.0, offset_s=10),
+    ]
+    adapter, _ = _adapter_with_events(events)
+    repo = _char_repo_stub(envelope=[5.0, 10.0, 20.0, 30.0])
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    # Peak: 200 realized + 10 unrealized = 210
+    # Current: (200 - 100) realized + 10 unrealized = 110
+    assert result.peak_equity_usd == pytest.approx(210.0)
+    assert result.current_equity_usd == pytest.approx(110.0)
+
+
+@pytest.mark.asyncio
+async def test_unknown_pnl_kind_falls_back_to_field_presence():
+    events = [
+        _ev("weird_new_kind", realized=100.0, offset_s=0),
+        _ev("weird_new_kind", unrealized=-30.0, offset_s=10),
+    ]
+    adapter, _ = _adapter_with_events(events)
+    repo = _char_repo_stub(envelope=None)
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    assert result.peak_equity_usd == pytest.approx(100.0)
+    assert result.current_equity_usd == pytest.approx(70.0)
+
+
+@pytest.mark.asyncio
+async def test_missing_envelope_does_not_breach():
+    events = [
+        _ev("closed", realized=100.0, offset_s=0),
+        _ev("closed", realized=-50.0, offset_s=10),
+    ]
+    adapter, _ = _adapter_with_events(events)
+    repo = _char_repo_stub(envelope=None)
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    assert result.envelope_threshold_pct is None
+    assert result.breach_percentile is None
+    assert result.breached is False
+    assert "no envelope available" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_compute_returns_empty_when_adapter_disconnected():
+    adapter = MagicMock()
+    adapter._connected = False
+    repo = _char_repo_stub(envelope=[5.0, 10.0, 20.0, 30.0])
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    assert result.events_evaluated == 0
+    assert result.current_drawdown_pct == 0.0
+
+
+@pytest.mark.asyncio
+async def test_short_envelope_falls_back_to_last_index():
+    # Only [p50, p90] provided — breach_percentile_index defaults to 2,
+    # which is out of range, so service falls back to the last entry
+    # (the worst-case percentile available).
+    events = [
+        _ev("closed", realized=100.0, offset_s=0),
+        _ev("closed", realized=-50.0, offset_s=10),  # 50% drawdown
+    ]
+    adapter, _ = _adapter_with_events(events)
+    repo = _char_repo_stub(envelope=[5.0, 10.0])
+    svc = DrawdownService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.compute("ta-momentum")
+    assert result.envelope_threshold_pct == 10.0
+    assert result.breach_percentile == "p[1]"
+    assert result.breached is True
+
+
+# ---------------------------------------------------------------------------
+# DrawdownBreachPublisher
+# ---------------------------------------------------------------------------
+
+
+def _result(*, breached: bool, strategy_id="ta-momentum") -> DrawdownResult:
+    return DrawdownResult(
+        strategy_id=strategy_id,
+        current_drawdown_pct=25.0 if breached else 5.0,
+        envelope_threshold_pct=20.0,
+        breach_percentile="p99",
+        breached=breached,
+        peak_equity_usd=200.0,
+        current_equity_usd=150.0,
+        events_evaluated=3,
+        timestamp=NOW,
+        reason="…",
+        envelope=[5.0, 10.0, 20.0, 30.0],
+    )
+
+
+@pytest.mark.asyncio
+async def test_publisher_publishes_breach():
+    nats = AsyncMock()
+    pub = DrawdownBreachPublisher(nats_client=nats)
+
+    published = await pub.maybe_publish(_result(breached=True))
+    assert published is True
+    nats.publish.assert_awaited_once()
+    subject, data = nats.publish.call_args.args
+    assert subject == "portfolio.drawdown.breach.ta-momentum"
+    body = json.loads(data.decode())
+    assert body["breached"] is True
+    assert body["strategy_id"] == "ta-momentum"
+
+
+@pytest.mark.asyncio
+async def test_publisher_skips_when_not_breached():
+    nats = AsyncMock()
+    pub = DrawdownBreachPublisher(nats_client=nats)
+
+    published = await pub.maybe_publish(_result(breached=False))
+    assert published is False
+    nats.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publisher_swallows_nats_errors():
+    nats = AsyncMock()
+    nats.publish = AsyncMock(side_effect=RuntimeError("NATS disconnected"))
+    pub = DrawdownBreachPublisher(nats_client=nats)
+    # Must not raise — scheduler loop relies on this.
+    published = await pub.maybe_publish(_result(breached=True))
+    assert published is False
+
+
+# ---------------------------------------------------------------------------
+# DrawdownScheduler.run_cycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduler_run_cycle_publishes_breaches_and_skips_healthy():
+    adapter, _ = _adapter_with_events(
+        [
+            _ev("closed", realized=100.0, offset_s=0),
+            _ev("closed", realized=-50.0, offset_s=10),
+        ]
+    )
+    repo = _char_repo_stub(envelope=[5.0, 10.0, 20.0, 30.0])
+    nats = AsyncMock()
+
+    scheduler = DrawdownScheduler(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        nats_client=nats,
+        interval_seconds=300,
+        strategy_ids=["ta-momentum"],
+    )
+    results = await scheduler.run_cycle()
+    assert len(results) == 1
+    assert results[0].breached is True
+    nats.publish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_run_cycle_survives_per_strategy_failure():
+    adapter, _ = _adapter_with_events([])
+    repo = _char_repo_stub(envelope=[5.0, 10.0, 20.0, 30.0])
+    nats = AsyncMock()
+
+    scheduler = DrawdownScheduler(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        nats_client=nats,
+        interval_seconds=300,
+        strategy_ids=["ok", "explodes"],
+    )
+
+    original = scheduler._service.compute
+
+    async def flaky(strategy_id, *, start=None, end=None):
+        if strategy_id == "explodes":
+            raise RuntimeError("synthetic")
+        return await original(strategy_id, start=start, end=end)
+
+    scheduler._service.compute = flaky  # type: ignore[assignment]
+    results = await scheduler.run_cycle()
+    # Only "ok" yielded a result; "explodes" was skipped.
+    assert [r.strategy_id for r in results] == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_falls_back_to_adapter_discovery():
+    """When no static list, discovery comes from mongodb.list_all_strategy_ids."""
+    adapter, _ = _adapter_with_events([])
+    adapter.list_all_strategy_ids = AsyncMock(return_value=["s1", "s2"])
+    repo = _char_repo_stub(envelope=None)
+    nats = AsyncMock()
+
+    scheduler = DrawdownScheduler(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        nats_client=nats,
+        interval_seconds=300,
+        strategy_ids=None,
+    )
+    results = await scheduler.run_cycle()
+    assert {r.strategy_id for r in results} == {"s1", "s2"}
+    adapter.list_all_strategy_ids.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# HTTP route — GET /api/v1/portfolio/drawdown
+# ---------------------------------------------------------------------------
+
+
+def _client_with_db(db_manager):
+    from fastapi.testclient import TestClient
+
+    import data_manager.api.app as api_module
+    from data_manager.api.app import create_app
+
+    api_module.db_manager = db_manager
+    return TestClient(create_app())
+
+
+def test_route_returns_503_when_db_manager_missing():
+    client = _client_with_db(None)
+    r = client.get("/api/v1/portfolio/drawdown", params={"strategy_id": "ta-momentum"})
+    assert r.status_code == 503
+
+
+def test_route_requires_strategy_id():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    client = _client_with_db(db)
+    r = client.get("/api/v1/portfolio/drawdown")
+    assert r.status_code == 422
+
+
+def test_route_returns_drawdown_result():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    fake = _result(breached=True)
+
+    with patch(
+        "data_manager.portfolio.drawdown_service.DrawdownService.compute",
+        new=AsyncMock(return_value=fake),
+    ) as mock_compute:
+        client = _client_with_db(db)
+        r = client.get(
+            "/api/v1/portfolio/drawdown",
+            params={"strategy_id": "ta-momentum"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["strategy_id"] == "ta-momentum"
+    assert body["breached"] is True
+    assert body["envelope_threshold_pct"] == 20.0
+    mock_compute.assert_awaited_once()
+
+
+def test_route_threads_time_window_through():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    with patch(
+        "data_manager.portfolio.drawdown_service.DrawdownService.compute",
+        new=AsyncMock(return_value=_result(breached=False)),
+    ) as mock_compute:
+        client = _client_with_db(db)
+        r = client.get(
+            "/api/v1/portfolio/drawdown",
+            params={
+                "strategy_id": "ta-momentum",
+                "from": "2026-05-21T11:00:00+00:00",
+                "to": "2026-05-21T13:00:00+00:00",
+            },
+        )
+    assert r.status_code == 200
+    kwargs = mock_compute.await_args.kwargs
+    assert kwargs["start"] == datetime(2026, 5, 21, 11, 0, tzinfo=UTC)
+    assert kwargs["end"] == datetime(2026, 5, 21, 13, 0, tzinfo=UTC)
+
+
+def test_route_500_when_compute_raises():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    with patch(
+        "data_manager.portfolio.drawdown_service.DrawdownService.compute",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        client = _client_with_db(db)
+        r = client.get(
+            "/api/v1/portfolio/drawdown",
+            params={"strategy_id": "ta-momentum"},
+        )
+    assert r.status_code == 500


### PR DESCRIPTION
## Summary
- Adds peak-to-current drawdown computation per strategy from the `pnl_events` stream (P4.1), comparison to the strategy's characterization `drawdown_envelope` (P3.2), and a NATS breach surface on `portfolio.drawdown.breach.<strategy_id>` so CIO can intervene per FR30.

## Issue
Closes PetroSa2/petrosa_k8s#602 (P4.2). FR30 — RED → GREEN.

## Surface
- `data_manager/portfolio/drawdown_service.py` — `DrawdownService.compute` reconstructs equity by walking `pnl_events` chronologically: `realized` / `aggregate` events accumulate, `mark_to_market` overwrites the unrealized component. Peak across the window vs current equity → drawdown_pct, clamped to 0 when peak never went positive.
- `drawdown_publisher.py` — `DrawdownBreachPublisher` emits on `portfolio.drawdown.breach.<strategy_id>` **only** when breached; healthy ticks stay silent.
- `drawdown_scheduler.py` — `DrawdownScheduler` iterates strategies on a configurable interval (default 5 min). Strategy discovery falls back to `mongodb_adapter.list_all_strategy_ids` when no static list. Per-strategy compute failures are isolated; the loop survives.
- `data_manager/api/routes/drawdown.py` — `GET /api/v1/portfolio/drawdown?strategy_id=X[&from=...&to=...]` returns the same `DrawdownResult` shape for on-demand polls.

## Breach semantics
- Default threshold: envelope **p99** (index 2 of the `[p50, p90, p99, p100]` tuple).
- Graceful fallback to the last-available percentile when the envelope is shorter than 3 entries (with a `p[N]` label so the operator still sees what was compared).
- Missing envelope → no breach (returns drawdown_pct + a "no envelope available for breach comparison" reason for the dashboard).

## Scheduler wiring
The scheduler class is in place; main.py wiring is deferred to follow-up since it requires a manual review of where in the existing scheduler chain it slots (AuditScheduler + AnalyticsScheduler already running). The HTTP route is fully functional today.

## Test plan
- [x] No events → zero drawdown, breached=False, "no pnl events" reason
- [x] Monotonic equity growth → no drawdown
- [x] Peak-then-loss detects drawdown, compares vs p99
- [x] mark_to_market snapshots overwrite unrealized correctly
- [x] Drawdown clamped to 0 when peak_equity ≤ 0 (underwater from start)
- [x] aggregate pnl_kind folds into both realized + unrealized
- [x] Unknown pnl_kind falls back to field-presence logic
- [x] Missing envelope → no breach (with explanatory reason)
- [x] Disconnected MongoDB → empty result, doesn't raise
- [x] Short envelope (< 3 entries) → falls back to last index
- [x] Publisher publishes breach, skips healthy, swallows NATS errors
- [x] Scheduler.run_cycle publishes breaches + skips healthy + survives per-strategy failures
- [x] Scheduler discovery falls back to mongodb_adapter
- [x] HTTP route: 503 / 422 (missing strategy_id) / 200 / 500 paths
- [x] HTTP route: `from`/`to` time-window threading

Pipeline: `make lint` clean, format clean, 21/21 new tests passing, full suite 704 passing (1 pre-existing setuptools-missing failure unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)