### PR TITLE
feat(dashboard): 648 - strategy lifecycle view (P5.1e)

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -27,8 +27,8 @@ export default function App() {
               <NavLink to="/time/now" className={navLinkClass}>
                 time
               </NavLink>
-              <NavLink to="/strategy/_" className={navLinkClass}>
-                strategy
+              <NavLink to="/strategies" className={navLinkClass}>
+                strategies
               </NavLink>
             </nav>
           </div>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -136,3 +136,62 @@ export function fetchRecentDecisions(
     `/api/dashboard/decisions/recent?window=${window}`,
   );
 }
+
+// Per-strategy lifecycle timeline (FR36, P5.1e). The data-manager route
+// returns chronologically-merged events from six audit-trail collections;
+// payload shape is intentionally loose because each event type carries its
+// own per-source fields.
+export type TimelineEventType =
+  | "config"
+  | "characterization"
+  | "lifecycle"
+  | "intent"
+  | "decision"
+  | "execution";
+
+export interface TimelineEvent {
+  ts: string;
+  type: TimelineEventType;
+  source: string;
+  event_id: string;
+  payload: Record<string, unknown>;
+}
+
+export interface StrategyLifecyclePayload {
+  strategy_id: string;
+  events: TimelineEvent[];
+  window: string | null;
+  next_cursor: string | null;
+}
+
+export function fetchStrategyLifecycle(
+  strategy_id: string,
+  options: { window?: string | null; types?: TimelineEventType[] } = {},
+): Promise<StrategyLifecyclePayload> {
+  const q = new URLSearchParams();
+  // Omit window to get full history; pass an explicit value when the caller
+  // wants a rolling window.
+  if (options.window !== undefined && options.window !== null) {
+    q.set("window", options.window);
+  }
+  if (options.types && options.types.length > 0) {
+    q.set("types", options.types.join(","));
+  }
+  q.set("limit", "200");
+  const qs = q.toString();
+  return getJson<StrategyLifecyclePayload>(
+    `/api/dashboard/strategy/${encodeURIComponent(strategy_id)}/lifecycle${qs ? `?${qs}` : ""}`,
+  );
+}
+
+// Strategy index. The data-manager `/api/v1/config/strategies` route returns
+// every strategy known to the configuration store. P5.1a never shipped a
+// dedicated dashboard-side list endpoint; the SPA derives current_state per
+// strategy by fanning out lifecycle queries on top of this list (#648 P5.1e).
+export interface StrategyListPayload {
+  strategy_ids: string[];
+}
+
+export function fetchStrategyList(): Promise<StrategyListPayload> {
+  return getJson<StrategyListPayload>(`/api/v1/config/strategies`);
+}

