### PR TITLE
fix: 169 - leader_election naive datetime TypeError + OTel exporter 404 flood

### DIFF
--- a/data_manager/leader_election.py
+++ b/data_manager/leader_election.py
@@ -162,6 +162,8 @@ class LeaderElectionManager:
             if current_leader:
                 current_leader_pod = current_leader["pod_id"]
                 last_heartbeat = current_leader["last_heartbeat"]
+                if last_heartbeat is not None and last_heartbeat.tzinfo is None:
+                    last_heartbeat = last_heartbeat.replace(tzinfo=UTC)
 
                 # Check if current leader is stale (no heartbeat for timeout period)
                 if (

--- a/tests/test_leader_election.py
+++ b/tests/test_leader_election.py
@@ -322,3 +322,41 @@ class TestGetStatus:
         assert isinstance(status, dict)
         assert status["pod_id"] == "test-pod"
         assert status["is_leader"] is True
+
+
+class TestHeartbeatTimezoneHandling:
+    """Regression tests for #169: MongoDB naive datetimes must not cause TypeError."""
+
+    @pytest.mark.asyncio
+    async def test_naive_heartbeat_treated_as_utc(self):
+        client, db, coll = make_mongo_client()
+        naive_hb = datetime.now() - timedelta(seconds=5)
+        coll.find_one = AsyncMock(
+            return_value={
+                "pod_id": "other-pod",
+                "last_heartbeat": naive_hb,
+                "status": "leader",
+            }
+        )
+        mgr = LeaderElectionManager()
+        mgr.mongodb_db = db
+        mgr.election_timeout = 30
+        result = await mgr._try_become_leader()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_aware_heartbeat_unchanged(self):
+        client, db, coll = make_mongo_client()
+        aware_hb = datetime.now(UTC) - timedelta(seconds=5)
+        coll.find_one = AsyncMock(
+            return_value={
+                "pod_id": "other-pod",
+                "last_heartbeat": aware_hb,
+                "status": "leader",
+            }
+        )
+        mgr = LeaderElectionManager()
+        mgr.mongodb_db = db
+        mgr.election_timeout = 30
+        result = await mgr._try_become_leader()
+        assert result is False


### PR DESCRIPTION
## Summary

Fixes two root causes of the data-manager OOMKilled crash loop (PetroSa2/petrosa-data-manager#169).

### Fix A — `leader_election.py:169` datetime TypeError

MongoDB returns `last_heartbeat` as a timezone-naive `datetime`. Subtracting `datetime.now(UTC)` (tz-aware) from it raises `TypeError: can't subtract offset-naive and offset-aware datetimes` on every heartbeat tick. Same class of bug fixed in commit `d931817` for NATS subjects; this site was missed.

**Change:** normalize `last_heartbeat` to UTC-aware before the subtraction using `.replace(tzinfo=UTC)` when `tzinfo is None`.

### Fix B — OTel exporter 404 flood (companion configmap fix)

Explicit `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` vars added to the data-manager configmap in petrosa_k8s PR #708. Pins exact OTLP paths — audited against Grafana Alloy config (`otelcol.receiver.otlp` on port 4318 HTTP).

## Testing

- Added `TestHeartbeatTimezoneHandling` with two regression tests.
- All 28 `test_leader_election.py` tests pass.
- Ruff lint + format clean.

## Acceptance criteria coverage

- [x] AC1 — `leader_election.py:169` tz-aware fix applied.
- [x] AC1 test — naive and aware heartbeat regression tests added.
- [x] AC2 — OTel configmap fix in companion petrosa_k8s PR #708.

Closes #169

