### PR TITLE
feat: add strategy_revision_id to Characterization model + endpoint (#179)

### DIFF
--- a/data_manager/api/routes/characterizations.py
+++ b/data_manager/api/routes/characterizations.py
@@ -38,12 +38,24 @@ async def get_characterization(
             "recent characterization for the strategy."
         ),
     ),
+    strategy_revision_id: str | None = Query(
+        None,
+        description=(
+            "FR53 / P3.4 — filter by content-addressable strategy revision. "
+            "When set, returns the most recent characterization for "
+            "(strategy_id, strategy_revision_id) or 404 (stale revision)."
+        ),
+    ),
 ) -> dict:
     """Return one characterization for the given strategy.
 
-    Lookup semantics:
-      - With ``version``: exact (strategy_id, version) row, or 404.
-      - Without ``version``: most recently persisted row for the strategy.
+    Lookup semantics (first match wins):
+      - With ``strategy_revision_id``: most recent characterization whose
+        ``strategy_revision_id`` matches, or 404 (FR53 / P3.4 — consumers
+        use this to refuse intents against stale revisions).
+      - With ``version`` (and no revision filter): exact
+        (strategy_id, version) row, or 404.
+      - Otherwise: most recently persisted row for the strategy.
 
     The endpoint never returns a list; callers wanting multiple versions
     should call this endpoint per version, or extend the API in a
@@ -54,28 +66,31 @@ async def get_characterization(
         raise HTTPException(status_code=503, detail="Database not available")
 
     try:
-        artifact = (
-            await repo.get_version(strategy_id, version)
-            if version
-            else await repo.get_latest(strategy_id)
-        )
+        if strategy_revision_id is not None:
+            artifact = await repo.get_by_strategy_revision(
+                strategy_id, strategy_revision_id
+            )
+        elif version:
+            artifact = await repo.get_version(strategy_id, version)
+        else:
+            artifact = await repo.get_latest(strategy_id)
     except Exception as exc:
         logger.error(
-            "characterizations: lookup failed for %s/%s: %s",
+            "characterizations: lookup failed for %s/%s/rev=%s: %s",
             strategy_id,
             version,
+            strategy_revision_id,
             exc,
             exc_info=True,
         )
         raise HTTPException(status_code=500, detail="lookup failed") from exc
 
     if artifact is None:
-        raise HTTPException(
-            status_code=404,
-            detail=(
-                f"no characterization for strategy_id={strategy_id}"
-                + (f", version={version}" if version else "")
-            ),
-        )
+        detail = f"no characterization for strategy_id={strategy_id}"
+        if version:
+            detail += f", version={version}"
+        if strategy_revision_id:
+            detail += f", strategy_revision_id={strategy_revision_id}"
+        raise HTTPException(status_code=404, detail=detail)
 
     return artifact.model_dump(mode="json")

--- a/data_manager/db/repositories/characterization_repository.py
+++ b/data_manager/db/repositories/characterization_repository.py
@@ -94,6 +94,31 @@ class CharacterizationRepository(BaseRepository):
         docs = await cursor.to_list(length=1)
         return _document_to_artifact(docs[0]) if docs else None
 
+    async def get_by_strategy_revision(
+        self, strategy_id: str, strategy_revision_id: str
+    ) -> Characterization | None:
+        """Return the most recent characterization for a (strategy, revision) pair.
+
+        FR53 / P3.4 (#179): consumers (CIO refusal path / FR20 evaluator
+        binding) use this to confirm a characterization exists for the exact
+        revision the live intent carries — None ⇒ stale, refuse.
+        """
+        if not self.mongodb or not getattr(self.mongodb, "db", None):
+            return None
+        cursor = (
+            self.mongodb.db[CHARACTERIZATIONS_COLLECTION]
+            .find(
+                {
+                    "strategy_id": strategy_id,
+                    "strategy_revision_id": strategy_revision_id,
+                }
+            )
+            .sort("created_at", -1)
+            .limit(1)
+        )
+        docs = await cursor.to_list(length=1)
+        return _document_to_artifact(docs[0]) if docs else None
+
 
 def _document_to_artifact(doc: dict[str, Any] | None) -> Characterization | None:
     """Convert a stored Mongo document back to a `Characterization`.

