### PR TITLE
fix: harden data-manager async test isolation (event-loop leak) (#178)

### DIFF
--- a/data_manager/consumer/decision_consumer.py
+++ b/data_manager/consumer/decision_consumer.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import time
 from typing import Any
 
 from opentelemetry import trace
@@ -185,7 +186,10 @@ class DecisionConsumer:
         logger.info(f"Decision worker {worker_id} stopped")
 
     async def _process_message(self, msg: Any) -> None:
-        start_time = asyncio.get_event_loop().time()
+        # Use time.monotonic() instead of time.monotonic() — the
+        # latter is deprecated in modern asyncio and silently fragile under
+        # pytest-asyncio 1.x when called from sync helpers; see #178.
+        start_time = time.monotonic()
         subject = getattr(msg, "subject", self.subject)
 
         try:
@@ -252,7 +256,7 @@ class DecisionConsumer:
                 span.set_attribute("persistence.skipped", True)
 
             decision_processing_time.record(
-                asyncio.get_event_loop().time() - start_time, _METRIC_ATTRS
+                time.monotonic() - start_time, _METRIC_ATTRS
             )
 
     async def _persist(self, event: DecisionEvent) -> bool:

--- a/data_manager/consumer/execution_events_consumer.py
+++ b/data_manager/consumer/execution_events_consumer.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import time
 from typing import Any
 
 from opentelemetry import trace
@@ -197,7 +198,10 @@ class ExecutionEventsConsumer:
         logger.info(f"Execution events worker {worker_id} stopped")
 
     async def _process_message(self, msg: Any) -> None:
-        start_time = asyncio.get_event_loop().time()
+        # Use time.monotonic() instead of time.monotonic() — the
+        # latter is deprecated in modern asyncio and silently fragile under
+        # pytest-asyncio 1.x when called from sync helpers; see #178.
+        start_time = time.monotonic()
         subject = getattr(msg, "subject", self.subject)
 
         try:
@@ -284,7 +288,7 @@ class ExecutionEventsConsumer:
                 span.set_attribute("persistence.skipped", True)
 
             execution_processing_time.record(
-                asyncio.get_event_loop().time() - start_time, _METRIC_ATTRS
+                time.monotonic() - start_time, _METRIC_ATTRS
             )
 
     async def _persist(self, event: ExecutionEvent) -> bool:

--- a/data_manager/consumer/intent_consumer.py
+++ b/data_manager/consumer/intent_consumer.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import time
 from typing import Any
 
 from opentelemetry import trace
@@ -178,7 +179,10 @@ class IntentConsumer:
         logger.info(f"Intent worker {worker_id} stopped")
 
     async def _process_message(self, msg: Any) -> None:
-        start_time = asyncio.get_event_loop().time()
+        # Use time.monotonic() instead of time.monotonic() — the
+        # latter is deprecated in modern asyncio and silently fragile under
+        # pytest-asyncio 1.x when called from sync helpers; see #178.
+        start_time = time.monotonic()
         subject = getattr(msg, "subject", self.subject)
 
         try:
@@ -246,9 +250,7 @@ class IntentConsumer:
                 logger.warning("intent_persistence_skipped", extra=log_extra)
                 span.set_attribute("persistence.skipped", True)
 
-            intent_processing_time.record(
-                asyncio.get_event_loop().time() - start_time, _METRIC_ATTRS
-            )
+            intent_processing_time.record(time.monotonic() - start_time, _METRIC_ATTRS)
 
     async def _persist(self, event: IntentEvent) -> bool:
         adapter = (

--- a/data_manager/consumer/market_data_consumer.py
+++ b/data_manager/consumer/market_data_consumer.py
@@ -199,7 +199,10 @@ class MarketDataConsumer:
     async def _process_message(self, msg: Any) -> None:
         """Process a single message with trace context propagation."""
         event_type = "unknown"
-        start_time = asyncio.get_event_loop().time()
+        # Use time.monotonic() instead of asyncio.get_event_loop().time() — the
+        # latter is deprecated in modern asyncio and silently fragile under
+        # pytest-asyncio 1.x when called from sync helpers; see #178.
+        start_time = time.monotonic()
 
         try:
             # Decode message
@@ -262,7 +265,7 @@ class MarketDataConsumer:
                 await self.message_handler.handle_event(event)
 
                 # Track metrics
-                processing_time = asyncio.get_event_loop().time() - start_time
+                processing_time = time.monotonic() - start_time
                 message_processing_time.record(
                     processing_time, {**_METRIC_ATTRS, "event_type": event_type}
                 )

--- a/data_manager/consumer/pnl_consumer.py
+++ b/data_manager/consumer/pnl_consumer.py
@@ -15,6 +15,7 @@ disrupting the other three subscribers.
 import asyncio
 import json
 import logging
+import time
 from typing import Any
 
 from opentelemetry import trace
@@ -188,7 +189,10 @@ class PnlConsumer:
         logger.info(f"Pnl worker {worker_id} stopped")
 
     async def _process_message(self, msg: Any) -> None:
-        start_time = asyncio.get_event_loop().time()
+        # Use time.monotonic() instead of time.monotonic() — the
+        # latter is deprecated in modern asyncio and silently fragile under
+        # pytest-asyncio 1.x when called from sync helpers; see #178.
+        start_time = time.monotonic()
         subject = getattr(msg, "subject", self.subject)
 
         try:
@@ -254,9 +258,7 @@ class PnlConsumer:
                 logger.warning("pnl_event_persistence_skipped", extra=log_extra)
                 span.set_attribute("persistence.skipped", True)
 
-            pnl_processing_time.record(
-                asyncio.get_event_loop().time() - start_time, _METRIC_ATTRS
-            )
+            pnl_processing_time.record(time.monotonic() - start_time, _METRIC_ATTRS)
 
     async def _persist(self, event: PnlEvent) -> bool:
         adapter = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,9 @@ minversion = "8.0"
 addopts = "-v --cov=data_manager --cov-report=term --cov-report=html --cov-report=xml"
 testpaths = ["tests"]
 asyncio_mode = "auto"
+# #178 — pin the per-test loop scope so pytest-asyncio creates a fresh event
+# loop for every test and never shares one across tests. Explicit > implicit:
+# this guarantees no test can leak loop state into a later sync fixture that
+# touches `asyncio.get_event_loop()` (the deprecated pattern that triggered
+# the original failure on Python 3.11.15 CI).
+asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_consumer_sync_construction.py
+++ b/tests/test_consumer_sync_construction.py
@@ -1,0 +1,53 @@
+"""Regression guard for #178 — every consumer must construct cleanly from a
+sync context (no running event loop).
+
+Background: pre-#177, `MarketDataConsumer.__init__` called
+`asyncio.get_event_loop().time()` to seed a stats timer. Under pytest-asyncio
+1.4.0 on Python 3.11.15, that raised ``RuntimeError: There is no current event
+loop in thread 'MainThread'`` because pytest-asyncio's new strict-loop semantics
+do not implicitly create a loop in sync fixtures. PR #177 swapped that call to
+``time.monotonic()``; this hardening PR (#178) does the same for every other
+consumer's per-message timing and pins the per-test loop scope. These tests
+ensure no future consumer reintroduces a sync-context `asyncio.get_event_loop()`
+in its constructor — they intentionally run as **plain sync tests** (no
+``@pytest.mark.asyncio``) so pytest-asyncio does NOT install a current loop for
+the assertion.
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+
+# (module_path, class_name) pairs for every consumer that owns timing state.
+_CONSUMER_CLASSES = [
+    ("data_manager.consumer.market_data_consumer", "MarketDataConsumer"),
+    ("data_manager.consumer.execution_events_consumer", "ExecutionEventsConsumer"),
+    ("data_manager.consumer.intent_consumer", "IntentConsumer"),
+    ("data_manager.consumer.decision_consumer", "DecisionConsumer"),
+    ("data_manager.consumer.pnl_consumer", "PnlConsumer"),
+]
+
+
+@pytest.mark.parametrize(("module_path", "class_name"), _CONSUMER_CLASSES)
+def test_consumer_constructs_without_running_event_loop(module_path, class_name):
+    """Consumer __init__ must not require a running event loop (issue #178).
+
+    Any sync-context call to ``asyncio.get_event_loop()`` would raise here
+    under pytest-asyncio 1.x semantics, surfacing the regression immediately.
+    """
+    module = importlib.import_module(module_path)
+    cls = getattr(module, class_name)
+    # Pass MagicMocks for the optional collaborators so we do not pull in real
+    # NATS / Mongo plumbing — we are only exercising the constructor's
+    # synchronous setup code path.
+    instance = cls(
+        nats_client=MagicMock(),
+        db_manager=MagicMock(),
+    )
+    assert instance is not None
+    # Light sanity touch on the constructed object so any partial-init silently
+    # swallowed by a try/except would surface here.
+    assert hasattr(instance, "nats_client")


### PR DESCRIPTION
## Summary

Closes #178. Hardens data-manager's async test isolation by removing every remaining `asyncio.get_event_loop()` call from the consumers and pinning pytest-asyncio's per-test loop scope, so the regression that PR #177 fixed-forward in `MarketDataConsumer` cannot reappear elsewhere on Python 3.11.15 CI.

## What changed

- **AC1 (find the leak)** — there is no test that directly closes the loop. The latent risk is the deprecated `asyncio.get_event_loop()` pattern in consumer `__init__` / sync helpers, which pytest-asyncio 1.4.0 + Python 3.11.15 no longer tolerate from a sync fixture.
- **AC2 (durable fix)** — pinned `asyncio_default_fixture_loop_scope = "function"` in `pyproject.toml` so every test gets a fresh event loop; added `tests/test_consumer_sync_construction.py`, a parametrized sync regression test that constructs each of the 5 consumers from a plain sync test (no `@pytest.mark.asyncio`). Any future re-introduction of sync-context `asyncio.get_event_loop()` raises here immediately, surfacing the bug before it hits CI.
- **AC3 (audit + convert)** — replaced `asyncio.get_event_loop().time()` with `time.monotonic()` in all 5 consumers (10 sites total). Added `import time` where missing (4 consumers). The first occurrence in each file carries an inline comment linking back to #178 so the rationale is visible to future readers.
- **AC4 (verify)** — full suite passes locally on Python 3.11.9: **817 passed, 3 skipped**, including the 5 new parametrized sync-construction tests.

## Acceptance criteria

- [x] **AC1** — Latent leak identified (sync-context `get_event_loop()` in consumer init / helpers).
- [x] **AC2** — Loop scope pinned per-test + sync-construction regression test added.
- [x] **AC3** — All `asyncio.get_event_loop()` removed from `data_manager/`; only inline-comment mentions remain.
- [x] **AC4** — Full suite green; main CI stays green; structural guard prevents silent regression.

## Out of scope (follow-up)

The 4 non-MarketData consumers also construct `asyncio.Queue(maxsize=…)` in sync `__init__`. On Python 3.10/3.11 this deprecation-warns but still works; on 3.12+ it will eventually raise. That's a wider refactor (lazy-init the queues in `start()`) and is intentionally not folded into this hardening PR — it would expand the diff well beyond what #178 scoped.

## Test plan

- [x] `pytest tests/test_consumer_sync_construction.py -v` — 5 parametrized cases pass.
- [x] Full suite: 817 passed, 3 skipped.
- [x] `grep -rn "asyncio.get_event_loop" data_manager/` returns only the explanatory comments (no live calls).
- [x] `ruff check` + `ruff format --check` clean.

Closes #178
