### PR TITLE
fix: #167 - wire DrawdownScheduler into data-manager startup (FR30 / P4.2)

### DIFF
--- a/data_manager/main.py
+++ b/data_manager/main.py
@@ -373,6 +373,7 @@ class DataManagerApp:
         # Start background workers
         asyncio.create_task(self._run_auditor())
         asyncio.create_task(self._run_analytics())
+        asyncio.create_task(self._run_drawdown_scheduler())
 
         self.running = True
         logger.info("All components started successfully")
@@ -720,6 +721,59 @@ class DataManagerApp:
             logger.error(f"Error in analytics: {e}", exc_info=True)
 
         logger.info("Analytics stopped")
+
+    async def _run_drawdown_scheduler(self) -> None:
+        """Periodic drawdown-vs-envelope check (P4.2, #602; FR30).
+
+        Iterates known strategies on each tick, computes current
+        drawdown against the latest characterization envelope, and
+        emits a breach event on ``portfolio.drawdown.breach.{sid}``
+        so CIO can intervene. Healthy ticks do not publish — only
+        envelope breaches do.
+
+        Surfaced as the FR30 production-wiring gap by the 2026-05-22
+        reality-check audit (see prd-reality-check-2026-05-22.md).
+        """
+        if not self.db_manager or not getattr(self.db_manager, "mongodb_adapter", None):
+            logger.warning("DrawdownScheduler not started: no mongodb_adapter")
+            return
+
+        if not self.db_manager.is_healthy():
+            logger.warning("DrawdownScheduler not started: databases not healthy")
+            return
+
+        # Import here to avoid circular dependency at module load.
+        from data_manager.db.repositories.characterization_repository import (
+            CharacterizationRepository,
+        )
+        from data_manager.portfolio.drawdown_scheduler import (
+            DrawdownScheduler,
+        )
+
+        # Same lazy-extraction pattern used by the audit scheduler:
+        # the breach publisher tolerates a None client (logs + drops
+        # without raising), so local-dev without a broker is safe.
+        drawdown_nats_client = None
+        if self.consumer is not None and getattr(self.consumer, "nats_client", None):
+            drawdown_nats_client = getattr(self.consumer.nats_client, "nc", None)
+
+        try:
+            char_repo = CharacterizationRepository(
+                mysql_adapter=None,
+                mongodb_adapter=self.db_manager.mongodb_adapter,
+            )
+            scheduler = DrawdownScheduler(
+                mongodb_adapter=self.db_manager.mongodb_adapter,
+                characterization_repository=char_repo,
+                nats_client=drawdown_nats_client,
+            )
+            await scheduler.start()
+            logger.info(
+                "drawdown_scheduler_started",
+                extra={"interval_seconds": 300},
+            )
+        except Exception as e:
+            logger.error(f"Error in DrawdownScheduler: {e}", exc_info=True)
 
     def shutdown(self, signum, frame):
         """Handle shutdown signal."""


### PR DESCRIPTION
## Summary

P4.2 (#602) shipped DrawdownService + DrawdownBreachPublisher + DrawdownScheduler, but the scheduler was never instantiated in ` + "`data_manager/main.py`" + `. Only the on-demand HTTP endpoint and unit tests referenced it. As a result, periodic envelope-breach publication on ` + "`portfolio.drawdown.breach.{strategy_id}`" + ` was not running in production — CIO never received drawdown-breach events.

Adds ` + "`_run_drawdown_scheduler`" + ` background task alongside ` + "`_run_auditor`" + ` and ` + "`_run_analytics`" + `, mirroring the existing pattern (mongodb tolerance, lazy NATS extraction, 300s default interval).

## Test plan

- [x] Scheduler instantiated in startup
- [x] Local-dev tolerance preserved (skips if mongodb unhealthy)
- [x] NATS publisher works lazily (None client tolerated)
- [x] Default interval 300s
- [x] Pre-commit hooks pass (Ruff, Bandit, Gitleaks)
- [ ] **Post-merge:** verify in production that ` + "`drawdown_scheduler_started`" + ` log line appears and ` + "`portfolio.drawdown.breach.*`" + ` events are published when envelopes breach
- [ ] **Post-merge:** next reality-check snapshot should record FR30 → 🟢 GREEN

## Context

Surfaced by the 2026-05-22 reality-check audit (Agent D report; PetroSa2/petrosa_k8s reality-check-2026-05-22 snapshot, "Audit Trail & Query" section). FR30 was the only FR in audit-trail subsystem that didn't make it to GREEN, with this as the only documented gap.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)