### PR TITLE
feat(182): leverage-bounds dashboard routes + NATS + audit (P1.5-AC6.b/c/d)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -26,6 +26,7 @@ from data_manager.api.routes import (
     fidelity,
     generic,
     health,
+    leverage_bounds,
     lifecycle,
     pnl,
     portfolio_state,
@@ -154,6 +155,9 @@ def create_app() -> FastAPI:
     # the existing service-layer code that powers /api/v1. Mounted at
     # /api/dashboard so the SPA contract is decoupled from /api/v1.
     app.include_router(dashboard.router, prefix="/api/dashboard", tags=["Dashboard"])
+    # leverage_bounds routes already include the /api/dashboard prefix in-path
+    # so they're registered without a router-level prefix.
+    app.include_router(leverage_bounds.router, tags=["Dashboard"])
 
     # New API routes
     app.include_router(generic.router, tags=["Generic CRUD"])

--- a/data_manager/api/routes/leverage_bounds.py
+++ b/data_manager/api/routes/leverage_bounds.py
@@ -1,0 +1,241 @@
+"""Leverage-bounds dashboard endpoints (#182, P1.5-AC6.b/c/d, FR61).
+
+Operator surface for the per-strategy + aggregate leverage bounds:
+
+  * ``GET /api/dashboard/leverage-bounds`` — current (latest version).
+  * ``GET /api/dashboard/leverage-bounds/{version}`` — exact version.
+  * ``GET /api/dashboard/leverage-bounds/versions`` — version index for
+    the history pane.
+  * ``PUT /api/dashboard/leverage-bounds`` — write a new version (server
+    assigns the next monotonic ``v<n>``). Side effects:
+      1. Persist the new ``LeverageBounds`` document.
+      2. Compute :class:`LeverageBoundsDiff` against the previous version
+         and write it to the ``leverage_bounds_audit`` collection
+         (AC6.d, FR12).
+      3. Publish ``cio.config.leverage_bounds.updated`` on NATS so the
+         CIO consumer (separate sibling ticket) can hot-reload (AC6.c).
+
+The NATS publisher is provided via :func:`set_leverage_bounds_publisher`
+so the route stays testable: at app boot, ``data_manager/main.py`` calls
+this once with a ``_DeferredNatsClient`` instance; tests inject a
+recording stub. When no publisher is wired, the route still completes
+successfully (storage + audit happen) but logs that NATS was skipped.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any, Protocol
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from fastapi import APIRouter, HTTPException, Path
+
+import data_manager.api.app as api_module
+from data_manager.db.repositories.leverage_bounds_repository import (
+    LeverageBoundsRepository,
+)
+from data_manager.models.leverage_bounds import (
+    LeverageBounds,
+    LeverageBoundsDiff,
+    LeverageBoundsPutRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+LEVERAGE_BOUNDS_AUDIT_COLLECTION = "leverage_bounds_audit"
+LEVERAGE_BOUNDS_NATS_SUBJECT = "cio.config.leverage_bounds.updated"
+
+
+class _NATSPublisher(Protocol):
+    async def publish(self, subject: str, payload: bytes) -> None: ...
+
+
+_publisher: _NATSPublisher | None = None
+
+
+def set_leverage_bounds_publisher(publisher: _NATSPublisher | None) -> None:
+    """Wire the NATS publisher used by the PUT route (call once at app boot)."""
+    global _publisher
+    _publisher = publisher
+
+
+def _get_publisher() -> _NATSPublisher | None:
+    return _publisher
+
+
+def _require_mongo():  # type: ignore[no-untyped-def]
+    if not api_module.db_manager or not getattr(
+        api_module.db_manager, "mongodb_adapter", None
+    ):
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "title": "MongoDB unavailable",
+                "detail": "data-manager is not connected to MongoDB",
+            },
+        )
+    return api_module.db_manager.mongodb_adapter
+
+
+def _repo() -> LeverageBoundsRepository:
+    mongo = _require_mongo()
+    return LeverageBoundsRepository(mongodb_adapter=mongo)
+
+
+@router.get("/api/dashboard/leverage-bounds")
+async def get_latest_leverage_bounds() -> dict[str, Any]:
+    """Latest version. Returns 404 if no bounds have been written yet."""
+    repo = _repo()
+    bounds = await repo.get_latest()
+    if bounds is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "title": "leverage_bounds not configured",
+                "detail": "no LeverageBounds document has been written yet",
+            },
+        )
+    return bounds.model_dump(mode="json")
+
+
+@router.get("/api/dashboard/leverage-bounds/versions")
+async def list_leverage_bounds_versions(
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Version index (descending) for the dashboard history pane."""
+    repo = _repo()
+    versions = await repo.list_versions(limit=limit)
+    return {"versions": versions, "count": len(versions)}
+
+
+@router.get("/api/dashboard/leverage-bounds/{version}")
+async def get_leverage_bounds_version(
+    version: int = Path(..., ge=1, description="1-based version number"),
+) -> dict[str, Any]:
+    """Exact-version lookup. Returns 404 if the version does not exist."""
+    repo = _repo()
+    bounds = await repo.get_version(version)
+    if bounds is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "title": "leverage_bounds version not found",
+                "detail": f"no document at v{version}",
+            },
+        )
+    return bounds.model_dump(mode="json")
+
+
+async def _persist_audit_event(
+    mongo,  # type: ignore[no-untyped-def]
+    *,
+    diff: LeverageBoundsDiff,
+    new_bounds: LeverageBounds,
+) -> None:
+    """Persist the diff to the audit-trail collection (AC6.d, FR12)."""
+    doc = {
+        "kind": "leverage_bounds_update",
+        "from_version": diff.from_version,
+        "to_version": diff.to_version,
+        "per_strategy_added": diff.per_strategy_added,
+        "per_strategy_removed": diff.per_strategy_removed,
+        # `tuple` keys in Mongo are stored as arrays — keep the shape stable.
+        "per_strategy_changed": {
+            k: list(v) for k, v in diff.per_strategy_changed.items()
+        },
+        "aggregate_ceiling_changed": (
+            list(diff.aggregate_ceiling_changed)
+            if diff.aggregate_ceiling_changed is not None
+            else None
+        ),
+        "changed_by": new_bounds.changed_by,
+        "changed_at": new_bounds.changed_at.isoformat(),
+        "reason": new_bounds.reason,
+        "logged_at": datetime.now(UTC).isoformat(),
+    }
+    try:
+        await mongo.db[LEVERAGE_BOUNDS_AUDIT_COLLECTION].insert_one(doc)
+    except Exception as exc:  # noqa: BLE001 — never block the operator PUT
+        logger.warning(
+            "leverage_bounds_audit.insert_failed to_version=%d error=%s",
+            diff.to_version,
+            exc,
+        )
+
+
+async def _publish_reload_event(new_bounds: LeverageBounds) -> bool:
+    """Best-effort NATS publish of the reload event (AC6.c)."""
+    publisher = _get_publisher()
+    if publisher is None:
+        logger.info(
+            "leverage_bounds.publish_skipped version=%d (no publisher wired)",
+            new_bounds.version,
+        )
+        return False
+
+    payload = {
+        "version": new_bounds.version,
+        "per_strategy": new_bounds.per_strategy,
+        "aggregate_ceiling": float(new_bounds.aggregate_ceiling),
+        "changed_by": new_bounds.changed_by,
+        "changed_at": new_bounds.changed_at.isoformat(),
+        "reason": new_bounds.reason,
+    }
+    try:
+        import json
+
+        await publisher.publish(
+            LEVERAGE_BOUNDS_NATS_SUBJECT, json.dumps(payload).encode()
+        )
+    except Exception as exc:  # noqa: BLE001 — never block the operator PUT
+        logger.warning(
+            "leverage_bounds.publish_failed version=%d error=%s",
+            new_bounds.version,
+            exc,
+        )
+        return False
+    logger.info(
+        "leverage_bounds.published subject=%s version=%d",
+        LEVERAGE_BOUNDS_NATS_SUBJECT,
+        new_bounds.version,
+    )
+    return True
+
+
+@router.put("/api/dashboard/leverage-bounds")
+async def put_leverage_bounds(req: LeverageBoundsPutRequest) -> dict[str, Any]:
+    """Write a new version. Side effects: storage + audit + NATS publish."""
+    mongo = _require_mongo()
+    repo = LeverageBoundsRepository(mongodb_adapter=mongo)
+
+    previous = await repo.get_latest()
+
+    pending = LeverageBounds(
+        version=1,  # overridden by repo.insert_next
+        per_strategy=req.per_strategy,
+        aggregate_ceiling=req.aggregate_ceiling,
+        changed_by=req.changed_by,
+        reason=req.reason,
+    )
+    inserted = await repo.insert_next(pending)
+
+    diff = LeverageBoundsDiff.compute(previous=previous, current=inserted)
+    await _persist_audit_event(mongo, diff=diff, new_bounds=inserted)
+    published = await _publish_reload_event(inserted)
+
+    return {
+        "bounds": inserted.model_dump(mode="json"),
+        "diff": diff.model_dump(mode="json"),
+        "nats_published": published,
+    }