--- a/dashboard/src/lib/strategyState.ts
+++ b/dashboard/src/lib/strategyState.ts
@@ -1,0 +1,155 @@
+import type { TimelineEvent } from "./api";
+
+// Strategy lifecycle states. The vocabulary is the producer's verbatim enum
+// (petrosa-cio/cio/core/lifecycle.py::LifecycleState). The ticket's draft
+// list ("trial") is reconciled to the actual producer value ("on_trial").
+export type StrategyState =
+  | "registered"
+  | "characterized"
+  | "admitted"
+  | "on_trial"
+  | "graduated"
+  | "demoted"
+  | "retired"
+  | "rejected"
+  | "unknown";
+
+// One state transition derived from a single lifecycle / characterization
+// event. Auxiliary types (config, intent, decision, execution) are not state
+// transitions and are excluded by the API call's `types` filter.
+export interface StrategyTransition {
+  ts: string;
+  state: StrategyState;
+  // Verbatim source-of-truth text from the producer. Empty string when the
+  // event has no reasoning attached — never substitute filler copy.
+  reason: string;
+  decision_id: string | null;
+  event_id: string;
+  event_type: TimelineEvent["type"];
+}
+
+const KNOWN_STATES = new Set<StrategyState>([
+  "registered",
+  "characterized",
+  "admitted",
+  "on_trial",
+  "graduated",
+  "demoted",
+  "retired",
+  "rejected",
+]);
+
+function asKnownState(raw: unknown): StrategyState {
+  if (typeof raw !== "string") return "unknown";
+  return KNOWN_STATES.has(raw as StrategyState)
+    ? (raw as StrategyState)
+    : "unknown";
+}
+
+function asString(raw: unknown): string {
+  return typeof raw === "string" ? raw : "";
+}
+
+function reasoningToText(raw: unknown): string {
+  // The producer's `reasoning` is a free-form dict; the operator-facing view
+  // serializes it verbatim per NFR-O5. A plain string passes through; a dict
+  // is JSON-stringified so nothing is silently dropped.
+  if (raw === undefined || raw === null) return "";
+  if (typeof raw === "string") return raw;
+  try {
+    return JSON.stringify(raw);
+  } catch {
+    return "";
+  }
+}
+
+// Map a single timeline event to a transition, or null when the event does
+// not represent a state change. `lifecycle` events carry `to_state`;
+// `characterization` events implicitly mark the strategy as characterized.
+function eventToTransition(e: TimelineEvent): StrategyTransition | null {
+  if (e.type === "lifecycle") {
+    const state = asKnownState(e.payload.to_state);
+    return {
+      ts: e.ts,
+      state,
+      reason: reasoningToText(e.payload.reasoning),
+      decision_id: asString(e.payload.decision_id) || null,
+      event_id: e.event_id,
+      event_type: "lifecycle",
+    };
+  }
+  if (e.type === "characterization") {
+    return {
+      ts: e.ts,
+      state: "characterized",
+      reason: reasoningToText(e.payload.summary ?? e.payload.notes),
+      decision_id: null,
+      event_id: e.event_id,
+      event_type: "characterization",
+    };
+  }
+  return null;
+}
+
+// Walks events in chronological order and produces:
+// - `state`: the most-recent known state (defaults to `registered` when at
+//   least one config audit row exists, else `unknown`).
+// - `lastTransitionAt`: ISO timestamp of the most-recent transition, or null.
+// - `transitions`: filtered list of lifecycle + characterization transitions,
+//   ascending by ts.
+export interface DerivedState {
+  state: StrategyState;
+  lastTransitionAt: string | null;
+  transitions: StrategyTransition[];
+}
+
+export function deriveCurrentState(events: TimelineEvent[]): DerivedState {
+  const transitions: StrategyTransition[] = [];
+  let hasConfig = false;
+  for (const e of events) {
+    if (e.type === "config") hasConfig = true;
+    const t = eventToTransition(e);
+    if (t) transitions.push(t);
+  }
+  // The API sorts ascending by (ts, event_id); preserve that order here.
+  transitions.sort((a, b) =>
+    a.ts === b.ts ? a.event_id.localeCompare(b.event_id) : a.ts.localeCompare(b.ts),
+  );
+
+  const last = transitions.length > 0 ? transitions[transitions.length - 1] : null;
+  if (last) {
+    return {
+      state: last.state,
+      lastTransitionAt: last.ts,
+      transitions,
+    };
+  }
+  return {
+    state: hasConfig ? "registered" : "unknown",
+    lastTransitionAt: null,
+    transitions,
+  };
+}
+
+// Tailwind colour class for a state badge. Centralised so the detail view
+// and the index page render identically.
+export function stateBadgeClass(state: StrategyState): string {
+  switch (state) {
+    case "graduated":
+      return "bg-emerald-900/60 text-emerald-200 border-emerald-700/60";
+    case "admitted":
+    case "on_trial":
+      return "bg-sky-900/60 text-sky-200 border-sky-700/60";
+    case "characterized":
+      return "bg-indigo-900/60 text-indigo-200 border-indigo-700/60";
+    case "registered":
+      return "bg-slate-800 text-slate-200 border-slate-700";
+    case "demoted":
+      return "bg-amber-900/60 text-amber-200 border-amber-700/60";
+    case "retired":
+    case "rejected":
+      return "bg-rose-900/60 text-rose-200 border-rose-700/60";
+    default:
+      return "bg-slate-800 text-slate-400 border-slate-700";
+  }
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -6,6 +6,7 @@ import App from "./App";
 import Home from "./routes/Home";
 import TimeSlider from "./routes/TimeSlider";
 import Strategy from "./routes/Strategy";
+import Strategies from "./routes/Strategies";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
@@ -15,6 +16,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <Route path="/" element={<App />}>
           <Route index element={<Home />} />
           <Route path="time/:t" element={<TimeSlider />} />
+          <Route path="strategies" element={<Strategies />} />
           <Route path="strategy/:id" element={<Strategy />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>

--- a/dashboard/src/routes/Strategies.tsx
+++ b/dashboard/src/routes/Strategies.tsx
@@ -1,0 +1,286 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  ApiError,
+  fetchStrategyLifecycle,
+  fetchStrategyList,
+  type StrategyLifecyclePayload,
+} from "../lib/api";
+import { useEndpoint } from "../lib/useEndpoint";
+import { formatRelativeTime } from "../lib/format";
+import {
+  deriveCurrentState,
+  stateBadgeClass,
+  type DerivedState,
+  type StrategyState,
+} from "../lib/strategyState";
+
+type SortKey = "id" | "state" | "ts";
+type SortDir = "asc" | "desc";
+
+interface StrategyRow {
+  strategy_id: string;
+  state: StrategyState;
+  lastTransitionAt: string | null;
+  error: ApiError | null;
+}
+
+// Per-strategy lifecycle fan-out. The list is small (a handful in steady
+// state; tens at most under MVP load), so a parallel fetch per row is fine.
+// If the count ever grows past O(50) this should move to a dedicated
+// pre-aggregated `/api/dashboard/strategies` route — capture as a follow-up.
+function fetchStrategyRows(ids: string[]): Promise<StrategyRow[]> {
+  return Promise.all(
+    ids.map((id) =>
+      fetchStrategyLifecycle(id, {
+        window: null,
+        types: ["lifecycle", "characterization"],
+      })
+        .then((payload: StrategyLifecyclePayload) => {
+          const derived: DerivedState = deriveCurrentState(payload.events);
+          return {
+            strategy_id: id,
+            state: derived.state,
+            lastTransitionAt: derived.lastTransitionAt,
+            error: null,
+          };
+        })
+        .catch((e: unknown) => ({
+          strategy_id: id,
+          state: "unknown" as StrategyState,
+          lastTransitionAt: null,
+          error:
+            e instanceof ApiError
+              ? e
+              : new ApiError(0, null, (e as Error).message),
+        })),
+    ),
+  );
+}
+
+const HEADER_CLS =
+  "px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wider text-slate-400";
+const CELL_CLS = "px-3 py-2 text-sm";
+
+function SortableHeader({
+  label,
+  sortKey,
+  current,
+  dir,
+  onSort,
+}: {
+  label: string;
+  sortKey: SortKey;
+  current: SortKey;
+  dir: SortDir;
+  onSort: (k: SortKey) => void;
+}) {
+  const active = current === sortKey;
+  const arrow = active ? (dir === "asc" ? "↑" : "↓") : "";
+  return (
+    <th className={HEADER_CLS}>
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={`flex items-center gap-1 ${
+          active ? "text-slate-200" : "text-slate-400 hover:text-slate-200"
+        }`}
+      >
+        {label} {arrow && <span aria-hidden>{arrow}</span>}
+      </button>
+    </th>
+  );
+}
+
+export default function Strategies() {
+  const list = useEndpoint(fetchStrategyList, 30_000);
+  const ids = useMemo(() => list.data?.strategy_ids ?? [], [list.data]);
+
+  const [rows, setRows] = useState<StrategyRow[] | null>(null);
+  const [rowsLoading, setRowsLoading] = useState<boolean>(false);
+  const [rowsError, setRowsError] = useState<ApiError | null>(null);
+
+  // Re-fan-out whenever the id list mutates. Stale resolutions are dropped
+  // via the alive flag (mirrors useEndpoint's pattern).
+  useEffect(() => {
+    if (ids.length === 0) {
+      setRows(list.data ? [] : null);
+      return;
+    }
+    let alive = true;
+    setRowsLoading(true);
+    fetchStrategyRows(ids)
+      .then((next) => {
+        if (!alive) return;
+        setRows(next);
+        setRowsError(null);
+      })
+      .catch((e: unknown) => {
+        if (!alive) return;
+        setRowsError(
+          e instanceof ApiError ? e : new ApiError(0, null, (e as Error).message),
+        );
+      })
+      .finally(() => {
+        if (alive) setRowsLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [ids, list.data]);
+
+  const [sortKey, setSortKey] = useState<SortKey>("id");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const onSort = useCallback(
+    (k: SortKey) => {
+      if (k === sortKey) {
+        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      } else {
+        setSortKey(k);
+        setSortDir("asc");
+      }
+    },
+    [sortKey],
+  );
+
+  const sorted = useMemo(() => {
+    if (!rows) return null;
+    const out = [...rows];
+    out.sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === "id") {
+        cmp = a.strategy_id.localeCompare(b.strategy_id);
+      } else if (sortKey === "state") {
+        cmp = a.state.localeCompare(b.state);
+      } else {
+        // ts: null sorts last regardless of direction.
+        const at = a.lastTransitionAt;
+        const bt = b.lastTransitionAt;
+        if (at === null && bt === null) cmp = 0;
+        else if (at === null) cmp = 1;
+        else if (bt === null) cmp = -1;
+        else cmp = at.localeCompare(bt);
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return out;
+  }, [rows, sortKey, sortDir]);
+
+  return (
+    <section className="space-y-4">
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-2xl font-semibold text-slate-100">
+          operator · strategies
+        </h1>
+        <p className="text-xs text-slate-500">
+          live · current lifecycle state per strategy
+        </p>
+      </header>
+
+      <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-4">
+        {list.error && !list.data && (
+          <p className="text-xs text-rose-400">
+            unable to load list — {list.error.message}
+          </p>
+        )}
+        {!list.data && !list.error && (
+          <div className="flex items-center gap-2 text-sm text-slate-400">
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-slate-500" />
+            <span>waiting on /api/v1/config/strategies…</span>
+          </div>
+        )}
+        {list.data && ids.length === 0 && (
+          <p className="text-xs text-slate-400">
+            no strategies registered in the configuration store yet.
+          </p>
+        )}
+
+        {rowsError && (
+          <p className="mt-3 text-xs text-rose-400">
+            unable to fetch per-strategy lifecycle — {rowsError.message}
+          </p>
+        )}
+
+        {sorted && sorted.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr className="border-b border-slate-800">
+                  <SortableHeader
+                    label="strategy id"
+                    sortKey="id"
+                    current={sortKey}
+                    dir={sortDir}
+                    onSort={onSort}
+                  />
+                  <SortableHeader
+                    label="current state"
+                    sortKey="state"
+                    current={sortKey}
+                    dir={sortDir}
+                    onSort={onSort}
+                  />
+                  <SortableHeader
+                    label="last transition"
+                    sortKey="ts"
+                    current={sortKey}
+                    dir={sortDir}
+                    onSort={onSort}
+                  />
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((r) => (
+                  <tr
+                    key={r.strategy_id}
+                    className="border-b border-slate-800/60 hover:bg-slate-900/60"
+                  >
+                    <td className={CELL_CLS}>
+                      <Link
+                        to={`/strategy/${encodeURIComponent(r.strategy_id)}`}
+                        className="font-mono text-sky-400 hover:underline"
+                      >
+                        {r.strategy_id}
+                      </Link>
+                    </td>
+                    <td className={CELL_CLS}>
+                      <span
+                        className={`rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider ${stateBadgeClass(
+                          r.state,
+                        )}`}
+                      >
+                        {r.state}
+                      </span>
+                      {r.error && (
+                        <span className="ml-2 text-[10px] text-rose-400">
+                          fetch failed
+                        </span>
+                      )}
+                    </td>
+                    <td className={`${CELL_CLS} text-slate-300`}>
+                      {r.lastTransitionAt ? (
+                        <>
+                          <span>{formatRelativeTime(r.lastTransitionAt)}</span>
+                          <span className="ml-2 text-[10px] text-slate-500">
+                            {r.lastTransitionAt}
+                          </span>
+                        </>
+                      ) : (
+                        <span className="text-slate-500">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {rowsLoading && (
+              <p className="mt-3 text-[10px] text-slate-500" aria-live="polite">
+                refreshing per-strategy lifecycle…
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/routes/Strategy.tsx
+++ b/dashboard/src/routes/Strategy.tsx
@@ -1,25 +1,216 @@
-import { useParams } from "react-router-dom";
+import { useCallback, useMemo } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  ApiError,
+  fetchStrategyLifecycle,
+  type StrategyLifecyclePayload,
+  type TimelineEventType,
+} from "../lib/api";
+import { useEndpoint } from "../lib/useEndpoint";
+import { formatRelativeTime } from "../lib/format";
+import {
+  deriveCurrentState,
+  stateBadgeClass,
+  type StrategyTransition,
+} from "../lib/strategyState";
+
+// Only the state-change event types are rendered here. Auxiliary types
+// (config, intent, decision, execution) come back from the same endpoint
+// but would dominate the visual timeline; the index page links to them via
+// the time slider instead.
+const STATE_EVENT_TYPES: TimelineEventType[] = ["lifecycle", "characterization"];
+
+function TransitionRow({ transition }: { transition: StrategyTransition }) {
+  const navigate = useNavigate();
+  const open = useCallback(() => {
+    navigate(`/time/${encodeURIComponent(transition.ts)}`);
+  }, [navigate, transition.ts]);
+
+  const badge = stateBadgeClass(transition.state);
+  return (
+    <li className="border-t border-slate-800/70 first:border-t-0">
+      <button
+        type="button"
+        onClick={open}
+        className="flex w-full flex-col gap-1 px-1 py-3 text-left hover:bg-slate-900/60"
+        aria-label={`Open time slider at ${transition.ts}`}
+      >
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="flex items-baseline gap-2">
+            <span
+              className={`rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider ${badge}`}
+            >
+              {transition.state}
+            </span>
+            <span className="font-mono text-[10px] text-slate-500">
+              {transition.event_type}
+            </span>
+            {transition.decision_id && (
+              <span className="font-mono text-[10px] text-slate-500">
+                decision: {transition.decision_id}
+              </span>
+            )}
+          </span>
+          <span className="text-[10px] text-slate-500">
+            {formatRelativeTime(transition.ts)} · {transition.ts}
+          </span>
+        </div>
+        {transition.reason && (
+          // Verbatim — NFR-O5 forbids truncation or rephrasing.
+          <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-words text-xs text-slate-300">
+            {transition.reason}
+          </pre>
+        )}
+      </button>
+    </li>
+  );
+}
 
 export default function Strategy() {
   const { id } = useParams();
+  const strategyId = id ?? "";
+  const fetcher = useCallback(
+    () =>
+      fetchStrategyLifecycle(strategyId, {
+        window: null,
+        types: STATE_EVENT_TYPES,
+      }),
+    [strategyId],
+  );
+  const endpoint = useEndpoint<StrategyLifecyclePayload>(fetcher, 15_000);
+
+  const derived = useMemo(() => {
+    if (!endpoint.data) return null;
+    return deriveCurrentState(endpoint.data.events);
+  }, [endpoint.data]);
+
+  const notFound =
+    endpoint.error instanceof ApiError && endpoint.error.status === 404;
+  if (notFound) {
+    return (
+      <section className="space-y-4">
+        <header className="flex items-baseline justify-between">
+          <h1 className="text-2xl font-semibold text-slate-100">
+            strategy lifecycle
+          </h1>
+          <Link
+            to="/strategies"
+            className="text-xs text-sky-400 hover:underline"
+          >
+            ← all strategies
+          </Link>
+        </header>
+        <div className="rounded-lg border border-rose-700/60 bg-rose-950/40 p-4">
+          <p className="text-sm text-rose-200">
+            strategy <code className="text-rose-100">{strategyId}</code> not
+            found.
+          </p>
+          <p className="mt-1 text-xs text-rose-300/80">
+            the configuration store has no record of this id. it may have
+            never been registered, or it may have been renamed.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const badgeCls = derived ? stateBadgeClass(derived.state) : "";
+
   return (
     <section className="space-y-4">
-      <h1 className="text-2xl font-semibold text-slate-100">
-        Strategy lifecycle
-      </h1>
-      <p className="text-slate-400">
-        Strategy id: <code className="text-slate-200">{id}</code>.
-      </p>
-      <p className="text-slate-500 text-sm">
-        Implementation pending — see{" "}
-        <a
-          className="text-sky-400 hover:underline"
-          href="https://github.com/PetroSa2/petrosa_k8s/issues/648"
-        >
-          #648
-        </a>
-        .
-      </p>
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-2xl font-semibold text-slate-100">
+          strategy lifecycle
+        </h1>
+        <Link to="/strategies" className="text-xs text-sky-400 hover:underline">
+          ← all strategies
+        </Link>
+      </header>
+
+      <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-4">
+        <p className="text-xs uppercase tracking-wider text-slate-500">
+          strategy id
+        </p>
+        <p className="mt-1 font-mono text-sm text-slate-100">{strategyId}</p>
+
+        <div className="mt-4 flex items-baseline justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wider text-slate-500">
+              current state
+            </p>
+            <p className="mt-1">
+              {derived ? (
+                <span
+                  className={`rounded border px-2 py-1 font-mono text-xs uppercase tracking-wider ${badgeCls}`}
+                >
+                  {derived.state}
+                </span>
+              ) : (
+                <span className="text-xs text-slate-500">loading…</span>
+              )}
+            </p>
+          </div>
+          {derived?.lastTransitionAt && (
+            <div className="text-right">
+              <p className="text-xs uppercase tracking-wider text-slate-500">
+                last transition
+              </p>
+              <p className="mt-1 text-xs text-slate-300">
+                {formatRelativeTime(derived.lastTransitionAt)}
+              </p>
+              <p className="text-[10px] text-slate-500">
+                {derived.lastTransitionAt}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-4">
+        <header className="flex items-baseline justify-between">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-slate-300">
+            transitions
+          </h2>
+          <span className="text-[10px] uppercase tracking-wider text-slate-500">
+            /api/dashboard/strategy/{strategyId}/lifecycle
+          </span>
+        </header>
+
+        {endpoint.error && !endpoint.data && (
+          <p className="mt-3 text-xs text-rose-400">
+            unable to load — {endpoint.error.message}
+          </p>
+        )}
+        {endpoint.error && endpoint.data && (
+          <p className="mt-3 text-xs text-amber-400">
+            last refresh failed ({endpoint.error.status || "network"}); showing
+            previous value
+          </p>
+        )}
+
+        {!endpoint.data && !endpoint.error && (
+          <div className="mt-3 flex items-center gap-2 text-sm text-slate-400">
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-slate-500" />
+            <span>waiting on transitions…</span>
+          </div>
+        )}
+
+        {derived && derived.transitions.length === 0 && (
+          <p className="mt-3 text-xs text-slate-400">
+            no transitions yet. the strategy may be registered but not
+            characterized, or the lifecycle writer has not started recording
+            (P1.2 dependency).
+          </p>
+        )}
+
+        {derived && derived.transitions.length > 0 && (
+          <ol className="mt-2">
+            {derived.transitions.map((t) => (
+              <TransitionRow key={t.event_id} transition={t} />
+            ))}
+          </ol>
+        )}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- **`/strategy/:id`** — replaces the P5.1b placeholder with a real lifecycle viewer. Pulls `/api/dashboard/strategy/{id}/lifecycle?types=lifecycle,characterization` and renders a "current state" card plus a chronological list of transitions. Each transition is a button that deep-links to `/time/<iso>` for the P5.1d slider (renders the timestamp as-is until #647 lands). Verbatim reasoning text per NFR-O5. Explicit 404 banner when the api 404s.
- **`/strategies`** (new index page) — fetches `/api/v1/config/strategies` and fans out per-strategy lifecycle queries to derive `current_state` client-side. Sortable by strategy id, current state, or last-transition timestamp.
- **Nav** — replaces the cryptic `strategy → /strategy/_` link in `App.tsx` with `strategies → /strategies`.

## State vocabulary reconciliation
The ticket lists `registered/characterized/admitted/trial/graduated/demoted/retired`. The shipped enum (`petrosa-cio/cio/core/lifecycle.py::LifecycleState`) is `REGISTERED|CHARACTERIZED|ADMITTED|ON_TRIAL|GRADUATED|DEMOTED|RETIRED|REJECTED`. The UI uses the producer's verbatim values — `on_trial` not `trial`; `rejected` is included as a terminal state. This is the path the ticket's "Notes" section explicitly invites ("if P3.3 shipped with a different vocabulary, reconcile in this ticket's design comments").

## Scope decisions
- **No backend changes.** Adding a pre-aggregated `/api/dashboard/strategies` route was tempting but pushed the ticket outside size=S. The strategy count is small (handful in steady state, tens at most under MVP load), so the client-side fan-out is acceptable. If list-page latency ever becomes a problem, a follow-up ticket can add the route — captured in MemPalace as a known eventual follow-up.
- **Timeline filter.** The lifecycle endpoint can return six event types; only `lifecycle` and `characterization` are state transitions. The detail view passes `?types=lifecycle,characterization` so auxiliary events (intent/decision/execution) don't dominate the timeline. The time-slider deep-link is the path to the full event detail.
- **No unit tests.** `dashboard/package.json` has no test runner today; validation is `tsc --noEmit` + `eslint` + `vite build`. All three pass locally. Adding a runner is out of scope.

## Acceptance criteria
- [x] Each state transition renders as a node on the timeline, with state name + timestamp
- [x] Current state is visually highlighted (bordered card at the top of the detail view)
- [x] Transition reasons render verbatim from the lifecycle history (NFR-O5; rendered inside a `<pre>` so whitespace/JSON is preserved)
- [x] Clicking a transition opens the time slider centered at that timestamp (`/time/<iso>` — cross-feature deep-link)
- [x] "Strategy not found" 404 state is rendered explicitly when the API 404s
- [x] Listing/index page shows all strategies with current-state column, sortable

## Test plan
- [ ] CI on this PR is green (build/lint/typecheck only — no JS test runner in this repo)
- [ ] After merge + dashboard image rebuild (via #657 wiring) + GitOps redeploy, open `/strategies` in the operator dashboard and verify the table populates and is sortable
- [ ] Click a row → confirm the detail view renders, current state badge appears, transitions list appears (or the "no transitions yet" copy if the lifecycle writer hasn't started for that strategy)
- [ ] Click a transition → confirm navigation to `/time/<ts>` (TimeSlider placeholder until #647)
- [ ] Visit `/strategy/<bogus-id>` and confirm the 404 banner renders

Refs: PetroSa2/petrosa_k8s#648 (P5.1e)
Depends-on: PetroSa2/petrosa_k8s#657 (dashboard CI publishing — landed)
Unblocks: PetroSa2/petrosa_k8s#647 (P5.1d time slider — the detail view's deep-links target its route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)