### PR TITLE
feat(data-manager): #603 - lifecycle reconstruction join (P4.3)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -23,6 +23,7 @@ from data_manager.api.routes import (
     data,
     generic,
     health,
+    lifecycle,
     pnl,
     raw,
     schemas,
@@ -134,6 +135,8 @@ def create_app() -> FastAPI:
     app.include_router(pnl.router, prefix="/api/v1", tags=["P&L"])
     # Cross-service decision audit-trail (#605 P4.5).
     app.include_router(audit.router, prefix="/api/v1", tags=["Audit Trail"])
+    # Lifecycle reconstruction join (#603 P4.3).
+    app.include_router(lifecycle.router, prefix="/api/v1", tags=["Lifecycle"])
 
     # New API routes
     app.include_router(generic.router, tags=["Generic CRUD"])

--- a/data_manager/api/routes/lifecycle.py
+++ b/data_manager/api/routes/lifecycle.py
@@ -1,0 +1,130 @@
+"""Lifecycle reconstruction endpoints (#603 P4.3).
+
+Two surfaces:
+
+  * ``GET /api/v1/lifecycle/{decision_id}`` — full lifecycle for one
+    decision (intents → decision → executions → pnl_events). Returns 404
+    when the anchor decision doesn't exist.
+  * ``GET /api/v1/lifecycle?strategy_id=...[&from=...&to=...&limit=...]``
+    — newest-first lifecycle list for a strategy. Powers the P5.1
+    strategy lifecycle view; #604 ("why did portfolio do X at time T")
+    will build on the single-decision endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query
+
+import data_manager.api.app as api_module
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/lifecycle/{decision_id}")
+async def get_lifecycle_by_decision(decision_id: str) -> dict:
+    """Reconstruct the full lifecycle for ``decision_id``.
+
+    Joins ``intents``, ``cio_decisions``, ``execution_events``, and
+    ``pnl_events`` by ``decision_id``. Returns 404 when no
+    ``cio_decisions`` row exists for the given id (the decision is the
+    anchor — without it the join has no root).
+    """
+    if not api_module.db_manager or not api_module.db_manager.mongodb_adapter:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    try:
+        from data_manager.db.repositories.lifecycle_repository import (
+            LifecycleRepository,
+        )
+
+        repo = LifecycleRepository(
+            api_module.db_manager.mysql_adapter,
+            api_module.db_manager.mongodb_adapter,
+        )
+        result = await repo.reconstruct(decision_id)
+        if result is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No decision found for decision_id={decision_id}",
+            )
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "lifecycle_endpoint_failed",
+            extra={"decision_id": decision_id, "error": str(e)},
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500, detail="Failed to reconstruct lifecycle"
+        ) from e
+
+
+@router.get("/lifecycle")
+async def list_lifecycle_by_strategy(
+    strategy_id: str = Query(..., description="Strategy identifier"),
+    from_time: datetime | None = Query(
+        None,
+        alias="from",
+        description="Inclusive start of the decision-timestamp window",
+    ),
+    to_time: datetime | None = Query(
+        None, alias="to", description="Exclusive end of the decision-timestamp window"
+    ),
+    limit: int = Query(
+        50,
+        ge=1,
+        le=200,
+        description=(
+            "Max decisions reconstructed in one call (default 50, max 200). "
+            "Each decision triggers four collection reads — cap is tighter "
+            "than the audit-trail endpoint."
+        ),
+    ),
+) -> dict:
+    """List reconstructed lifecycles for a strategy, newest first.
+
+    Each entry is the same shape as the single-decision endpoint. Set
+    ``limit`` carefully — every decision triggers four MongoDB queries.
+    """
+    if not api_module.db_manager or not api_module.db_manager.mongodb_adapter:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    try:
+        from data_manager.db.repositories.lifecycle_repository import (
+            LifecycleRepository,
+        )
+
+        repo = LifecycleRepository(
+            api_module.db_manager.mysql_adapter,
+            api_module.db_manager.mongodb_adapter,
+        )
+        lifecycles = await repo.reconstruct_by_strategy(
+            strategy_id,
+            start=from_time,
+            end=to_time,
+            limit=limit,
+        )
+        return {
+            "strategy_id": strategy_id,
+            "count": len(lifecycles),
+            "limit": limit,
+            "from": from_time.isoformat() if from_time else None,
+            "to": to_time.isoformat() if to_time else None,
+            "lifecycles": lifecycles,
+        }
+    except Exception as e:
+        logger.error(
+            "lifecycle_strategy_endpoint_failed",
+            extra={"strategy_id": strategy_id, "error": str(e)},
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500, detail="Failed to list strategy lifecycles"
+        ) from e

--- a/data_manager/db/repositories/lifecycle_repository.py
+++ b/data_manager/db/repositories/lifecycle_repository.py
@@ -1,0 +1,236 @@
+"""Lifecycle reconstruction join (#603 P4.3).
+
+Reconstructs the full lifecycle of a single CIO decision by joining the
+four cross-service identifier collections established by P0.2:
+
+  ``intents``  →  ``cio_decisions``  →  ``execution_events``  →  ``pnl_events``
+
+All four collections key on ``decision_id``. ``cio_decisions.decision_id``
+is unique (CIO has assigned the id by the time it publishes onto
+``signals.trading.>``); ``intents.decision_id`` is sparse (publishers
+may emit before CIO assigns); ``execution_events`` and ``pnl_events``
+have non-unique ``decision_id`` (one decision produces many events over
+time).
+
+The reconstruction is intentionally read-only and ordered: each leg is
+sorted chronologically so consumers (P4.4 "why did portfolio do X at
+time T", P5.1 time slider) can scrub through the lifecycle without
+re-sorting. ``_id`` is stripped from every document so the response is
+JSON-safe.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from data_manager.db.repositories.base_repository import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+INTENTS_COLLECTION = "intents"
+CIO_DECISIONS_COLLECTION = "cio_decisions"
+EXECUTION_EVENTS_COLLECTION = "execution_events"
+PNL_EVENTS_COLLECTION = "pnl_events"
+
+
+class LifecycleRepository(BaseRepository):
+    """MongoDB-backed reconstruction across the four lifecycle collections."""
+
+    async def reconstruct(self, decision_id: str) -> dict[str, Any] | None:
+        """Reconstruct the full lifecycle for one ``decision_id``.
+
+        Returns ``None`` when no ``cio_decisions`` row exists for the
+        given id — the decision itself is the anchor; without it the
+        join has no meaningful root (and the HTTP layer should serve
+        404). If the decision exists but some legs are empty (no
+        execution events yet, no P&L closed yet), those legs come back
+        as empty lists / None and the caller surfaces that state
+        verbatim — empty legs are signal, not error.
+        """
+        if self.mongodb is None or not getattr(self.mongodb, "db", None):
+            logger.warning(
+                "lifecycle_reconstruct_no_mongo",
+                extra={"decision_id": decision_id},
+            )
+            return None
+
+        decision = await self._fetch_one(CIO_DECISIONS_COLLECTION, decision_id)
+        if decision is None:
+            return None
+
+        # Intents: sparse decision_id, so multiple intents may share one
+        # decision OR an intent may exist with no decision_id at all
+        # (publisher emitted before CIO assigned). For the join, we ask
+        # for "intents that resolved to this decision_id".
+        intents = await self._fetch_many(
+            INTENTS_COLLECTION, decision_id, sort_field="timestamp"
+        )
+        executions = await self._fetch_many(
+            EXECUTION_EVENTS_COLLECTION,
+            decision_id,
+            sort_field="timestamp",
+        )
+        pnl_events = await self._fetch_many(
+            PNL_EVENTS_COLLECTION, decision_id, sort_field="timestamp"
+        )
+
+        return {
+            "decision_id": decision_id,
+            "decision": decision,
+            "intents": intents,
+            "executions": executions,
+            "pnl_events": pnl_events,
+            "summary": _lifecycle_summary(decision, executions, pnl_events),
+        }
+
+    async def reconstruct_by_strategy(
+        self,
+        strategy_id: str,
+        *,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List reconstructions for every decision the strategy made.
+
+        Used by P5.1's strategy lifecycle view. Picks up to ``limit``
+        decisions, newest first, then reconstructs each. Time window
+        applies to the decision's timestamp — not to individual leg
+        events — so a long-running decision's late P&L still surfaces.
+        """
+        if self.mongodb is None or not getattr(self.mongodb, "db", None):
+            return []
+
+        try:
+            decisions = await self.mongodb.find_filtered(
+                CIO_DECISIONS_COLLECTION,
+                filters={"strategy_id": strategy_id},
+                start=start,
+                end=end,
+                limit=limit,
+                sort_field="timestamp",
+                sort_order=-1,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "lifecycle_strategy_decisions_fetch_failed",
+                extra={"strategy_id": strategy_id, "error": str(exc)},
+            )
+            return []
+
+        results: list[dict[str, Any]] = []
+        for dec in decisions:
+            decision_id = dec.get("decision_id")
+            if not decision_id:
+                # Shouldn't happen (decision_id is the unique key for the
+                # collection) but defend against drift.
+                continue
+            try:
+                reconstruction = await self.reconstruct(decision_id)
+                if reconstruction is not None:
+                    results.append(reconstruction)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "lifecycle_strategy_per_decision_failed",
+                    extra={"decision_id": decision_id, "error": str(exc)},
+                )
+        return results
+
+    async def _fetch_one(self, collection: str, decision_id: str) -> dict | None:
+        try:
+            doc = await self.mongodb.db[collection].find_one(
+                {"decision_id": decision_id}
+            )
+            if doc is None:
+                return None
+            doc = dict(doc)
+            doc.pop("_id", None)
+            return doc
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "lifecycle_fetch_one_failed",
+                extra={
+                    "collection": collection,
+                    "decision_id": decision_id,
+                    "error": str(exc),
+                },
+            )
+            return None
+
+    async def _fetch_many(
+        self,
+        collection: str,
+        decision_id: str,
+        *,
+        sort_field: str = "timestamp",
+    ) -> list[dict]:
+        try:
+            cursor = (
+                self.mongodb.db[collection]
+                .find({"decision_id": decision_id})
+                .sort(sort_field, 1)
+            )
+            docs = await cursor.to_list(length=None)
+            for d in docs:
+                d.pop("_id", None)
+            return docs
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "lifecycle_fetch_many_failed",
+                extra={
+                    "collection": collection,
+                    "decision_id": decision_id,
+                    "error": str(exc),
+                },
+            )
+            return []
+
+
+def _lifecycle_summary(
+    decision: dict[str, Any],
+    executions: list[dict[str, Any]],
+    pnl_events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Derive an at-a-glance summary for the lifecycle.
+
+    Calculated fields:
+      * ``action`` — verbatim from the decision.
+      * ``executions_count`` / ``pnl_events_count``.
+      * ``has_filled`` — True iff any execution event has
+        ``event_type == "filled"``.
+      * ``realized_pnl_usd`` — sum of ``realized_pnl_usd`` across closed
+        P&L events; None when no closed events exist.
+
+    The summary is best-effort: missing optional fields don't fail the
+    reconstruction, they just leave the summary entry as None.
+    """
+    has_filled = any(
+        (e.get("event_type") or "").lower() == "filled" for e in executions
+    )
+    realized = [
+        float(p.get("realized_pnl_usd"))
+        for p in pnl_events
+        if (p.get("pnl_kind") or "").lower() == "closed"
+        and p.get("realized_pnl_usd") is not None
+    ]
+    return {
+        "action": decision.get("action"),
+        "strategy_id": decision.get("strategy_id"),
+        "decision_timestamp": _maybe_iso(decision.get("timestamp")),
+        "executions_count": len(executions),
+        "pnl_events_count": len(pnl_events),
+        "has_filled": has_filled,
+        "realized_pnl_usd": sum(realized) if realized else None,
+    }
+
+
+def _maybe_iso(value: Any) -> str | None:
+    """Coerce a datetime field to ISO 8601 — leaves strings/None alone."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, str):
+        return value
+    return None

--- a/tests/test_lifecycle_reconstruction.py
+++ b/tests/test_lifecycle_reconstruction.py
@@ -1,0 +1,491 @@
+"""Tests for the lifecycle reconstruction join (#603 P4.3).
+
+Covers:
+  * ``LifecycleRepository.reconstruct`` joins all four collections,
+    sorts each leg chronologically, strips ``_id``, and returns ``None``
+    when the anchor decision doesn't exist.
+  * ``LifecycleRepository.reconstruct_by_strategy`` lists decisions,
+    reconstructs each, and survives per-decision failures.
+  * The summary fields (``has_filled``, ``realized_pnl_usd`` over
+    closed events, counts) are derived correctly.
+  * The HTTP route — 200 / 404 / 503 / 500 paths and the strategy list
+    variant.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from data_manager.db.repositories.lifecycle_repository import LifecycleRepository
+
+NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+class _FakeCursor:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def sort(self, *_args, **_kwargs):
+        return self
+
+    async def to_list(self, length=None):
+        return self._docs
+
+
+def _adapter_with_collections(mapping):
+    """Build a stub MongoDB adapter where each collection name maps to
+    a (find_one_result, find_many_results) tuple."""
+    adapter = MagicMock()
+    adapter._connected = True
+
+    db = MagicMock()
+
+    def get_coll(name):
+        find_one_doc, find_many_docs = mapping.get(name, (None, []))
+        coll = MagicMock()
+        coll.find_one = AsyncMock(return_value=find_one_doc)
+        coll.find = MagicMock(return_value=_FakeCursor(find_many_docs))
+        return coll
+
+    db.__getitem__ = MagicMock(side_effect=get_coll)
+    adapter.db = db
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# LifecycleRepository.reconstruct
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_returns_none_when_decision_missing():
+    adapter = _adapter_with_collections({"cio_decisions": (None, [])})
+    repo = LifecycleRepository(mysql_adapter=None, mongodb_adapter=adapter)
+
+    result = await repo.reconstruct("d-missing")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_joins_all_four_collections():
+    decision = {
+        "decision_id": "d-1",
+        "strategy_id": "ta-momentum",
+        "action": "execute",
+        "timestamp": NOW,
+        "_id": "internal",
+    }
+    intent = {
+        "intent_id": "i-1",
+        "decision_id": "d-1",
+        "timestamp": NOW - timedelta(seconds=2),
+        "_id": "x",
+    }
+    exec_placed = {
+        "decision_id": "d-1",
+        "order_id": "o-1",
+        "event_type": "placed",
+        "timestamp": NOW + timedelta(seconds=1),
+        "_id": "y",
+    }
+    exec_filled = {
+        "decision_id": "d-1",
+        "order_id": "o-1",
+        "event_type": "filled",
+        "timestamp": NOW + timedelta(seconds=2),
+        "_id": "z",
+    }
+    pnl_closed = {
+        "decision_id": "d-1",
+        "pnl_kind": "closed",
+        "realized_pnl_usd": 12.5,
+        "timestamp": NOW + timedelta(minutes=30),
+        "_id": "w",
+    }
+
+    adapter = _adapter_with_collections(
+        {
+            "cio_decisions": (decision, []),
+            "intents": (None, [intent]),
+            "execution_events": (None, [exec_placed, exec_filled]),
+            "pnl_events": (None, [pnl_closed]),
+        }
+    )
+    repo = LifecycleRepository(mysql_adapter=None, mongodb_adapter=adapter)
+
+    result = await repo.reconstruct("d-1")
+    assert result is not None
+    # _id is stripped from every leg.
+    assert "_id" not in result["decision"]
+    assert all("_id" not in i for i in result["intents"])
+    assert all("_id" not in e for e in result["executions"])
+    assert all("_id" not in p for p in result["pnl_events"])
+    assert result["decision_id"] == "d-1"
+    assert result["intents"][0]["intent_id"] == "i-1"
+    assert [e["event_type"] for e in result["executions"]] == ["placed", "filled"]
+    assert result["pnl_events"][0]["realized_pnl_usd"] == 12.5
+
+    summary = result["summary"]
+    assert summary["action"] == "execute"
+    assert summary["strategy_id"] == "ta-momentum"
+    assert summary["executions_count"] == 2
+    assert summary["pnl_events_count"] == 1
+    assert summary["has_filled"] is True
+    assert summary["realized_pnl_usd"] == 12.5
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_summary_handles_empty_legs():
+    decision = {
+        "decision_id": "d-2",
+        "strategy_id": "ta-momentum",
+        "action": "skip",
+        "timestamp": NOW,
+    }
+    adapter = _adapter_with_collections(
+        {
+            "cio_decisions": (decision, []),
+            "intents": (None, []),
+            "execution_events": (None, []),
+            "pnl_events": (None, []),
+        }
+    )
+    repo = LifecycleRepository(mysql_adapter=None, mongodb_adapter=adapter)
+
+    result = await repo.reconstruct("d-2")
+    assert result is not None
+    summary = result["summary"]
+    assert summary["has_filled"] is False
+    assert summary["executions_count"] == 0
+    assert summary["pnl_events_count"] == 0
+    # realized_pnl_usd is None when no closed events exist — operators
+    # see a deliberate "not applicable" rather than a fake 0.0.
+    assert summary["realized_pnl_usd"] is None
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_summary_realized_pnl_excludes_non_closed():
+    """``realized_pnl_usd`` should only sum events where
+    ``pnl_kind == "closed"``. mark_to_market snapshots have unrealized
+    P&L and must NOT be folded into realized."""
+    decision = {
+        "decision_id": "d-3",
+        "strategy_id": "ta-momentum",
+        "action": "execute",
+        "timestamp": NOW,
+    }
+    pnl_events = [
+        {
+            "decision_id": "d-3",
+            "pnl_kind": "mark_to_market",
+            "unrealized_pnl_usd": 30.0,
+            "timestamp": NOW,
+        },
+        {
+            "decision_id": "d-3",
+            "pnl_kind": "closed",
+            "realized_pnl_usd": 25.0,
+            "timestamp": NOW + timedelta(minutes=10),
+        },
+        {
+            "decision_id": "d-3",
+            "pnl_kind": "closed",
+            "realized_pnl_usd": -5.0,
+            "timestamp": NOW + timedelta(minutes=20),
+        },
+    ]
+    adapter = _adapter_with_collections(
+        {
+            "cio_decisions": (decision, []),
+            "intents": (None, []),
+            "execution_events": (None, []),
+            "pnl_events": (None, pnl_events),
+        }
+    )
+    repo = LifecycleRepository(mysql_adapter=None, mongodb_adapter=adapter)
+
+    result = await repo.reconstruct("d-3")
+    assert result["summary"]["realized_pnl_usd"] == 20.0  # 25 - 5
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_returns_none_when_mongo_unavailable():
+    repo = LifecycleRepository(mysql_adapter=None, mongodb_adapter=None)
+    assert await repo.reconstruct("d-1") is None
+
+
+# ---------------------------------------------------------------------------
+# reconstruct_by_strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_by_strategy_iterates_decisions():
+    adapter = MagicMock()
+    adapter._connected = True
+
+    # find_filtered is the #605 helper — returns one row per decision.
+    adapter.find_filtered = AsyncMock(
+        return_value=[
+            {
+                "decision_id": "d-a",
+                "strategy_id": "ta",
+                "action": "execute",
+                "timestamp": NOW,
+            },
+            {
+                "decision_id": "d-b",
+                "strategy_id": "ta",
+                "action": "skip",
+                "timestamp": NOW - timedelta(minutes=10),
+            },
+        ]
+    )
+
+    # Build a per-decision-id mock for db[<collection>] reads.
+    leg_doc = lambda did: {  # noqa: E731
+        "decision_id": did,
+        "timestamp": NOW,
+    }
+    decision_doc = lambda did: {  # noqa: E731
+        "decision_id": did,
+        "strategy_id": "ta",
+        "action": "execute",
+        "timestamp": NOW,
+    }
+
+    db = MagicMock()
+
+    def get_coll(name):
+        coll = MagicMock()
+        if name == "cio_decisions":
+            coll.find_one = AsyncMock(
+                side_effect=lambda q: decision_doc(q["decision_id"])
+            )
+        else:
+            coll.find_one = AsyncMock(return_value=None)
+        coll.find = MagicMock(return_value=_FakeCursor([leg_doc(name + "-event")]))
+        return coll
+
+    db.__getitem__ = MagicMock(side_effect=get_coll)
+    adapter.db = db
+
+    repo = LifecycleRepository(mysql_adapter=None, mongodb_adapter=adapter)
+    results = await repo.reconstruct_by_strategy("ta", limit=5)
+    assert len(results) == 2
+    assert {r["decision_id"] for r in results} == {"d-a", "d-b"}
+    adapter.find_filtered.assert_awaited_once()
+    kwargs = adapter.find_filtered.call_args.kwargs
+    assert kwargs["filters"] == {"strategy_id": "ta"}
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_by_strategy_returns_empty_when_no_mongo():
+    repo = LifecycleRepository(mysql_adapter=None, mongodb_adapter=None)
+    assert await repo.reconstruct_by_strategy("ta") == []
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_by_strategy_skips_per_decision_failures():
+    adapter = MagicMock()
+    adapter._connected = True
+    adapter.find_filtered = AsyncMock(
+        return_value=[
+            {"decision_id": "ok", "strategy_id": "ta", "timestamp": NOW},
+            {"decision_id": "boom", "strategy_id": "ta", "timestamp": NOW},
+        ]
+    )
+
+    db = MagicMock()
+
+    def get_coll(name):
+        coll = MagicMock()
+        if name == "cio_decisions":
+
+            async def find_one(q):
+                if q["decision_id"] == "boom":
+                    raise RuntimeError("synthetic")
+                return {
+                    "decision_id": q["decision_id"],
+                    "strategy_id": "ta",
+                    "timestamp": NOW,
+                }
+
+            coll.find_one = AsyncMock(side_effect=find_one)
+        else:
+            coll.find_one = AsyncMock(return_value=None)
+        coll.find = MagicMock(return_value=_FakeCursor([]))
+        return coll
+
+    db.__getitem__ = MagicMock(side_effect=get_coll)
+    adapter.db = db
+
+    repo = LifecycleRepository(mysql_adapter=None, mongodb_adapter=adapter)
+    results = await repo.reconstruct_by_strategy("ta")
+    # "boom" decision's find_one raised → _fetch_one swallows the
+    # error and returns None → reconstruct() returns None → skipped.
+    # "ok" decision still reconstructs.
+    assert [r["decision_id"] for r in results] == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP route — GET /api/v1/lifecycle/{decision_id}
+# ---------------------------------------------------------------------------
+
+
+def _client_with_db(db_manager):
+    from fastapi.testclient import TestClient
+
+    import data_manager.api.app as api_module
+    from data_manager.api.app import create_app
+
+    api_module.db_manager = db_manager
+    return TestClient(create_app())
+
+
+def test_single_route_503_when_db_missing():
+    client = _client_with_db(None)
+    r = client.get("/api/v1/lifecycle/d-1")
+    assert r.status_code == 503
+
+
+def test_single_route_404_when_decision_missing():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    with patch(
+        "data_manager.db.repositories.lifecycle_repository.LifecycleRepository.reconstruct",
+        new=AsyncMock(return_value=None),
+    ):
+        client = _client_with_db(db)
+        r = client.get("/api/v1/lifecycle/d-missing")
+    assert r.status_code == 404
+    assert "decision_id=d-missing" in r.json()["detail"]
+
+
+def test_single_route_returns_reconstruction():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    fake = {
+        "decision_id": "d-1",
+        "decision": {"decision_id": "d-1", "action": "execute"},
+        "intents": [],
+        "executions": [],
+        "pnl_events": [],
+        "summary": {"action": "execute", "executions_count": 0},
+    }
+    with patch(
+        "data_manager.db.repositories.lifecycle_repository.LifecycleRepository.reconstruct",
+        new=AsyncMock(return_value=fake),
+    ):
+        client = _client_with_db(db)
+        r = client.get("/api/v1/lifecycle/d-1")
+    assert r.status_code == 200
+    assert r.json()["decision_id"] == "d-1"
+
+
+def test_single_route_500_when_repo_raises():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    with patch(
+        "data_manager.db.repositories.lifecycle_repository.LifecycleRepository.reconstruct",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        client = _client_with_db(db)
+        r = client.get("/api/v1/lifecycle/d-1")
+    assert r.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# HTTP route — GET /api/v1/lifecycle?strategy_id=...
+# ---------------------------------------------------------------------------
+
+
+def test_strategy_route_requires_strategy_id():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    client = _client_with_db(db)
+    r = client.get("/api/v1/lifecycle")
+    assert r.status_code == 422
+
+
+def test_strategy_route_returns_list_and_threads_filters():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    fake_list = [
+        {
+            "decision_id": "d-1",
+            "decision": {},
+            "intents": [],
+            "executions": [],
+            "pnl_events": [],
+            "summary": {},
+        },
+        {
+            "decision_id": "d-2",
+            "decision": {},
+            "intents": [],
+            "executions": [],
+            "pnl_events": [],
+            "summary": {},
+        },
+    ]
+    with patch(
+        "data_manager.db.repositories.lifecycle_repository.LifecycleRepository.reconstruct_by_strategy",
+        new=AsyncMock(return_value=fake_list),
+    ) as mock_recon:
+        client = _client_with_db(db)
+        r = client.get(
+            "/api/v1/lifecycle",
+            params={
+                "strategy_id": "ta-momentum",
+                "from": "2026-05-21T11:00:00+00:00",
+                "to": "2026-05-21T13:00:00+00:00",
+                "limit": 10,
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["strategy_id"] == "ta-momentum"
+    assert body["count"] == 2
+    assert body["limit"] == 10
+    assert body["from"] == "2026-05-21T11:00:00+00:00"
+    kwargs = mock_recon.await_args.kwargs
+    assert kwargs["start"] == datetime(2026, 5, 21, 11, 0, tzinfo=UTC)
+    assert kwargs["end"] == datetime(2026, 5, 21, 13, 0, tzinfo=UTC)
+    assert kwargs["limit"] == 10
+
+
+def test_strategy_route_limit_clamping():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    client = _client_with_db(db)
+    # Below min.
+    assert (
+        client.get(
+            "/api/v1/lifecycle", params={"strategy_id": "ta", "limit": 0}
+        ).status_code
+        == 422
+    )
+    # Above max (200).
+    assert (
+        client.get(
+            "/api/v1/lifecycle", params={"strategy_id": "ta", "limit": 9999}
+        ).status_code
+        == 422
+    )


### PR DESCRIPTION
## Summary
- Adds a cross-collection join that reconstructs the full lifecycle of one CIO decision: `intents` → `cio_decisions` → `execution_events` → `pnl_events`. Single anchor: every collection keys on `decision_id`.
- Surface: `LifecycleRepository` + two HTTP routes (`GET /api/v1/lifecycle/{decision_id}` and `GET /api/v1/lifecycle?strategy_id=...`).

## Issue
Closes PetroSa2/petrosa_k8s#603 (P4.3). FR25 — RED → GREEN. Unblocks #604 P4.4 + P5.1 time slider.

## Surface
- `data_manager/db/repositories/lifecycle_repository.py:LifecycleRepository.reconstruct(decision_id)` — joins all four collections, sorts each leg chronologically, strips `_id`, returns `None` when the anchor decision doesn't exist (HTTP layer → 404).
- `.reconstruct_by_strategy(strategy_id, start, end, limit)` — picks up to `limit` decisions newest-first (reusing #605's `find_filtered` helper), reconstructs each, survives per-decision failures.
- Summary block — `action`, `strategy_id`, counts, `has_filled` (any execution event with `event_type=="filled"`), `realized_pnl_usd` (sum of `realized_pnl_usd` across `pnl_kind=="closed"` events only — `None` when no closed events exist so operators see a deliberate "n/a" rather than a fake 0.0).
- `GET /api/v1/lifecycle/{decision_id}` — single decision; 200/404/503/500.
- `GET /api/v1/lifecycle?strategy_id=X[&from=&to=&limit=]` — listed reconstructions for P5.1 strategy lifecycle view. Limit capped at 200 (tighter than other endpoints — each decision is four MongoDB reads).

## Test plan
- [x] `reconstruct` returns None when no anchor decision
- [x] `reconstruct` joins all four collections, strips `_id`, threads timestamps
- [x] Summary `has_filled` / `executions_count` / `pnl_events_count`
- [x] Summary `realized_pnl_usd` excludes mark_to_market (only sums `pnl_kind == "closed"`)
- [x] Summary `realized_pnl_usd` is None when no closed events
- [x] `reconstruct` returns None when mongodb is None (degraded deployment)
- [x] `reconstruct_by_strategy` threads filter to `find_filtered`, reconstructs each result
- [x] `reconstruct_by_strategy` skips per-decision failures without losing the list
- [x] Single-decision HTTP route: 503 (no db), 404 (no decision), 200 (happy), 500 (raises)
- [x] Strategy HTTP route: 422 (no strategy_id), 200 (filters threaded), limit clamping (422 below 1 / above 200)

Pipeline: lint + format clean, 15/15 new tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)