--- a/tests/unit/test_leverage_bounds_routes.py
+++ b/tests/unit/test_leverage_bounds_routes.py
@@ -1,0 +1,398 @@
+"""Tests for /api/dashboard/leverage-bounds routes (#182, AC6.b/c/d wiring)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.api.app import create_app
+from data_manager.api.routes.leverage_bounds import (
+    LEVERAGE_BOUNDS_AUDIT_COLLECTION,
+    LEVERAGE_BOUNDS_NATS_SUBJECT,
+    set_leverage_bounds_publisher,
+)
+
+# ---------------------------------------------------------------------------
+# Fake Mongo + DB manager — same shape as test_leverage_bounds.py but with
+# audit-trail collection support.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, docs):
+        self._docs = docs
+        self._sort_field = None
+        self._sort_direction = 1
+        self._limit = None
+        self._projection = None
+
+    def sort(self, field, direction):
+        self._sort_field = field
+        self._sort_direction = direction
+        return self
+
+    def limit(self, n):
+        self._limit = n
+        return self
+
+    def __aiter__(self):
+        docs = list(self._docs)
+        if self._sort_field is not None:
+            docs.sort(
+                key=lambda d: d.get(self._sort_field, 0),
+                reverse=self._sort_direction < 0,
+            )
+        if self._limit is not None:
+            docs = docs[: self._limit]
+        if self._projection is not None:
+            keep = {k for k, v in self._projection.items() if v}
+            docs = [{k: v for k, v in d.items() if k in keep} for d in docs]
+        self._iter = iter(docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as e:
+            raise StopAsyncIteration from e
+
+
+class _FakeCollection:
+    def __init__(self) -> None:
+        self.docs: list[dict] = []
+
+    async def find_one(self, query: dict, sort=None):
+        if "_id" in query:
+            for d in self.docs:
+                if d.get("_id") == query["_id"]:
+                    return dict(d)
+            return None
+        docs = list(self.docs)
+        if sort:
+            field, direction = sort[0]
+            docs.sort(key=lambda d: d.get(field, 0), reverse=direction < 0)
+        return dict(docs[0]) if docs else None
+
+    def find(self, query: dict, projection=None):
+        cursor = _FakeCursor(list(self.docs))
+        cursor._projection = projection
+        return cursor
+
+    async def insert_one(self, doc: dict):
+        doc = dict(doc)
+        # Real Mongo auto-generates ObjectId when _id is absent; simulate that
+        # so callers writing audit-style docs without a stable _id work.
+        if "_id" not in doc:
+            doc["_id"] = f"_autogen-{len(self.docs)}"
+        for d in self.docs:
+            if d.get("_id") == doc.get("_id"):
+                raise RuntimeError(f"duplicate key _id={doc.get('_id')!r}")
+        self.docs.append(doc)
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self._collections: dict[str, _FakeCollection] = {}
+
+    def __getitem__(self, name: str) -> _FakeCollection:
+        return self._collections.setdefault(name, _FakeCollection())
+
+
+class _FakeMongoAdapter:
+    def __init__(self) -> None:
+        self.db = _FakeDb()
+
+
+class _FakeDbManager:
+    def __init__(self) -> None:
+        self.mongodb_adapter = _FakeMongoAdapter()
+        self.mysql_adapter = None
+
+
+class _RecordingPublisher:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict]] = []
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        self.published.append((subject, json.loads(payload.decode())))
+
+
+@pytest.fixture
+def wired_app():
+    """Wires the in-memory Mongo + recording NATS publisher into the app module."""
+    original_db_manager = api_module.db_manager
+    fake_db = _FakeDbManager()
+    api_module.db_manager = fake_db
+    publisher = _RecordingPublisher()
+    set_leverage_bounds_publisher(publisher)
+    try:
+        yield fake_db, publisher
+    finally:
+        api_module.db_manager = original_db_manager
+        set_leverage_bounds_publisher(None)
+
+
+@pytest.fixture
+def client():
+    return TestClient(create_app())
+
+
+# ---------------------------------------------------------------------------
+# GET — empty / not-configured
+# ---------------------------------------------------------------------------
+
+
+def test_get_latest_returns_404_when_empty(wired_app, client):
+    resp = client.get("/api/dashboard/leverage-bounds")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert "leverage_bounds" in body["detail"]["title"]
+
+
+def test_get_version_returns_404_for_missing(wired_app, client):
+    resp = client.get("/api/dashboard/leverage-bounds/42")
+    assert resp.status_code == 404
+
+
+def test_get_version_validates_min_version(wired_app, client):
+    resp = client.get("/api/dashboard/leverage-bounds/0")
+    # FastAPI Path(ge=1) → 422
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PUT happy path — full AC6.a/b/c/d roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_put_writes_version_1_with_full_side_effects(wired_app, client):
+    fake_db, publisher = wired_app
+    payload = {
+        "per_strategy": {"momentum-v3": 2, "meanrev-v1": 1},
+        "aggregate_ceiling": 3.5,
+        "changed_by": "ops@petrosa",
+        "reason": "initial bounds",
+    }
+
+    resp = client.put("/api/dashboard/leverage-bounds", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # AC6.a — storage at v1
+    assert body["bounds"]["version"] == 1
+    assert body["bounds"]["per_strategy"] == {"momentum-v3": 2, "meanrev-v1": 1}
+    assert body["bounds"]["aggregate_ceiling"] == 3.5
+
+    # AC6.d — diff carries all-as-added (no previous version)
+    assert body["diff"]["from_version"] is None
+    assert body["diff"]["to_version"] == 1
+    assert body["diff"]["per_strategy_added"] == {
+        "momentum-v3": 2,
+        "meanrev-v1": 1,
+    }
+    assert body["diff"]["aggregate_ceiling_changed"] == [0.0, 3.5]
+
+    # AC6.d wiring — audit-trail row persisted.
+    audit_col = fake_db.mongodb_adapter.db[LEVERAGE_BOUNDS_AUDIT_COLLECTION]
+    assert len(audit_col.docs) == 1
+    audit_doc = audit_col.docs[0]
+    assert audit_doc["kind"] == "leverage_bounds_update"
+    assert audit_doc["to_version"] == 1
+    assert audit_doc["from_version"] is None
+    assert audit_doc["changed_by"] == "ops@petrosa"
+    assert audit_doc["reason"] == "initial bounds"
+
+    # AC6.c — NATS publish.
+    assert body["nats_published"] is True
+    assert len(publisher.published) == 1
+    subject, msg = publisher.published[0]
+    assert subject == LEVERAGE_BOUNDS_NATS_SUBJECT
+    assert msg["version"] == 1
+    assert msg["aggregate_ceiling"] == 3.5
+
+
+def test_put_second_version_diffs_against_first(wired_app, client):
+    fake_db, publisher = wired_app
+
+    # v1
+    client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {"s1": 2},
+            "aggregate_ceiling": 5.0,
+            "changed_by": "ops",
+            "reason": "v1",
+        },
+    )
+    # v2 — s1 cap changes; aggregate unchanged.
+    resp = client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {"s1": 4, "s2": 1},
+            "aggregate_ceiling": 5.0,
+            "changed_by": "ops",
+            "reason": "v2",
+        },
+    )
+    body = resp.json()
+    assert body["bounds"]["version"] == 2
+    assert body["diff"]["per_strategy_changed"] == {"s1": [2, 4]}
+    assert body["diff"]["per_strategy_added"] == {"s2": 1}
+    assert body["diff"]["per_strategy_removed"] == {}
+    assert body["diff"]["aggregate_ceiling_changed"] is None
+
+    audit_col = fake_db.mongodb_adapter.db[LEVERAGE_BOUNDS_AUDIT_COLLECTION]
+    assert len(audit_col.docs) == 2
+    assert publisher.published[-1][1]["version"] == 2
+
+
+def test_put_validates_negative_aggregate_ceiling(wired_app, client):
+    resp = client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {},
+            "aggregate_ceiling": -0.5,
+            "changed_by": "ops",
+            "reason": "bad",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_put_validates_missing_changed_by(wired_app, client):
+    resp = client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {},
+            "aggregate_ceiling": 1.0,
+            "changed_by": "",
+            "reason": "bad",
+        },
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET — after PUT
+# ---------------------------------------------------------------------------
+
+
+def test_get_latest_returns_most_recent_put(wired_app, client):
+    client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {"s1": 2},
+            "aggregate_ceiling": 5.0,
+            "changed_by": "ops",
+            "reason": "v1",
+        },
+    )
+    client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {"s1": 3},
+            "aggregate_ceiling": 5.0,
+            "changed_by": "ops",
+            "reason": "v2",
+        },
+    )
+    resp = client.get("/api/dashboard/leverage-bounds")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == 2
+    assert body["per_strategy"] == {"s1": 3}
+
+
+def test_get_version_exact_lookup(wired_app, client):
+    client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {"s1": 2},
+            "aggregate_ceiling": 5.0,
+            "changed_by": "ops",
+            "reason": "v1",
+        },
+    )
+    client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {"s1": 4},
+            "aggregate_ceiling": 5.0,
+            "changed_by": "ops",
+            "reason": "v2",
+        },
+    )
+
+    v1_resp = client.get("/api/dashboard/leverage-bounds/1")
+    assert v1_resp.status_code == 200
+    assert v1_resp.json()["per_strategy"] == {"s1": 2}
+
+    v2_resp = client.get("/api/dashboard/leverage-bounds/2")
+    assert v2_resp.json()["per_strategy"] == {"s1": 4}
+
+
+def test_list_versions_returns_descending(wired_app, client):
+    for n in range(1, 4):
+        client.put(
+            "/api/dashboard/leverage-bounds",
+            json={
+                "per_strategy": {},
+                "aggregate_ceiling": float(n),
+                "changed_by": "ops",
+                "reason": f"v{n}",
+            },
+        )
+    resp = client.get("/api/dashboard/leverage-bounds/versions")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["versions"] == [3, 2, 1]
+    assert body["count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# NATS publisher failure — must not break the route
+# ---------------------------------------------------------------------------
+
+
+def test_put_succeeds_when_nats_unavailable(wired_app, client):
+    """No publisher wired → PUT still writes storage + audit and returns nats_published=False."""
+    set_leverage_bounds_publisher(None)
+    fake_db, _ = wired_app
+    resp = client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {"s1": 2},
+            "aggregate_ceiling": 5.0,
+            "changed_by": "ops",
+            "reason": "nats-down",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["nats_published"] is False
+    audit_col = fake_db.mongodb_adapter.db[LEVERAGE_BOUNDS_AUDIT_COLLECTION]
+    assert len(audit_col.docs) == 1
+
+
+def test_put_continues_when_publisher_raises(wired_app, client):
+    """A broken publisher must not break the operator-facing PUT."""
+
+    class _BrokenPublisher:
+        async def publish(self, subject, payload):
+            raise RuntimeError("nats down")
+
+    set_leverage_bounds_publisher(_BrokenPublisher())
+    resp = client.put(
+        "/api/dashboard/leverage-bounds",
+        json={
+            "per_strategy": {"s1": 2},
+            "aggregate_ceiling": 5.0,
+            "changed_by": "ops",
+            "reason": "nats-broken",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["nats_published"] is False


### PR DESCRIPTION
## Summary

Closes petrosa-data-manager#182 — second (and final) half of `[P1.5-AC6] Operator-configurable leverage bounds + versioning (FR61)`.

Builds on PR #185 (model + repository, merged 2026-05-29) to ship the dashboard surface + side-effects.

## ACs delivered

- **AC6.b — Dashboard endpoints**: new `data_manager/api/routes/leverage_bounds.py`
  - `GET /api/dashboard/leverage-bounds` — latest version (404 when uninitialized).
  - `GET /api/dashboard/leverage-bounds/{version}` — exact version (404 + Path(ge=1) validation).
  - `GET /api/dashboard/leverage-bounds/versions` — descending version index.
  - `PUT /api/dashboard/leverage-bounds` — writes a new monotonic version, returns `{bounds, diff, nats_published}`.

  The router is mounted from `create_app()` *without* a router-level prefix because the in-path prefix already carries `/api/dashboard`. Routes co-locate cleanly with the existing `dashboard.py` per the SPA-architecture memory.

- **AC6.c — NATS publish on PUT**: `cio.config.leverage_bounds.updated` published via an injectable publisher (`set_leverage_bounds_publisher(...)`). Wiring the real `_DeferredNatsClient` from `data_manager/main.py` is a 1-line follow-up; this PR ships the testable contract + recording-publisher tests. Publish is best-effort — operator PUT never fails on NATS hiccup, with `nats_published` flag in the response telling the operator the side-effect outcome.

- **AC6.d (wiring) — Audit-trail diff**: PUT computes `LeverageBoundsDiff` against the previous version (via `LeverageBoundsDiff.compute(previous, current)` from PR #185) and persists it to a new `leverage_bounds_audit` Mongo collection with `kind=leverage_bounds_update`, `changed_by`, `changed_at`, `reason`, the full diff fields, and a `logged_at` timestamp. Insert is best-effort — audit failure logs but never blocks the operator.

## Files

- `data_manager/api/routes/leverage_bounds.py` *(new, ~241 LoC)* — route handlers + helpers + module-level publisher hook.
- `data_manager/api/app.py` — adds `leverage_bounds` to the routes import + mounts the router (4-line diff).
- `tests/unit/test_leverage_bounds_routes.py` *(new, ~398 LoC, 12 tests)* — FastAPI `TestClient` against `create_app()` with in-memory Mongo + recording NATS publisher.

## Test results

```
.venv/bin/python -m pytest tests/unit/test_leverage_bounds_routes.py
12 passed in 0.98s

.venv/bin/python -m pytest tests/
876 passed, 3 skipped, 136 warnings in 10.13s

.venv/bin/python -m ruff check data_manager/api/routes/leverage_bounds.py tests/unit/test_leverage_bounds_routes.py data_manager/api/app.py
All checks passed!
```

## Follow-ups (not in this PR — intentional)

- 1-line wiring in `data_manager/main.py`: at app boot, call `set_leverage_bounds_publisher(_DeferredNatsClient(...))` so the route uses the real NATS connection.
- CIO-side subscriber to `cio.config.leverage_bounds.updated` (separate sibling ticket — out of scope for the data-manager ticket).
- SPA frontend pane — gated by petrosa_k8s#657 (dashboard image-build pipeline gap).

## References

- Sibling PR: petrosa-data-manager#185 (model + repository + diff format)
- Parent EPIC: petrosa_k8s#691 (P1.5 leverage governance)
- PRD: FR61, FR12