--- a/data_manager/models/characterization.py
+++ b/data_manager/models/characterization.py
@@ -32,6 +32,33 @@ from pydantic import BaseModel, Field
 REQUIRED_METRIC_KEYS = ("sharpe", "win_rate", "mean_return")
 
 
+class StrategyRevisionRef(BaseModel):
+    """FR53 / P3.4 — typed reference to a strategy revision.
+
+    Mirrors the producer's nested shape (petrosa-bot-ta-analysis
+    `backtest/strategy_revision.py`, PR #250). The flat
+    ``strategy_revision_id`` carries the short, sortable display form
+    (``srev_{module_hash[:12]}_{parameter_hash[:12]}``) and is the field
+    consumers filter / refuse on; the nested object preserves the full
+    SHA-256 hashes so any byte-level audit can recompute hashes without
+    a producer round-trip.
+    """
+
+    revision_id: str = Field(
+        ...,
+        description=(
+            "Short revision identifier — "
+            "`srev_{module_hash[:12]}_{parameter_hash[:12]}`."
+        ),
+    )
+    module_hash: str = Field(
+        ..., description="Full 64-hex SHA-256 of the strategy module source"
+    )
+    parameter_hash: str = Field(
+        ..., description="Full 64-hex SHA-256 of the canonicalized parameter set"
+    )
+
+
 class Characterization(BaseModel):
     """A single backtest characterization persisted in `characterizations`."""
 
