### PR TITLE
feat(data-manager): #604 - portfolio state-at-time-T query (P4.4)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -27,6 +27,7 @@ from data_manager.api.routes import (
     health,
     lifecycle,
     pnl,
+    portfolio_state,
     raw,
     schemas,
     strategy_timeline,
@@ -143,6 +144,10 @@ def create_app() -> FastAPI:
     app.include_router(drawdown.router, prefix="/api/v1", tags=["Portfolio"])
     # Strategy-fidelity evaluator (#594 P2.3).
     app.include_router(fidelity.router, prefix="/api/v1", tags=["Strategy Fidelity"])
+    # Portfolio state-at-time-T query (#604 P4.4).
+    app.include_router(
+        portfolio_state.router, prefix="/api/v1", tags=["Portfolio State"]
+    )
 
     # New API routes
     app.include_router(generic.router, tags=["Generic CRUD"])

--- a/data_manager/api/routes/portfolio_state.py
+++ b/data_manager/api/routes/portfolio_state.py
@@ -1,0 +1,56 @@
+"""Portfolio state-at-time-T query endpoint (#604 P4.4).
+
+``GET /api/v1/portfolio/state-at?at=<ts>[&strategy_id=<id>]`` answers the
+operator question "why did the portfolio do X at time T?" by combining
+the cumulative equity reconstruction (P4.1 substrate) with a slice of
+recent decisions / executions / pnl_events leading up to T.
+
+Powers the dashboard time-slider (FR34). The companion endpoint
+``GET /api/v1/lifecycle/{decision_id}`` (#603) drills down from any
+recent_decisions entry into the full per-decision lifecycle.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query
+
+import data_manager.api.app as api_module
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/portfolio/state-at")
+async def get_portfolio_state_at(
+    at: datetime = Query(
+        ..., description="Point-in-time timestamp (ISO 8601, exclusive upper bound)"
+    ),
+    strategy_id: str | None = Query(
+        None, description="Optional strategy filter — omit for portfolio-wide state"
+    ),
+) -> dict:
+    """Compute portfolio state + recent event chain at the given timestamp."""
+    if not api_module.db_manager or not api_module.db_manager.mongodb_adapter:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    try:
+        from data_manager.portfolio.state_service import PortfolioStateService
+
+        service = PortfolioStateService(
+            mongodb_adapter=api_module.db_manager.mongodb_adapter,
+        )
+        result = await service.state_at(at, strategy_id=strategy_id)
+        return result.to_dict()
+    except Exception as e:
+        logger.error(
+            "portfolio_state_endpoint_failed",
+            extra={"at": at.isoformat(), "error": str(e)},
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500, detail="Failed to compute portfolio state-at-time"
+        ) from e

--- a/data_manager/portfolio/__init__.py
+++ b/data_manager/portfolio/__init__.py
@@ -1,8 +1,17 @@
-"""Portfolio-level analytics: drawdown vs characterization envelope (P4.2, #602)."""
+"""Portfolio-level analytics: drawdown surface (#602) + state-at-time-T (#604)."""
 
 from data_manager.portfolio.drawdown_service import (
     DrawdownResult,
     DrawdownService,
 )
+from data_manager.portfolio.state_service import (
+    PortfolioStateAtTime,
+    PortfolioStateService,
+)
 
-__all__ = ["DrawdownResult", "DrawdownService"]
+__all__ = [
+    "DrawdownResult",
+    "DrawdownService",
+    "PortfolioStateAtTime",
+    "PortfolioStateService",
+]

--- a/data_manager/portfolio/state_service.py
+++ b/data_manager/portfolio/state_service.py
@@ -1,0 +1,307 @@
+"""Portfolio state-at-time-T query (P4.4, #604).
+
+Answers the operator question "why did the portfolio do X at time T?"
+by reconstructing two things for a given timestamp ``T``:
+
+  1. **Portfolio state at T** — cumulative realized P&L, latest
+     mark-to-market unrealized P&L, peak equity, current drawdown,
+     and a sketch of open positions (filled minus closed via the
+     execution_events stream).
+
+  2. **Event chain leading up to T** — the last N decisions, the last
+     M execution events, and the last K P&L events, all timestamp
+     ``< T`` and ordered oldest-first within their slice so the
+     operator can read the chain forward.
+
+Optional ``strategy_id`` filter scopes both the state and the chain
+to a single strategy. Without it, the response is portfolio-wide.
+
+The endpoint is operator-facing and read-only. It composes the
+existing storage primitives (``pnl_events``, ``execution_events``,
+``cio_decisions``) via ``MongoDBAdapter.find_filtered`` — no new
+collection or schema needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+if TYPE_CHECKING:
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+logger = logging.getLogger(__name__)
+
+
+PNL_EVENTS_COLLECTION = "pnl_events"
+EXECUTION_EVENTS_COLLECTION = "execution_events"
+CIO_DECISIONS_COLLECTION = "cio_decisions"
+
+DEFAULT_DECISIONS_IN_CHAIN = 20
+DEFAULT_EXECUTIONS_IN_CHAIN = 50
+DEFAULT_PNL_EVENTS_IN_CHAIN = 50
+
+
+@dataclass(slots=True)
+class PortfolioStateAtTime:
+    """Portfolio state + event chain at time T.
+
+    Equity values are in USD per the PnlEvent schema. Drawdown is
+    expressed as positive percent off-peak (consistent with #602's
+    DrawdownResult).
+    """
+
+    at: datetime
+    strategy_id: str | None
+    cumulative_realized_pnl_usd: float
+    latest_unrealized_pnl_usd: float
+    current_equity_usd: float
+    peak_equity_usd: float
+    current_drawdown_pct: float
+    open_positions: list[dict[str, Any]] = field(default_factory=list)
+    recent_decisions: list[dict[str, Any]] = field(default_factory=list)
+    recent_executions: list[dict[str, Any]] = field(default_factory=list)
+    recent_pnl_events: list[dict[str, Any]] = field(default_factory=list)
+    events_evaluated: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "at": self.at.isoformat(),
+            "strategy_id": self.strategy_id,
+            "cumulative_realized_pnl_usd": self.cumulative_realized_pnl_usd,
+            "latest_unrealized_pnl_usd": self.latest_unrealized_pnl_usd,
+            "current_equity_usd": self.current_equity_usd,
+            "peak_equity_usd": self.peak_equity_usd,
+            "current_drawdown_pct": self.current_drawdown_pct,
+            "open_positions": self.open_positions,
+            "recent_decisions": self.recent_decisions,
+            "recent_executions": self.recent_executions,
+            "recent_pnl_events": self.recent_pnl_events,
+            "events_evaluated": self.events_evaluated,
+        }
+
+
+class PortfolioStateService:
+    """Computes portfolio state + event chain at a given timestamp."""
+
+    def __init__(
+        self,
+        mongodb_adapter: MongoDBAdapter,
+        *,
+        decisions_in_chain: int = DEFAULT_DECISIONS_IN_CHAIN,
+        executions_in_chain: int = DEFAULT_EXECUTIONS_IN_CHAIN,
+        pnl_events_in_chain: int = DEFAULT_PNL_EVENTS_IN_CHAIN,
+    ) -> None:
+        self._mongo = mongodb_adapter
+        self._decisions_in_chain = max(1, decisions_in_chain)
+        self._executions_in_chain = max(1, executions_in_chain)
+        self._pnl_events_in_chain = max(1, pnl_events_in_chain)
+
+    async def state_at(
+        self,
+        at: datetime,
+        *,
+        strategy_id: str | None = None,
+    ) -> PortfolioStateAtTime:
+        """Compute the portfolio state at ``at`` plus the chain leading up to it."""
+        pnl_filters: dict[str, Any] = {}
+        if strategy_id is not None:
+            pnl_filters["strategy_id"] = strategy_id
+
+        # Pull every pnl_event up to T (oldest first) for cumulative
+        # equity reconstruction. The same chronological replay shape as
+        # DrawdownService.compute (#602), bounded by ``at`` instead of a
+        # rolling window.
+        pnl_events = await self._fetch_window(
+            PNL_EVENTS_COLLECTION,
+            filters=pnl_filters,
+            end=at,
+            limit=5000,
+            sort_order=1,  # oldest first
+        )
+
+        (
+            cumulative_realized,
+            latest_unrealized,
+            current_equity,
+            peak_equity,
+            drawdown_pct,
+        ) = self._replay_equity(pnl_events)
+
+        # Pull execution events and decisions up to T (newest first,
+        # then slice + reverse for the chain). Newest-first query lets
+        # the limit cap the most recent slice naturally.
+        exec_filters: dict[str, Any] = {}
+        if strategy_id is not None:
+            exec_filters["strategy_id"] = strategy_id
+
+        recent_executions_desc = await self._fetch_window(
+            EXECUTION_EVENTS_COLLECTION,
+            filters=exec_filters,
+            end=at,
+            limit=self._executions_in_chain,
+            sort_order=-1,  # newest first
+        )
+        recent_executions = list(reversed(recent_executions_desc))
+
+        dec_filters: dict[str, Any] = {}
+        if strategy_id is not None:
+            dec_filters["strategy_id"] = strategy_id
+        recent_decisions_desc = await self._fetch_window(
+            CIO_DECISIONS_COLLECTION,
+            filters=dec_filters,
+            end=at,
+            limit=self._decisions_in_chain,
+            sort_order=-1,
+        )
+        recent_decisions = list(reversed(recent_decisions_desc))
+
+        # The recent P&L slice is independent of the cumulative replay
+        # — operators may want a tail-of-N P&L events even when the
+        # cumulative scan walked thousands. Take from the tail of the
+        # already-fetched pnl_events to avoid a second query.
+        recent_pnl_events = pnl_events[-self._pnl_events_in_chain :]
+
+        open_positions = self._infer_open_positions(recent_executions_desc)
+
+        return PortfolioStateAtTime(
+            at=at,
+            strategy_id=strategy_id,
+            cumulative_realized_pnl_usd=cumulative_realized,
+            latest_unrealized_pnl_usd=latest_unrealized,
+            current_equity_usd=current_equity,
+            peak_equity_usd=peak_equity,
+            current_drawdown_pct=drawdown_pct,
+            open_positions=open_positions,
+            recent_decisions=recent_decisions,
+            recent_executions=recent_executions,
+            recent_pnl_events=recent_pnl_events,
+            events_evaluated=len(pnl_events),
+        )
+
+    def _replay_equity(
+        self, pnl_events: list[dict[str, Any]]
+    ) -> tuple[float, float, float, float, float]:
+        """Chronologically replay the equity series. Same rules as #602's
+        DrawdownService — realized accumulates, mark_to_market overwrites
+        the unrealized component, aggregate folds into realized.
+
+        Returns: (cumulative_realized, latest_unrealized, current_equity,
+        peak_equity, drawdown_pct).
+        """
+        cumulative_realized = 0.0
+        latest_unrealized = 0.0
+        peak_equity = 0.0
+        current_equity = 0.0
+        for ev in pnl_events:
+            kind = (ev.get("pnl_kind") or "").lower()
+            realized = float(ev.get("realized_pnl_usd") or 0.0)
+            unrealized = float(ev.get("unrealized_pnl_usd") or 0.0)
+            if kind == "closed":
+                cumulative_realized += realized
+            elif kind == "mark_to_market":
+                latest_unrealized = unrealized
+            elif kind == "aggregate":
+                cumulative_realized += realized
+                if unrealized != 0.0:
+                    latest_unrealized = unrealized
+            else:
+                if realized:
+                    cumulative_realized += realized
+                if unrealized:
+                    latest_unrealized = unrealized
+            current_equity = cumulative_realized + latest_unrealized
+            if current_equity > peak_equity:
+                peak_equity = current_equity
+        drawdown_pct = 0.0
+        if peak_equity > 0:
+            drawdown_pct = max(
+                0.0,
+                (peak_equity - current_equity) / peak_equity * 100.0,
+            )
+        return (
+            cumulative_realized,
+            latest_unrealized,
+            current_equity,
+            peak_equity,
+            drawdown_pct,
+        )
+
+    def _infer_open_positions(
+        self, executions_desc: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Sketch of which orders look "still open" at ``at``.
+
+        Heuristic: an order_id is open iff its most recent
+        ``event_type`` (looking newest-first) is ``"filled"`` or
+        ``"partial_fill"`` AND we have NOT yet seen a later
+        ``"closed"`` / ``"cancelled"`` for it. This is a sketch — the
+        execution event stream may have multiple intermediate states
+        between fill and close, and a fully accurate position read
+        would replay the entire history. For the operator's "why at T"
+        view, the recent-slice sketch is enough to surface "look, here
+        are the strategies with open exposure right now".
+        """
+        seen: dict[str, dict[str, Any]] = {}
+        for ev in executions_desc:
+            oid = ev.get("order_id")
+            if not oid or oid in seen:
+                continue
+            evt = (ev.get("event_type") or "").lower()
+            if evt in ("filled", "partial_fill"):
+                seen[oid] = {
+                    "order_id": oid,
+                    "strategy_id": ev.get("strategy_id"),
+                    "symbol": ev.get("symbol"),
+                    "event_type": evt,
+                    "timestamp": _maybe_iso(ev.get("timestamp")),
+                }
+            else:
+                # Mark as "seen but closed/cancelled" — skip it from
+                # the open list.
+                seen[oid] = {}
+        return [v for v in seen.values() if v]
+
+    async def _fetch_window(
+        self,
+        collection: str,
+        *,
+        filters: dict[str, Any],
+        end: datetime,
+        limit: int,
+        sort_order: int,
+    ) -> list[dict[str, Any]]:
+        if self._mongo is None or not getattr(self._mongo, "_connected", False):
+            return []
+        try:
+            return await self._mongo.find_filtered(
+                collection,
+                filters=filters,
+                end=end,
+                limit=limit,
+                sort_field="timestamp",
+                sort_order=sort_order,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error(
+                "portfolio_state_fetch_failed",
+                extra={"collection": collection, "error": str(e)},
+            )
+            return []
+
+
+def _maybe_iso(value: Any) -> str | None:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, str):
+        return value
+    return None

--- a/tests/test_portfolio_state_at_time.py
+++ b/tests/test_portfolio_state_at_time.py
@@ -1,0 +1,388 @@
+"""Tests for the portfolio state-at-time-T query (#604 P4.4).
+
+Covers:
+  * ``PortfolioStateService.state_at`` — equity replay matches the
+    #602 rules, recent-events slices are bounded and ordered correctly,
+    strategy_id scopes the query, open-position inference behaves on
+    the filled→closed transition.
+  * HTTP route — 200 / 422 / 500 / 503 paths and the ``at`` parameter
+    handling.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from data_manager.portfolio.state_service import (
+    PortfolioStateAtTime,
+    PortfolioStateService,
+)
+
+NOW = datetime(2026, 5, 21, 12, 0, tzinfo=UTC)
+AT_T = NOW + timedelta(hours=1)  # the query timestamp
+
+
+# ---------------------------------------------------------------------------
+# Adapter stub
+# ---------------------------------------------------------------------------
+
+
+def _adapter_with_collections(returns: dict[str, list[dict]]):
+    """Stub MongoDB adapter where ``find_filtered`` returns a per-collection list.
+
+    The ``returns`` mapping is keyed by collection name. ``find_filtered``
+    inspects the first positional arg (collection name) to pick the right
+    response.
+    """
+    adapter = MagicMock()
+    adapter._connected = True
+
+    async def find_filtered(collection, **kwargs):
+        # Honor sort_order: newest-first reverses the chronological list.
+        docs = list(returns.get(collection, []))
+        sort_order = kwargs.get("sort_order", -1)
+        # Stored chronological; if newest-first requested, reverse.
+        if sort_order == -1:
+            docs = list(reversed(docs))
+        limit = kwargs.get("limit", 1000)
+        return docs[:limit]
+
+    adapter.find_filtered = AsyncMock(side_effect=find_filtered)
+    return adapter
+
+
+def _pnl(kind: str, *, realized=0.0, unrealized=0.0, offset_min=0):
+    return {
+        "pnl_kind": kind,
+        "realized_pnl_usd": realized,
+        "unrealized_pnl_usd": unrealized,
+        "timestamp": NOW + timedelta(minutes=offset_min),
+    }
+
+
+def _exec(order_id: str, event_type: str, *, offset_min=0, strategy_id="ta-momentum"):
+    return {
+        "order_id": order_id,
+        "event_type": event_type,
+        "strategy_id": strategy_id,
+        "symbol": "BTCUSDT",
+        "timestamp": NOW + timedelta(minutes=offset_min),
+    }
+
+
+def _decision(decision_id: str, action: str = "execute", *, offset_min=0):
+    return {
+        "decision_id": decision_id,
+        "action": action,
+        "strategy_id": "ta-momentum",
+        "timestamp": NOW + timedelta(minutes=offset_min),
+    }
+
+
+# ---------------------------------------------------------------------------
+# PortfolioStateService.state_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_state_at_empty_window_yields_zeroes():
+    adapter = _adapter_with_collections({})
+    svc = PortfolioStateService(mongodb_adapter=adapter)
+
+    result = await svc.state_at(AT_T)
+    assert result.events_evaluated == 0
+    assert result.cumulative_realized_pnl_usd == 0.0
+    assert result.peak_equity_usd == 0.0
+    assert result.current_drawdown_pct == 0.0
+    assert result.recent_decisions == []
+    assert result.open_positions == []
+
+
+@pytest.mark.asyncio
+async def test_state_at_computes_cumulative_realized_and_unrealized():
+    pnl_events = [
+        _pnl("closed", realized=100.0, offset_min=0),
+        _pnl("closed", realized=50.0, offset_min=10),
+        _pnl("mark_to_market", unrealized=25.0, offset_min=20),
+        _pnl("closed", realized=-30.0, offset_min=30),
+        _pnl("mark_to_market", unrealized=10.0, offset_min=40),
+    ]
+    adapter = _adapter_with_collections({"pnl_events": pnl_events})
+    svc = PortfolioStateService(mongodb_adapter=adapter)
+
+    result = await svc.state_at(AT_T)
+    # Realized: 100 + 50 - 30 = 120
+    # Latest unrealized: 10 (last m2m)
+    assert result.cumulative_realized_pnl_usd == pytest.approx(120.0)
+    assert result.latest_unrealized_pnl_usd == pytest.approx(10.0)
+    assert result.current_equity_usd == pytest.approx(130.0)
+    # Peak happens at offset 20 — right after the +25 m2m snap when
+    # realized was already 150 (from the two closed events): 150 + 25 = 175.
+    assert result.peak_equity_usd == pytest.approx(175.0)
+    # Drawdown: (175 - 130) / 175 * 100 ≈ 25.71%
+    assert result.current_drawdown_pct == pytest.approx((175 - 130) / 175 * 100)
+
+
+@pytest.mark.asyncio
+async def test_state_at_threads_end_time_filter_to_find_filtered():
+    """Every find_filtered call must have ``end=at`` so events after T
+    don't leak into the reconstruction."""
+    adapter = _adapter_with_collections({"pnl_events": [_pnl("closed", realized=1.0)]})
+    svc = PortfolioStateService(mongodb_adapter=adapter)
+
+    await svc.state_at(AT_T)
+    # find_filtered called for pnl_events + execution_events + decisions = 3 times.
+    assert adapter.find_filtered.await_count == 3
+    for call in adapter.find_filtered.call_args_list:
+        kwargs = call.kwargs
+        assert kwargs["end"] == AT_T
+
+
+@pytest.mark.asyncio
+async def test_state_at_threads_strategy_id_filter():
+    """When ``strategy_id`` is supplied, every find_filtered call's
+    ``filters`` must include it."""
+    adapter = _adapter_with_collections({})
+    svc = PortfolioStateService(mongodb_adapter=adapter)
+
+    await svc.state_at(AT_T, strategy_id="ta-momentum")
+    for call in adapter.find_filtered.call_args_list:
+        filters = call.kwargs["filters"]
+        assert filters.get("strategy_id") == "ta-momentum"
+
+
+@pytest.mark.asyncio
+async def test_state_at_strategy_id_none_omits_filter():
+    """Without strategy_id, the find_filtered ``filters`` map must be empty
+    so the query is portfolio-wide."""
+    adapter = _adapter_with_collections({})
+    svc = PortfolioStateService(mongodb_adapter=adapter)
+
+    await svc.state_at(AT_T)
+    for call in adapter.find_filtered.call_args_list:
+        filters = call.kwargs["filters"]
+        assert "strategy_id" not in filters
+
+
+@pytest.mark.asyncio
+async def test_state_at_chains_recent_events_oldest_first():
+    """The recent_decisions / recent_executions slices must be ordered
+    oldest-first within the slice so the operator reads forward through
+    the chain."""
+    decisions = [
+        _decision("d-1", offset_min=0),
+        _decision("d-2", offset_min=10),
+        _decision("d-3", offset_min=20),
+    ]
+    executions = [
+        _exec("o-1", "placed", offset_min=5),
+        _exec("o-1", "filled", offset_min=10),
+        _exec("o-2", "placed", offset_min=20),
+    ]
+    adapter = _adapter_with_collections(
+        {"cio_decisions": decisions, "execution_events": executions}
+    )
+    svc = PortfolioStateService(mongodb_adapter=adapter)
+
+    result = await svc.state_at(AT_T)
+    assert [d["decision_id"] for d in result.recent_decisions] == ["d-1", "d-2", "d-3"]
+    assert [e["event_type"] for e in result.recent_executions] == [
+        "placed",
+        "filled",
+        "placed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_state_at_infers_open_positions_from_filled_orders():
+    """Orders whose latest event_type is filled/partial_fill are 'open';
+    those followed by closed/cancelled are NOT in the open list."""
+    executions = [
+        _exec("o-open", "placed", offset_min=0),
+        _exec("o-open", "filled", offset_min=5),
+        _exec("o-closed", "placed", offset_min=10),
+        _exec("o-closed", "filled", offset_min=15),
+        _exec("o-closed", "closed", offset_min=20),
+    ]
+    adapter = _adapter_with_collections({"execution_events": executions})
+    svc = PortfolioStateService(mongodb_adapter=adapter)
+
+    result = await svc.state_at(AT_T)
+    open_ids = {p["order_id"] for p in result.open_positions}
+    assert open_ids == {"o-open"}
+
+
+@pytest.mark.asyncio
+async def test_state_at_respects_chain_limits():
+    """Configurable chain limits truncate the recent slices."""
+    decisions = [_decision(f"d-{i}", offset_min=i) for i in range(50)]
+    adapter = _adapter_with_collections({"cio_decisions": decisions})
+    svc = PortfolioStateService(
+        mongodb_adapter=adapter,
+        decisions_in_chain=5,
+        executions_in_chain=5,
+        pnl_events_in_chain=5,
+    )
+
+    result = await svc.state_at(AT_T)
+    # Newest-5 of 50, then re-ordered oldest-first within the slice.
+    assert len(result.recent_decisions) == 5
+    assert [d["decision_id"] for d in result.recent_decisions] == [
+        "d-45",
+        "d-46",
+        "d-47",
+        "d-48",
+        "d-49",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_state_at_returns_empty_when_adapter_disconnected():
+    adapter = MagicMock()
+    adapter._connected = False
+    svc = PortfolioStateService(mongodb_adapter=adapter)
+
+    result = await svc.state_at(AT_T)
+    assert result.events_evaluated == 0
+    assert result.recent_decisions == []
+
+
+@pytest.mark.asyncio
+async def test_state_at_swallows_adapter_errors_per_collection():
+    """A failure on one find_filtered call mustn't kill the whole query —
+    each collection fetch is independently swallowed to []."""
+    adapter = MagicMock()
+    adapter._connected = True
+    adapter.find_filtered = AsyncMock(side_effect=RuntimeError("mongo hiccup"))
+    svc = PortfolioStateService(mongodb_adapter=adapter)
+
+    result = await svc.state_at(AT_T)
+    assert result.events_evaluated == 0
+    assert result.recent_decisions == []
+
+
+# ---------------------------------------------------------------------------
+# HTTP route
+# ---------------------------------------------------------------------------
+
+
+def _client_with_db(db_manager):
+    from fastapi.testclient import TestClient
+
+    import data_manager.api.app as api_module
+    from data_manager.api.app import create_app
+
+    api_module.db_manager = db_manager
+    return TestClient(create_app())
+
+
+def test_route_503_when_db_missing():
+    client = _client_with_db(None)
+    r = client.get(
+        "/api/v1/portfolio/state-at",
+        params={"at": "2026-05-21T12:00:00+00:00"},
+    )
+    assert r.status_code == 503
+
+
+def test_route_requires_at_param():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    client = _client_with_db(db)
+    r = client.get("/api/v1/portfolio/state-at")
+    assert r.status_code == 422
+
+
+def test_route_returns_state_payload():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    fake = PortfolioStateAtTime(
+        at=AT_T,
+        strategy_id=None,
+        cumulative_realized_pnl_usd=100.0,
+        latest_unrealized_pnl_usd=10.0,
+        current_equity_usd=110.0,
+        peak_equity_usd=120.0,
+        current_drawdown_pct=8.33,
+        open_positions=[],
+        recent_decisions=[],
+        recent_executions=[],
+        recent_pnl_events=[],
+        events_evaluated=5,
+    )
+    with patch(
+        "data_manager.portfolio.state_service.PortfolioStateService.state_at",
+        new=AsyncMock(return_value=fake),
+    ) as mock_state:
+        client = _client_with_db(db)
+        r = client.get(
+            "/api/v1/portfolio/state-at",
+            params={"at": "2026-05-21T13:00:00+00:00"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["events_evaluated"] == 5
+    assert body["cumulative_realized_pnl_usd"] == 100.0
+    mock_state.assert_awaited_once()
+    kwargs = mock_state.await_args.kwargs
+    assert kwargs["strategy_id"] is None
+    args = mock_state.await_args.args
+    assert args[0] == AT_T
+
+
+def test_route_threads_strategy_id():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    fake = PortfolioStateAtTime(
+        at=AT_T,
+        strategy_id="ta-momentum",
+        cumulative_realized_pnl_usd=0.0,
+        latest_unrealized_pnl_usd=0.0,
+        current_equity_usd=0.0,
+        peak_equity_usd=0.0,
+        current_drawdown_pct=0.0,
+    )
+    with patch(
+        "data_manager.portfolio.state_service.PortfolioStateService.state_at",
+        new=AsyncMock(return_value=fake),
+    ) as mock_state:
+        client = _client_with_db(db)
+        r = client.get(
+            "/api/v1/portfolio/state-at",
+            params={
+                "at": "2026-05-21T13:00:00+00:00",
+                "strategy_id": "ta-momentum",
+            },
+        )
+    assert r.status_code == 200
+    kwargs = mock_state.await_args.kwargs
+    assert kwargs["strategy_id"] == "ta-momentum"
+
+
+def test_route_500_when_service_raises():
+    db = MagicMock()
+    db.mongodb_adapter = MagicMock()
+    db.mysql_adapter = MagicMock()
+    with patch(
+        "data_manager.portfolio.state_service.PortfolioStateService.state_at",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        client = _client_with_db(db)
+        r = client.get(
+            "/api/v1/portfolio/state-at",
+            params={"at": "2026-05-21T13:00:00+00:00"},
+        )
+    assert r.status_code == 500


### PR DESCRIPTION
## Summary
- Answers the operator question "why did the portfolio do X at time T?" with a point-in-time reconstruction: portfolio state at T (cumulative realized P&L, latest m2m unrealized, current/peak equity, drawdown_pct, open-position sketch) + the event chain leading up to T (last N decisions, M executions, K pnl_events, oldest-first within each slice).
- Powers the dashboard time-slider (FR34); dovetails with #603 — any `recent_decisions[i].decision_id` from the response drills into `/api/v1/lifecycle/{decision_id}` for full per-decision lifecycle.

## Issue
Closes PetroSa2/petrosa_k8s#604 (P4.4). FR26 — RED → GREEN. Enables NFR-P1 ≤ 5-minute audit query.

## Surface
- `data_manager/portfolio/state_service.py:PortfolioStateService.state_at(at, strategy_id=None)` — pure compute. Time-bounded by `at` (exclusive upper bound) via `find_filtered`'s `end` arg. Optional `strategy_id` scopes both the equity replay and the recent slices. Open-position inference: an order_id is "open" iff its most recent event_type (newest-first) is filled/partial_fill and we haven't yet seen a later closed/cancelled — a sketch good enough for the operator's "what was on the books at T" view.
- `GET /api/v1/portfolio/state-at?at=<ts>[&strategy_id=<id>]` — FastAPI route exposing `PortfolioStateAtTime.to_dict()`.

## Test plan
- [x] Empty window → zeroes, no event chain entries
- [x] Cumulative realized + latest unrealized + peak + drawdown math
- [x] `end=at` threaded to every find_filtered call (events strictly < T)
- [x] `strategy_id` filter threaded to every find_filtered call
- [x] No strategy_id → filters map omits the key (portfolio-wide)
- [x] Event chains ordered oldest-first within each slice
- [x] Open positions inference: filled remains open, filled→closed disappears
- [x] Chain limits truncate to the configured size (newest-N then re-ordered)
- [x] Disconnected adapter → empty result
- [x] Per-collection find_filtered failure swallowed independently
- [x] HTTP: 503 / 422 (missing `at`) / 200 / 500 paths
- [x] HTTP: `strategy_id` threaded through

Pipeline: lint + format clean, 15/15 new tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)