### PR TITLE
feat(data-manager): #594 - strategy-fidelity evaluator (P2.3)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -22,6 +22,7 @@ from data_manager.api.routes import (
     config,
     data,
     drawdown,
+    fidelity,
     generic,
     health,
     lifecycle,
@@ -140,6 +141,8 @@ def create_app() -> FastAPI:
     app.include_router(lifecycle.router, prefix="/api/v1", tags=["Lifecycle"])
     # Portfolio drawdown vs characterization envelope (#602 P4.2).
     app.include_router(drawdown.router, prefix="/api/v1", tags=["Portfolio"])
+    # Strategy-fidelity evaluator (#594 P2.3).
+    app.include_router(fidelity.router, prefix="/api/v1", tags=["Strategy Fidelity"])
 
     # New API routes
     app.include_router(generic.router, tags=["Generic CRUD"])

--- a/data_manager/api/routes/fidelity.py
+++ b/data_manager/api/routes/fidelity.py
@@ -1,0 +1,60 @@
+"""Strategy-fidelity query endpoint (P2.3, #594).
+
+Operators poll ``GET /api/v1/strategy/{strategy_id}/fidelity`` to see the
+current FidelityResult on demand, in the same shape the NATS verdict
+publisher emits on ``evaluator.strategy.<strategy_id>.verdict``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query
+
+import data_manager.api.app as api_module
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/strategy/{strategy_id}/fidelity")
+async def get_strategy_fidelity(
+    strategy_id: str,
+    from_time: datetime | None = Query(
+        None, alias="from", description="Inclusive start of the PnL window (ISO 8601)"
+    ),
+    to_time: datetime | None = Query(
+        None, alias="to", description="Exclusive end of the PnL window (ISO 8601)"
+    ),
+) -> dict:
+    """Current strategy-fidelity verdict for one strategy."""
+    if not api_module.db_manager or not api_module.db_manager.mongodb_adapter:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    try:
+        from data_manager.db.repositories.characterization_repository import (
+            CharacterizationRepository,
+        )
+        from data_manager.strategies.fidelity_service import FidelityService
+
+        char_repo = CharacterizationRepository(
+            api_module.db_manager.mysql_adapter,
+            api_module.db_manager.mongodb_adapter,
+        )
+        service = FidelityService(
+            mongodb_adapter=api_module.db_manager.mongodb_adapter,
+            characterization_repository=char_repo,
+        )
+        result = await service.evaluate(strategy_id, start=from_time, end=to_time)
+        return result.to_dict()
+    except Exception as e:
+        logger.error(
+            "fidelity_endpoint_failed",
+            extra={"strategy_id": strategy_id, "error": str(e)},
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500, detail="Failed to compute strategy fidelity"
+        ) from e

--- a/data_manager/strategies/__init__.py
+++ b/data_manager/strategies/__init__.py
@@ -1,0 +1,8 @@
+"""Strategy-level analytics: fidelity vs backtest characterization (P2.3, #594)."""
+
+from data_manager.strategies.fidelity_service import (
+    FidelityResult,
+    FidelityService,
+)
+
+__all__ = ["FidelityResult", "FidelityService"]

--- a/data_manager/strategies/fidelity_publisher.py
+++ b/data_manager/strategies/fidelity_publisher.py
@@ -1,0 +1,102 @@
+"""NATS verdict publisher for strategy-fidelity (P2.3, #594).
+
+Publishes per-strategy verdicts on
+``evaluator.strategy.<strategy_id>.verdict`` per the P2.1 evaluator
+framework convention. The payload is JSON ``{"verdict", "reason"}`` —
+identical shape to ingest/audit/cio evaluators so the CIO
+EvaluatorSubscriber (#597) can consume it without extending its
+parser.
+
+Hysteresis is owned by the publisher rather than the service: the
+service computes a fresh verdict on every tick (stateless), and the
+publisher only emits when (a) the verdict has been stable for
+``stable_ticks_required`` consecutive ticks AND (b) the emitted
+verdict has actually changed. This prevents both flapping AND constant
+re-emission of the same healthy verdict.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from data_manager.consumer.nats_client import NATSClient
+    from data_manager.strategies.fidelity_service import FidelityResult
+
+logger = logging.getLogger(__name__)
+
+
+VERDICT_SUBJECT_PREFIX = "evaluator.strategy"
+
+
+class FidelityVerdictPublisher:
+    """Per-strategy NATS verdict publisher with hysteresis."""
+
+    def __init__(
+        self,
+        nats_client: NATSClient,
+        *,
+        stable_ticks_required: int = 2,
+    ) -> None:
+        self._nc = nats_client
+        self._stable_ticks_required = max(1, stable_ticks_required)
+        # strategy_id -> (last_emitted_verdict, candidate_verdict, candidate_streak)
+        self._state: dict[str, tuple[str | None, str, int]] = {}
+
+    async def maybe_publish(self, result: FidelityResult) -> bool:
+        """Apply hysteresis, then publish iff verdict has flipped.
+
+        Returns True iff a publish was attempted (the underlying client
+        may drop on disconnect; that's logged but not raised).
+        """
+        sid = result.strategy_id
+        raw_verdict = result.verdict
+        last_emitted, candidate, streak = self._state.get(sid, (None, raw_verdict, 0))
+
+        # Same as the externally-emitted verdict? Reset candidate streak
+        # — we're already in the stable state.
+        if raw_verdict == last_emitted:
+            self._state[sid] = (last_emitted, raw_verdict, 0)
+            return False
+
+        # New raw verdict — restart or continue the candidate streak.
+        if raw_verdict == candidate:
+            streak += 1
+        else:
+            candidate = raw_verdict
+            streak = 1
+
+        if streak < self._stable_ticks_required:
+            self._state[sid] = (last_emitted, candidate, streak)
+            return False
+
+        # Streak satisfied — promote to emitted.
+        subject = f"{VERDICT_SUBJECT_PREFIX}.{sid}.verdict"
+        payload = json.dumps(
+            {"verdict": raw_verdict, "reason": result.reason[:200]}
+        ).encode()
+        try:
+            await self._nc.publish(subject, payload)
+            logger.info(
+                "fidelity_verdict_published",
+                extra={
+                    "subject": subject,
+                    "strategy_id": sid,
+                    "verdict": raw_verdict,
+                    "previous": last_emitted,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — scheduler must survive
+            logger.error(
+                "fidelity_verdict_publish_failed",
+                extra={"subject": subject, "error": str(exc)},
+            )
+            # Reset hysteresis on publish failure so we retry on the next
+            # tick — don't lose the flip just because NATS hiccupped.
+            self._state[sid] = (last_emitted, candidate, streak - 1)
+            return False
+
+        self._state[sid] = (raw_verdict, raw_verdict, 0)
+        return True

--- a/data_manager/strategies/fidelity_scheduler.py
+++ b/data_manager/strategies/fidelity_scheduler.py
@@ -1,0 +1,113 @@
+"""Periodic strategy-fidelity scan (P2.3, #594).
+
+Iterates known strategies on each tick, runs ``FidelityService.evaluate``
+for each, and routes the result through ``FidelityVerdictPublisher``
+(which handles hysteresis + the emit decision).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from data_manager.consumer.nats_client import NATSClient
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+    from data_manager.db.repositories.characterization_repository import (
+        CharacterizationRepository,
+    )
+
+from data_manager.strategies.fidelity_publisher import FidelityVerdictPublisher
+from data_manager.strategies.fidelity_service import FidelityResult, FidelityService
+
+logger = logging.getLogger(__name__)
+
+
+class FidelityScheduler:
+    """Periodic loop that evaluates fidelity and publishes verdicts."""
+
+    def __init__(
+        self,
+        *,
+        mongodb_adapter: MongoDBAdapter,
+        characterization_repository: CharacterizationRepository,
+        nats_client: NATSClient,
+        interval_seconds: int = 300,
+        stable_ticks_required: int = 2,
+        strategy_ids: list[str] | None = None,
+        threshold: float = FidelityService.DEFAULT_THRESHOLD,
+    ) -> None:
+        self._mongo = mongodb_adapter
+        self._char_repo = characterization_repository
+        self._service = FidelityService(
+            mongodb_adapter=mongodb_adapter,
+            characterization_repository=characterization_repository,
+            threshold=threshold,
+        )
+        self._publisher = FidelityVerdictPublisher(
+            nats_client=nats_client,
+            stable_ticks_required=stable_ticks_required,
+        )
+        self._interval = max(1, interval_seconds)
+        self._static_strategy_ids = strategy_ids
+        self._task: asyncio.Task | None = None
+        self._running = False
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info(
+            "fidelity_scheduler_started",
+            extra={"interval_seconds": self._interval},
+        )
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._task = None
+
+    async def _loop(self) -> None:
+        while self._running:
+            try:
+                await self.run_cycle()
+            except Exception as exc:  # noqa: BLE001 — never crash the loop
+                logger.error(
+                    "fidelity_scheduler_cycle_failed", extra={"error": str(exc)}
+                )
+            await asyncio.sleep(self._interval)
+
+    async def run_cycle(self) -> list[FidelityResult]:
+        strategy_ids = await self._discover_strategies()
+        results: list[FidelityResult] = []
+        for sid in strategy_ids:
+            try:
+                result = await self._service.evaluate(sid)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "fidelity_cycle_strategy_failed",
+                    extra={"strategy_id": sid, "error": str(exc)},
+                )
+                continue
+            results.append(result)
+            await self._publisher.maybe_publish(result)
+        return results
+
+    async def _discover_strategies(self) -> list[str]:
+        if self._static_strategy_ids is not None:
+            return list(self._static_strategy_ids)
+        try:
+            return await self._mongo.list_all_strategy_ids()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "fidelity_scheduler_discovery_failed",
+                extra={"error": str(exc)},
+            )
+            return []

--- a/data_manager/strategies/fidelity_service.py
+++ b/data_manager/strategies/fidelity_service.py
@@ -1,0 +1,279 @@
+"""Strategy-fidelity evaluator (P2.3, #594).
+
+Compares per-strategy live signal behaviour to the strategy's persisted
+characterization artifact (P3.2). Verdict downgrades to ``unhealthy``
+when the divergence between live and characterized expected return
+exceeds a configurable threshold over a rolling window.
+
+The recommended metric in the ticket is rolling KL divergence between
+live and backtest signal distributions, but the ticket itself notes
+"subject to operator review". MVP uses a simpler, defensible metric
+that the operator can evolve into KL once the substrate is in place:
+
+  divergence = abs(live_mean_return - characterized_mean_return)
+               / max(abs(characterized_mean_return), 1e-9)
+
+The denominator floor prevents division-by-zero when the
+characterization's expected mean return is exactly zero (rare but
+possible). The metric is operator-review-pending — clearly documented
+so the next iteration can swap in a richer distribution comparator
+without rewriting the rest of the pipeline.
+
+Live mean_return is computed from ``pnl_events`` where
+``pnl_kind == "closed"``: ``mean(realized_pnl_usd / abs(reference_capital))``
+when reference capital is supplied, otherwise the raw realized P&L mean
+(operator can post-process). The MVP uses raw realized P&L mean — the
+characterization stores mean_return in the same per-trade units when
+populated by the standard backtest pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from data_manager.db.repositories.characterization_repository import (
+    CharacterizationRepository,
+)
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+if TYPE_CHECKING:
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+logger = logging.getLogger(__name__)
+
+
+PNL_EVENTS_COLLECTION = "pnl_events"
+
+HEALTHY = "healthy"
+UNHEALTHY = "unhealthy"
+UNKNOWN = "unknown"
+
+
+@dataclass(slots=True)
+class FidelityResult:
+    """Outcome of one strategy-fidelity evaluation cycle.
+
+    The shape mirrors what the verdict publisher sends on NATS and what
+    the HTTP query endpoint returns — operators see one consistent
+    payload across both surfaces.
+    """
+
+    strategy_id: str
+    verdict: str  # healthy | unhealthy | unknown
+    reason: str
+    live_mean_return: float | None
+    characterized_mean_return: float | None
+    divergence: float | None
+    threshold: float
+    samples: int
+    timestamp: datetime
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "strategy_id": self.strategy_id,
+            "verdict": self.verdict,
+            "reason": self.reason,
+            "live_mean_return": self.live_mean_return,
+            "characterized_mean_return": self.characterized_mean_return,
+            "divergence": self.divergence,
+            "threshold": self.threshold,
+            "samples": self.samples,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+class FidelityService:
+    """Compute strategy-fidelity verdicts from PnL + characterization."""
+
+    # Minimum number of closed P&L events required before we trust the
+    # live mean — below this the sample is too noisy to produce a
+    # confident verdict, so we return UNKNOWN.
+    MIN_SAMPLES_FOR_VERDICT = 10
+
+    # Default tolerance: live mean must stay within this fraction of
+    # characterized mean. 0.5 = up to 50% relative divergence is HEALTHY.
+    DEFAULT_THRESHOLD = 0.5
+
+    def __init__(
+        self,
+        mongodb_adapter: MongoDBAdapter,
+        characterization_repository: CharacterizationRepository | None = None,
+        *,
+        threshold: float = DEFAULT_THRESHOLD,
+        min_samples: int = MIN_SAMPLES_FOR_VERDICT,
+    ) -> None:
+        self._mongo = mongodb_adapter
+        self._char_repo = characterization_repository
+        self._threshold = threshold
+        self._min_samples = max(1, min_samples)
+
+    async def evaluate(
+        self,
+        strategy_id: str,
+        *,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> FidelityResult:
+        """Compute the strategy-fidelity verdict for one strategy."""
+        now = datetime.now(UTC)
+
+        # Pull characterization first — without it we can't compute
+        # divergence, so the verdict is UNKNOWN regardless of how many
+        # live samples we have.
+        characterized_mean = await self._fetch_characterized_mean_return(strategy_id)
+        if characterized_mean is None:
+            return FidelityResult(
+                strategy_id=strategy_id,
+                verdict=UNKNOWN,
+                reason="no characterization available — cannot measure fidelity",
+                live_mean_return=None,
+                characterized_mean_return=None,
+                divergence=None,
+                threshold=self._threshold,
+                samples=0,
+                timestamp=now,
+            )
+
+        events = await self._fetch_closed_pnl_events(strategy_id, start=start, end=end)
+        samples = len(events)
+        if samples < self._min_samples:
+            return FidelityResult(
+                strategy_id=strategy_id,
+                verdict=UNKNOWN,
+                reason=(
+                    f"only {samples} closed P&L events in window — need "
+                    f"≥{self._min_samples} for a confident verdict"
+                ),
+                live_mean_return=None,
+                characterized_mean_return=characterized_mean,
+                divergence=None,
+                threshold=self._threshold,
+                samples=samples,
+                timestamp=now,
+            )
+
+        live_mean = sum(events) / samples
+        denominator = max(abs(characterized_mean), 1e-9)
+        divergence = abs(live_mean - characterized_mean) / denominator
+
+        if not math.isfinite(divergence):
+            # Defensive — guards against weird float math when the
+            # characterized mean is enormous or the live mean is NaN.
+            return FidelityResult(
+                strategy_id=strategy_id,
+                verdict=UNKNOWN,
+                reason="divergence not finite — skipping verdict",
+                live_mean_return=live_mean,
+                characterized_mean_return=characterized_mean,
+                divergence=None,
+                threshold=self._threshold,
+                samples=samples,
+                timestamp=now,
+            )
+
+        if divergence > self._threshold:
+            return FidelityResult(
+                strategy_id=strategy_id,
+                verdict=UNHEALTHY,
+                reason=(
+                    f"divergence {divergence:.3f} exceeds threshold "
+                    f"{self._threshold:.3f} (live mean_return {live_mean:.4f} "
+                    f"vs characterized {characterized_mean:.4f} across "
+                    f"{samples} closed events)"
+                ),
+                live_mean_return=live_mean,
+                characterized_mean_return=characterized_mean,
+                divergence=divergence,
+                threshold=self._threshold,
+                samples=samples,
+                timestamp=now,
+            )
+
+        return FidelityResult(
+            strategy_id=strategy_id,
+            verdict=HEALTHY,
+            reason=(
+                f"divergence {divergence:.3f} within threshold "
+                f"{self._threshold:.3f} ({samples} closed events)"
+            ),
+            live_mean_return=live_mean,
+            characterized_mean_return=characterized_mean,
+            divergence=divergence,
+            threshold=self._threshold,
+            samples=samples,
+            timestamp=now,
+        )
+
+    async def _fetch_characterized_mean_return(self, strategy_id: str) -> float | None:
+        if self._char_repo is None:
+            return None
+        try:
+            artifact = await self._char_repo.get_latest(strategy_id)
+        except Exception as e:  # noqa: BLE001
+            logger.error(
+                "fidelity_characterization_fetch_failed",
+                extra={"strategy_id": strategy_id, "error": str(e)},
+            )
+            return None
+        if artifact is None:
+            return None
+        value = artifact.metrics.get("mean_return")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    async def _fetch_closed_pnl_events(
+        self,
+        strategy_id: str,
+        *,
+        start: datetime | None,
+        end: datetime | None,
+    ) -> list[float]:
+        """Pull realized P&L values for closed events.
+
+        Only ``pnl_kind == "closed"`` events contribute — mark_to_market
+        snapshots are noise here (the same open position re-snaps many
+        times). Returns the raw ``realized_pnl_usd`` list; the caller
+        averages.
+        """
+        if self._mongo is None or not getattr(self._mongo, "_connected", False):
+            return []
+        try:
+            docs = await self._mongo.find_filtered(
+                PNL_EVENTS_COLLECTION,
+                filters={"strategy_id": strategy_id, "pnl_kind": "closed"},
+                start=start,
+                end=end,
+                limit=1000,
+                sort_field="timestamp",
+                sort_order=1,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error(
+                "fidelity_pnl_fetch_failed",
+                extra={"strategy_id": strategy_id, "error": str(e)},
+            )
+            return []
+        out: list[float] = []
+        for d in docs:
+            val = d.get("realized_pnl_usd")
+            if val is None:
+                continue
+            try:
+                out.append(float(val))
+            except (TypeError, ValueError):
+                continue
+        return out

--- a/tests/test_strategy_fidelity.py
+++ b/tests/test_strategy_fidelity.py
@@ -1,0 +1,462 @@
+"""Tests for the strategy-fidelity evaluator (#594 P2.3).
+
+Covers:
+  * ``FidelityService.evaluate`` — UNKNOWN when no characterization,
+    UNKNOWN when sample size below threshold, HEALTHY/UNHEALTHY math,
+    NaN/infinity guards, threshold parameterization.
+  * ``FidelityVerdictPublisher`` hysteresis — same-verdict ticks
+    don't republish; ``stable_ticks_required`` consecutive raw
+    observations needed before flipping; publish failure rolls back
+    hysteresis so retry works on next tick.
+  * ``FidelityScheduler.run_cycle`` — iterates strategies, routes
+    results through the publisher, survives per-strategy failures.
+  * HTTP route — 200 / 503 / 500 paths.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from data_manager.models.characterization import Characterization
+from data_manager.strategies.fidelity_publisher import FidelityVerdictPublisher
+from data_manager.strategies.fidelity_scheduler import FidelityScheduler
+from data_manager.strategies.fidelity_service import (
+    HEALTHY,
+    UNHEALTHY,
+    UNKNOWN,
+    FidelityResult,
+    FidelityService,
+)
+
+NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _char_repo_stub(mean_return: float | None):
+    repo = AsyncMock()
+    if mean_return is None:
+        repo.get_latest = AsyncMock(return_value=None)
+    else:
+        repo.get_latest = AsyncMock(
+            return_value=Characterization(
+                strategy_id="ta-momentum",
+                strategy_version="v1",
+                data_window_from=NOW - timedelta(days=30),
+                data_window_to=NOW - timedelta(days=1),
+                seed=42,
+                metrics={
+                    "sharpe": 1.2,
+                    "win_rate": 0.55,
+                    "mean_return": mean_return,
+                },
+                drawdown_envelope=[5.0, 10.0, 20.0, 30.0],
+                inputs_hash="abc123",
+            )
+        )
+    return repo
+
+
+def _adapter_with_pnl(events):
+    """Stub MongoDB adapter where find_filtered returns ``events``."""
+    adapter = MagicMock()
+    adapter._connected = True
+    adapter.find_filtered = AsyncMock(return_value=events)
+    return adapter
+
+
+def _pnl_event(realized: float, *, kind: str = "closed"):
+    return {
+        "pnl_kind": kind,
+        "realized_pnl_usd": realized,
+        "timestamp": NOW,
+    }
+
+
+# ---------------------------------------------------------------------------
+# FidelityService.evaluate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_characterization_returns_unknown():
+    adapter = _adapter_with_pnl([_pnl_event(1.0) for _ in range(20)])
+    repo = _char_repo_stub(mean_return=None)
+    svc = FidelityService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.evaluate("ta-momentum")
+    assert result.verdict == UNKNOWN
+    assert "no characterization" in result.reason
+    # find_filtered is not even called when there's no characterization.
+    adapter.find_filtered.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_too_few_samples_returns_unknown():
+    adapter = _adapter_with_pnl([_pnl_event(1.0) for _ in range(3)])
+    repo = _char_repo_stub(mean_return=1.0)
+    svc = FidelityService(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        min_samples=10,
+    )
+
+    result = await svc.evaluate("ta-momentum")
+    assert result.verdict == UNKNOWN
+    assert "need ≥10" in result.reason
+    assert result.samples == 3
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_within_threshold():
+    # Live mean = 1.0, characterized = 1.1 → divergence ≈ 0.09 < 0.5
+    adapter = _adapter_with_pnl([_pnl_event(1.0) for _ in range(15)])
+    repo = _char_repo_stub(mean_return=1.1)
+    svc = FidelityService(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        threshold=0.5,
+    )
+
+    result = await svc.evaluate("ta-momentum")
+    assert result.verdict == HEALTHY
+    assert result.divergence is not None
+    assert result.divergence < 0.5
+    assert result.samples == 15
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_above_threshold():
+    # Live mean = -1.0, characterized = 1.0 → divergence = 2.0 > 0.5
+    adapter = _adapter_with_pnl([_pnl_event(-1.0) for _ in range(15)])
+    repo = _char_repo_stub(mean_return=1.0)
+    svc = FidelityService(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        threshold=0.5,
+    )
+
+    result = await svc.evaluate("ta-momentum")
+    assert result.verdict == UNHEALTHY
+    assert result.divergence == pytest.approx(2.0)
+    assert "exceeds threshold" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_zero_characterized_mean_uses_epsilon_denominator():
+    """When characterized mean_return is 0, the relative-divergence
+    formula must not divide by zero — the service uses a small epsilon
+    so the verdict is still computable (and almost always UNHEALTHY when
+    live is non-zero)."""
+    adapter = _adapter_with_pnl([_pnl_event(1.0) for _ in range(15)])
+    repo = _char_repo_stub(mean_return=0.0)
+    svc = FidelityService(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        threshold=0.5,
+    )
+
+    result = await svc.evaluate("ta-momentum")
+    # |1.0 - 0.0| / max(0.0, 1e-9) = 1e9 → huge divergence → unhealthy.
+    assert result.verdict == UNHEALTHY
+    assert result.divergence is not None
+    assert result.divergence > 0.5
+
+
+@pytest.mark.asyncio
+async def test_threshold_is_configurable():
+    """A tighter threshold flips the verdict from HEALTHY to UNHEALTHY
+    for the same input."""
+    adapter = _adapter_with_pnl([_pnl_event(0.5) for _ in range(15)])
+    repo = _char_repo_stub(mean_return=1.0)
+
+    loose = await FidelityService(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        threshold=1.0,
+    ).evaluate("ta-momentum")
+    tight = await FidelityService(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        threshold=0.1,
+    ).evaluate("ta-momentum")
+
+    assert loose.verdict == HEALTHY  # 0.5 ≤ 1.0 → fine
+    assert tight.verdict == UNHEALTHY  # 0.5 > 0.1 → flag
+
+
+@pytest.mark.asyncio
+async def test_disconnected_adapter_yields_zero_samples():
+    adapter = MagicMock()
+    adapter._connected = False
+    repo = _char_repo_stub(mean_return=1.0)
+    svc = FidelityService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.evaluate("ta-momentum")
+    assert result.samples == 0
+    assert result.verdict == UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_pnl_fetch_error_is_swallowed_to_empty_samples():
+    adapter = MagicMock()
+    adapter._connected = True
+    adapter.find_filtered = AsyncMock(side_effect=RuntimeError("mongo hiccup"))
+    repo = _char_repo_stub(mean_return=1.0)
+    svc = FidelityService(mongodb_adapter=adapter, characterization_repository=repo)
+
+    result = await svc.evaluate("ta-momentum")
+    assert result.samples == 0
+    assert result.verdict == UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# FidelityVerdictPublisher hysteresis
+# ---------------------------------------------------------------------------
+
+
+def _result(strategy_id: str, verdict: str, *, reason: str = "ok") -> FidelityResult:
+    return FidelityResult(
+        strategy_id=strategy_id,
+        verdict=verdict,
+        reason=reason,
+        live_mean_return=1.0,
+        characterized_mean_return=1.0,
+        divergence=0.0,
+        threshold=0.5,
+        samples=15,
+        timestamp=NOW,
+    )
+
+
+@pytest.mark.asyncio
+async def test_publisher_emits_on_first_stable_streak():
+    """With stable_ticks_required=2, two consecutive raw HEALTHY ticks
+    must flip from initial-None to HEALTHY on the second."""
+    nats = AsyncMock()
+    pub = FidelityVerdictPublisher(nats_client=nats, stable_ticks_required=2)
+
+    p1 = await pub.maybe_publish(_result("ta", HEALTHY))
+    assert p1 is False  # streak=1 — not yet
+    p2 = await pub.maybe_publish(_result("ta", HEALTHY))
+    assert p2 is True
+    nats.publish.assert_awaited_once()
+    subject, data = nats.publish.call_args.args
+    assert subject == "evaluator.strategy.ta.verdict"
+    body = json.loads(data.decode())
+    assert body["verdict"] == HEALTHY
+
+
+@pytest.mark.asyncio
+async def test_publisher_does_not_republish_same_verdict():
+    """Once HEALTHY has been emitted, subsequent HEALTHY ticks must
+    NOT publish — only flips are interesting."""
+    nats = AsyncMock()
+    pub = FidelityVerdictPublisher(nats_client=nats, stable_ticks_required=1)
+
+    await pub.maybe_publish(_result("ta", HEALTHY))  # emits
+    nats.publish.reset_mock()
+    await pub.maybe_publish(_result("ta", HEALTHY))  # no-op
+    await pub.maybe_publish(_result("ta", HEALTHY))  # no-op
+    nats.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publisher_flapping_does_not_emit_until_stable():
+    """Alternating raw verdicts must not flip the emitted verdict
+    because the candidate streak never reaches stable_ticks_required."""
+    nats = AsyncMock()
+    pub = FidelityVerdictPublisher(nats_client=nats, stable_ticks_required=3)
+
+    await pub.maybe_publish(_result("ta", HEALTHY))  # streak=1
+    await pub.maybe_publish(
+        _result("ta", UNHEALTHY)
+    )  # candidate reset to UNHEALTHY streak=1
+    await pub.maybe_publish(_result("ta", HEALTHY))  # candidate reset streak=1
+    await pub.maybe_publish(_result("ta", UNHEALTHY))  # streak=1
+    nats.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publisher_publish_failure_does_not_advance_state():
+    """If the NATS publish raises, the publisher must retry on the next
+    matching-verdict tick rather than treating the flip as committed."""
+    nats = AsyncMock()
+    nats.publish = AsyncMock(side_effect=[RuntimeError("nats down"), None])
+    pub = FidelityVerdictPublisher(nats_client=nats, stable_ticks_required=1)
+
+    p1 = await pub.maybe_publish(_result("ta", UNHEALTHY))
+    assert p1 is False  # publish raised
+    p2 = await pub.maybe_publish(_result("ta", UNHEALTHY))
+    assert p2 is True  # retried successfully
+    assert nats.publish.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_publisher_truncates_reason_to_200_chars():
+    nats = AsyncMock()
+    pub = FidelityVerdictPublisher(nats_client=nats, stable_ticks_required=1)
+    long_reason = "x" * 500
+    await pub.maybe_publish(_result("ta", UNHEALTHY, reason=long_reason))
+    args, _ = nats.publish.call_args
+    _, data = args
+    body = json.loads(data.decode())
+    assert len(body["reason"]) <= 200
+
+
+# ---------------------------------------------------------------------------
+# FidelityScheduler.run_cycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduler_publishes_per_strategy():
+    """Each strategy's verdict goes through the publisher; the
+    publisher's per-strategy hysteresis state is independent."""
+    adapter = MagicMock()
+    adapter._connected = True
+    adapter.find_filtered = AsyncMock(
+        return_value=[_pnl_event(-1.0) for _ in range(15)]
+    )
+    repo = _char_repo_stub(mean_return=1.0)
+    nats = AsyncMock()
+
+    scheduler = FidelityScheduler(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        nats_client=nats,
+        interval_seconds=300,
+        stable_ticks_required=1,
+        strategy_ids=["ta-momentum", "ta-reversion"],
+        threshold=0.5,
+    )
+
+    # Two ticks so both strategies flip into emitted state (stable=1
+    # means the first tick already flips; this exercises both
+    # publisher entries).
+    results1 = await scheduler.run_cycle()
+    results2 = await scheduler.run_cycle()
+
+    assert {r.strategy_id for r in results1} == {"ta-momentum", "ta-reversion"}
+    assert {r.strategy_id for r in results2} == {"ta-momentum", "ta-reversion"}
+    # Each strategy should have published exactly once (first cycle);
+    # the second cycle is a same-verdict no-op.
+    assert nats.publish.await_count == 2
+    subjects = {c.args[0] for c in nats.publish.call_args_list}
+    assert subjects == {
+        "evaluator.strategy.ta-momentum.verdict",
+        "evaluator.strategy.ta-reversion.verdict",
+    }
+
+
+@pytest.mark.asyncio
+async def test_scheduler_survives_per_strategy_failure():
+    adapter = MagicMock()
+    adapter._connected = True
+    adapter.find_filtered = AsyncMock(return_value=[_pnl_event(1.0) for _ in range(15)])
+    repo = _char_repo_stub(mean_return=1.0)
+    nats = AsyncMock()
+
+    scheduler = FidelityScheduler(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        nats_client=nats,
+        interval_seconds=300,
+        strategy_ids=["ok", "explodes"],
+    )
+
+    original = scheduler._service.evaluate
+
+    async def flaky(strategy_id, *, start=None, end=None):
+        if strategy_id == "explodes":
+            raise RuntimeError("synthetic")
+        return await original(strategy_id, start=start, end=end)
+
+    scheduler._service.evaluate = flaky  # type: ignore[assignment]
+    results = await scheduler.run_cycle()
+    assert [r.strategy_id for r in results] == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_falls_back_to_mongo_discovery():
+    adapter = MagicMock()
+    adapter._connected = True
+    adapter.find_filtered = AsyncMock(return_value=[])
+    adapter.list_all_strategy_ids = AsyncMock(return_value=["s1", "s2"])
+    repo = _char_repo_stub(mean_return=None)
+    nats = AsyncMock()
+
+    scheduler = FidelityScheduler(
+        mongodb_adapter=adapter,
+        characterization_repository=repo,
+        nats_client=nats,
+        strategy_ids=None,
+    )
+    results = await scheduler.run_cycle()
+    assert {r.strategy_id for r in results} == {"s1", "s2"}
+    adapter.list_all_strategy_ids.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# HTTP route
+# ---------------------------------------------------------------------------
+
+
+def _client_with_db(db_manager):
+    from fastapi.testclient import TestClient
+
+    import data_manager.api.app as api_module
+    from data_manager.api.app import create_app
+
+    api_module.db_manager = db_manager
+    return TestClient(create_app())
+
+
+def test_route_503_when_db_missing():
+    client = _client_with_db(None)
+    r = client.get("/api/v1/strategy/ta-momentum/fidelity")
+    assert r.status_code == 503
+
+
+def test_route_returns_fidelity_result():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    fake = _result("ta-momentum", HEALTHY)
+    with patch(
+        "data_manager.strategies.fidelity_service.FidelityService.evaluate",
+        new=AsyncMock(return_value=fake),
+    ):
+        client = _client_with_db(db)
+        r = client.get("/api/v1/strategy/ta-momentum/fidelity")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["strategy_id"] == "ta-momentum"
+    assert body["verdict"] == HEALTHY
+
+
+def test_route_500_when_service_raises():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    with patch(
+        "data_manager.strategies.fidelity_service.FidelityService.evaluate",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        client = _client_with_db(db)
+        r = client.get("/api/v1/strategy/ta-momentum/fidelity")
+    assert r.status_code == 500


### PR DESCRIPTION
## Summary
- Adds a per-strategy fidelity evaluator that compares live mean_return (from `pnl_events` closed P&L) against the strategy's characterization `metrics["mean_return"]` (from P3.2), emitting verdicts on `evaluator.strategy.<strategy_id>.verdict` per the P2.1 framework convention.
- CIO's existing EvaluatorSubscriber (#597) consumes this subject pattern automatically — the per-strategy pause gate (SignalArbiter consulting `subsystem="strategy.<id>"`) is the natural P2.6-style follow-up PR in cio.

## Issue
Closes PetroSa2/petrosa_k8s#594 (P2.3, data-manager side). FR20 — RED → GREEN.

## Divergence metric (operator-review-pending)
The ticket recommends rolling KL divergence and notes "subject to operator review". MVP uses a defensible-but-simpler comparator the operator can evolve:

```
divergence = abs(live_mean - characterized_mean)
             / max(abs(characterized_mean), 1e-9)
```

The epsilon denominator floor prevents divide-by-zero when the characterized mean is exactly 0. The substrate (Service + Publisher + Scheduler + HTTP route) doesn't change when the comparator is swapped for KL later — only `FidelityService.evaluate`'s body does.

## Surface
- `FidelityService.evaluate` — pure compute. UNKNOWN when no characterization OR fewer than `min_samples` (default 10) closed P&L events in the window. Otherwise HEALTHY/UNHEALTHY based on divergence vs threshold (default 0.5).
- `FidelityVerdictPublisher` — per-strategy hysteresis. Only emits when (a) verdict changed AND (b) `stable_ticks_required` consecutive raw ticks of the new verdict. Publish failures roll back hysteresis so retry works on the next tick.
- `FidelityScheduler` — periodic scan (default 5 min); strategy discovery falls back to `mongodb_adapter.list_all_strategy_ids` when no static list.
- `GET /api/v1/strategy/{strategy_id}/fidelity` — on-demand poll, same shape NATS emits.

## CIO consumer follow-up
Out of scope for this PR (matches the W3 wave plan's two-PR pattern for P2.6). CIO's `EvaluatorSubscriber._handle_message` parses `evaluator.{subsystem}.verdict` generically — it will already track `strategy.<id>` verdicts. The per-strategy pause integration in `SignalArbiter` (consulting that subsystem name to skip just-that-strategy's signals) is the natural follow-up.

## Test plan
- [x] No characterization → UNKNOWN (find_filtered not called)
- [x] Fewer than min_samples closed events → UNKNOWN
- [x] HEALTHY when within threshold
- [x] UNHEALTHY when above threshold (reason names the threshold + numbers)
- [x] Zero characterized_mean uses epsilon denominator → still computable
- [x] Threshold parameter flips HEALTHY → UNHEALTHY for the same input
- [x] Disconnected adapter → zero samples → UNKNOWN
- [x] Mongo error swallowed to empty samples → UNKNOWN
- [x] Publisher emits on first stable streak
- [x] Publisher does not republish same verdict
- [x] Flapping never reaches stable streak → no emit
- [x] Publish failure rolls back hysteresis so retry succeeds on next tick
- [x] Publisher truncates reason to 200 chars (NFR-O5)
- [x] Scheduler publishes per-strategy (independent hysteresis per strategy)
- [x] Scheduler survives per-strategy failures
- [x] Scheduler falls back to mongo discovery when no static list
- [x] HTTP route: 503 / 200 / 500 paths

Pipeline: lint + format clean, 19/19 new tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)