@@ -63,6 +90,25 @@ class Characterization(BaseModel):
         description=(
             "Hex SHA-256 of the deterministic inputs (strategy_id, version, "
             "window bounds, seed, params). Reproducibility key."
+        ),
+    )
+    # FR53 / P3.4 (#179): content-addressable strategy revision binding.
+    # `strategy_revision_id` is the flat lookup / filter key; `strategy_revision`
+    # carries the nested full-hash provenance. Both default `None` so existing
+    # documents (persisted before the producer side shipped) round-trip cleanly.
+    strategy_revision_id: str | None = Field(
+        default=None,
+        description=(
+            "Content-addressable strategy-revision identifier "
+            "`srev_{module_hash[:12]}_{parameter_hash[:12]}`. "
+            "None on artifacts persisted before P3.4 producer shipped."
+        ),
+    )
+    strategy_revision: StrategyRevisionRef | None = Field(
+        default=None,
+        description=(
+            "Full provenance (module_hash + parameter_hash) for the revision; "
+            "callers needing strict byte-level reproducibility audit hash from here."
         ),
     )
     created_at: datetime = Field(
@@ -143,12 +189,16 @@ def verify_characterization(
     )
 
     def _blob(c: Characterization) -> bytes:
+        # `strategy_revision_id` participates in the byte-equality check so a
+        # re-characterization against the same metrics but a different strategy
+        # revision (FR53 / P3.4) is correctly detected as drift, not a match.
         return json.dumps(
             {
                 "metrics": c.metrics,
                 "drawdown_envelope": c.drawdown_envelope,
                 "param_sensitivities": c.param_sensitivities,
                 "inputs_hash": c.inputs_hash,
+                "strategy_revision_id": c.strategy_revision_id,
             },
             sort_keys=True,
             separators=(",", ":"),

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -364,3 +364,186 @@ def test_endpoint_503_when_db_unavailable():
     client = TestClient(app)
     r = client.get("/api/v1/characterizations", params={"strategy_id": "any"})
     assert r.status_code == 503
+
+
+# ----------------------------------------------------------------------
+# FR53 / P3.4 (#179) — strategy_revision_id field + filter + verify drift.
+# ----------------------------------------------------------------------
+
+
+from data_manager.models.characterization import StrategyRevisionRef  # noqa: E402
+
+_SREV_HASH_A = "a" * 64
+_SREV_HASH_B = "b" * 64
+_SREV_ID_A = "srev_" + "a" * 12 + "_" + "a" * 12  # mirrors producer scheme
+_SREV_ID_B = "srev_" + "b" * 12 + "_" + "b" * 12
+
+
+def _make_artifact_with_revision(
+    *, revision_id: str = _SREV_ID_A, module_hash: str = _SREV_HASH_A
+) -> Characterization:
+    art = _make_artifact()
+    art.strategy_revision_id = revision_id
+    art.strategy_revision = StrategyRevisionRef(
+        revision_id=revision_id,
+        module_hash=module_hash,
+        parameter_hash=_SREV_HASH_B,
+    )
+    return art
+
+
+def test_artifact_round_trip_preserves_strategy_revision_id():
+    """AC1 — model round-trips strategy_revision_id + nested ref."""
+    artifact = _make_artifact_with_revision()
+    dumped = artifact.model_dump()
+    rebuilt = Characterization(**dumped)
+    assert rebuilt.strategy_revision_id == _SREV_ID_A
+    assert rebuilt.strategy_revision is not None
+    assert rebuilt.strategy_revision.revision_id == _SREV_ID_A
+    assert rebuilt.strategy_revision.module_hash == _SREV_HASH_A
+
+
+def test_artifact_strategy_revision_defaults_none_for_pre_p34_documents():
+    """AC1 — legacy documents (no revision binding) still parse cleanly."""
+    artifact = _make_artifact()
+    assert artifact.strategy_revision_id is None
+    assert artifact.strategy_revision is None
+    dumped = artifact.model_dump()
+    rebuilt = Characterization(**dumped)
+    assert rebuilt.strategy_revision_id is None
+
+
+def test_verify_characterization_detects_revision_id_drift():
+    """AC4 — verify_characterization must detect revision-id mismatch."""
+    artifact_a = _make_artifact_with_revision(revision_id=_SREV_ID_A)
+
+    def _recompute_with_b(**_kw) -> Characterization:
+        # Same metrics / drawdown / inputs_hash — only the revision_id differs.
+        out = _make_artifact_with_revision(revision_id=_SREV_ID_B)
+        out.inputs_hash = artifact_a.inputs_hash
+        out.metrics = dict(artifact_a.metrics)
+        out.drawdown_envelope = list(artifact_a.drawdown_envelope)
+        out.param_sensitivities = dict(artifact_a.param_sensitivities)
+        return out
+
+    assert verify_characterization(artifact_a, _recompute_with_b) is False
+
+    def _recompute_with_a(**_kw) -> Characterization:
+        return _make_artifact_with_revision(revision_id=_SREV_ID_A)
+
+    assert verify_characterization(artifact_a, _recompute_with_a) is True
+
+
+@pytest.fixture()
+def client_with_revision_artifact():
+    """TestClient where the stored artifact carries a revision id; the mock
+    cursor filters faithfully on `strategy_revision_id`.
+    """
+    app = create_app()
+    artifact = _make_artifact_with_revision(revision_id=_SREV_ID_A)
+
+    mongo = MagicMock()
+    coll = MagicMock()
+    stored = artifact.model_dump()
+    stored["_id"] = f"{artifact.strategy_id}::{artifact.strategy_version}"
+
+    async def _find_one(filt):
+        if (
+            filt.get("strategy_id") == artifact.strategy_id
+            and filt.get("strategy_version") == artifact.strategy_version
+        ):
+            return stored
+        return None
+
+    coll.find_one = AsyncMock(side_effect=_find_one)
+
+    def _find(filt):
+        cursor = MagicMock()
+        cursor.sort.return_value = cursor
+        cursor.limit.return_value = cursor
+        if (
+            "strategy_revision_id" in filt
+            and filt["strategy_revision_id"] != artifact.strategy_revision_id
+        ):
+            cursor.to_list = AsyncMock(return_value=[])
+        else:
+            cursor.to_list = AsyncMock(return_value=[stored])
+        return cursor
+
+    coll.find = MagicMock(side_effect=_find)
+    mongo.db = {CHARACTERIZATIONS_COLLECTION: coll}
+
+    db_manager_stub = MagicMock()
+    db_manager_stub.mongodb_adapter = mongo
+    db_manager_stub.mysql_adapter = None
+    api_module.db_manager = db_manager_stub
+    try:
+        yield TestClient(app), artifact
+    finally:
+        api_module.db_manager = None
+
+
+def test_endpoint_returns_artifact_filtered_by_strategy_revision_id(
+    client_with_revision_artifact,
+):
+    """AC3 — strategy_revision_id filter returns the matching artifact."""
+    client, artifact = client_with_revision_artifact
+    r = client.get(
+        "/api/v1/characterizations",
+        params={
+            "strategy_id": artifact.strategy_id,
+            "strategy_revision_id": artifact.strategy_revision_id,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["strategy_revision_id"] == _SREV_ID_A
+    assert body["strategy_revision"]["revision_id"] == _SREV_ID_A
+
+
+def test_endpoint_404_on_stale_strategy_revision_id(client_with_revision_artifact):
+    """AC3 — mismatched strategy_revision_id is 404 (consumer refusal signal)."""
+    client, artifact = client_with_revision_artifact
+    r = client.get(
+        "/api/v1/characterizations",
+        params={
+            "strategy_id": artifact.strategy_id,
+            "strategy_revision_id": _SREV_ID_B,  # stale revision
+        },
+    )
+    assert r.status_code == 404
+    assert _SREV_ID_B in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_repo_get_by_strategy_revision_matches_and_misses():
+    """AC2 — repo lookup returns the matching artifact and None for stale id."""
+    artifact = _make_artifact_with_revision(revision_id=_SREV_ID_A)
+    stored = artifact.model_dump()
+    stored["_id"] = f"{artifact.strategy_id}::{artifact.strategy_version}"
+
+    coll = MagicMock()
+
+    def _find(filt):
+        cursor = MagicMock()
+        cursor.sort.return_value = cursor
+        cursor.limit.return_value = cursor
+        if filt.get("strategy_revision_id") == artifact.strategy_revision_id:
+            cursor.to_list = AsyncMock(return_value=[stored])
+        else:
+            cursor.to_list = AsyncMock(return_value=[])
+        return cursor
+
+    coll.find = MagicMock(side_effect=_find)
+
+    mongo = MagicMock()
+    mongo.db = {CHARACTERIZATIONS_COLLECTION: coll}
+
+    repo = CharacterizationRepository(mysql_adapter=None, mongodb_adapter=mongo)
+
+    hit = await repo.get_by_strategy_revision(artifact.strategy_id, _SREV_ID_A)
+    assert hit is not None
+    assert hit.strategy_revision_id == _SREV_ID_A
+
+    miss = await repo.get_by_strategy_revision(artifact.strategy_id, _SREV_ID_B)
+    assert miss is None


### PR DESCRIPTION
Closes #179. P3.4-FU-AC2 — adds the typed-field side of the FR53 strategy-revision binding.

## What changed
- **Model**: `Characterization` gains `strategy_revision_id: str | None` + optional nested `strategy_revision: StrategyRevisionRef | None` (full module/parameter SHA-256 provenance). Both default `None` so pre-P3.4 documents round-trip cleanly.
- **Repository**: `upsert` round-trips via `model_dump()` automatically; added `get_by_strategy_revision()` for the consumer refusal lookup pattern.
- **Endpoint**: `GET /api/v1/characterizations?strategy_revision_id=...` — 200 on match, 404 on stale (the FR20 evaluator / petrosa-cio#130 refusal signal).
- **`verify_characterization`**: `strategy_revision_id` participates in the byte-equality blob — drift detected.

## Test plan
- [x] `pytest tests/test_characterization.py` — 6 new tests pass (round-trip, legacy default, verify drift detection both ways, endpoint match + stale, repo match + miss).
- [x] Full suite: **823 passed, 3 skipped**.
- [x] ruff check + ruff format clean.

## Unblocks
- petrosa-cio#130 (P3.4-FU-AC3, CIO refusal logic against stale characterizations).
- The future FR20 strategy-fidelity evaluator binding (#238 AC5).

Closes #179