### PR TITLE
feat(743): /api/dashboard/dr-status endpoint (P9-AC5.c)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -22,6 +22,7 @@ from data_manager.api.routes import (
     config,
     dashboard,
     data,
+    dr_status,
     drawdown,
     fidelity,
     generic,
@@ -158,6 +159,9 @@ def create_app() -> FastAPI:
     # leverage_bounds routes already include the /api/dashboard prefix in-path
     # so they're registered without a router-level prefix.
     app.include_router(leverage_bounds.router, tags=["Dashboard"])
+    # dr_status route also carries the /api/dashboard prefix in-path
+    # (#743 / P9-AC5.c).
+    app.include_router(dr_status.router, tags=["Dashboard"])
 
     # New API routes
     app.include_router(generic.router, tags=["Generic CRUD"])

--- a/data_manager/api/routes/dr_status.py
+++ b/data_manager/api/routes/dr_status.py
@@ -1,0 +1,129 @@
+"""DR status dashboard endpoint (petrosa_k8s#743, P9-AC5.c, NFR-R6).
+
+Single endpoint that surfaces the latest audit-trail restore-exercise
+verdict to the operator dashboard. The petrosa_k8s side (#743) ships
+the 90-day CronJob that writes ``restore_exercises`` rows; this route
+reads the latest row and returns the canonical AC5.c triple:
+
+  * ``last_exercise_at``
+  * ``last_exercise_outcome``
+  * ``days_since_last_exercise``
+
+Plus the snapshot id and operator identity from the row so the
+dashboard can render a one-glance DR-health card without a second
+round-trip.
+
+Mounted at ``/api/dashboard/dr-status`` from
+:func:`data_manager.api.app.create_app`. Patterns track the
+leverage-bounds routes shipped in #182 (PR #186): in-path
+``/api/dashboard`` prefix, error-as-RFC7807 problem JSON, MongoDB
+adapter pulled off ``api_module.db_manager``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from fastapi import APIRouter, HTTPException
+
+import data_manager.api.app as api_module
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+RESTORE_EXERCISES_COLLECTION = "restore_exercises"
+
+
+def _require_mongo():  # type: ignore[no-untyped-def]
+    if not api_module.db_manager or not getattr(
+        api_module.db_manager, "mongodb_adapter", None
+    ):
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "title": "MongoDB unavailable",
+                "detail": "data-manager is not connected to MongoDB",
+            },
+        )
+    return api_module.db_manager.mongodb_adapter
+
+
+def _coerce_exercised_at(value: Any) -> datetime | None:
+    """Mongo rows store ``exercised_at`` as a BSON Date, which motor
+    decodes as a ``datetime``. Defensive fallback for string-coerced rows
+    written by ad-hoc scripts."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+@router.get("/api/dashboard/dr-status")
+async def dr_status() -> dict[str, Any]:
+    """Latest restore-exercise verdict + age in days.
+
+    Response shape (AC5.c):
+
+    ::
+
+        {
+            "last_exercise_at":     "<ISO-8601 UTC>" | null,
+            "last_exercise_outcome": "pass" | "fail" | null,
+            "days_since_last_exercise": <int> | null,
+            "snapshot_id":           "<string>" | null,
+            "operator":              "<string>" | null
+        }
+
+    All fields are ``null`` when the collection has no rows
+    (no exercise ever ran). The dashboard renders this as
+    "DR exercise never run — schedule one" with a red status badge
+    via NFR-R6 AC5's cadence rule.
+    """
+    mongo = _require_mongo()
+    col = mongo.db[RESTORE_EXERCISES_COLLECTION]
+    doc = await col.find_one({}, sort=[("exercised_at", -1)])
+
+    if doc is None:
+        return {
+            "last_exercise_at": None,
+            "last_exercise_outcome": None,
+            "days_since_last_exercise": None,
+            "snapshot_id": None,
+            "operator": None,
+        }
+
+    exercised_at = _coerce_exercised_at(doc.get("exercised_at"))
+    if exercised_at is None:
+        days_since = None
+        iso_exercised_at = None
+    else:
+        now = datetime.now(UTC)
+        days_since = int((now - exercised_at).total_seconds() // 86400)
+        iso_exercised_at = exercised_at.astimezone(UTC).isoformat().replace(
+            "+00:00", "Z"
+        )
+
+    return {
+        "last_exercise_at": iso_exercised_at,
+        "last_exercise_outcome": doc.get("outcome"),
+        "days_since_last_exercise": days_since,
+        "snapshot_id": doc.get("snapshot_id"),
+        "operator": doc.get("operator"),
+    }

--- a/data_manager/api/routes/dr_status.py
+++ b/data_manager/api/routes/dr_status.py
@@ -116,8 +116,8 @@ async def dr_status() -> dict[str, Any]:
     else:
         now = datetime.now(UTC)
         days_since = int((now - exercised_at).total_seconds() // 86400)
-        iso_exercised_at = exercised_at.astimezone(UTC).isoformat().replace(
-            "+00:00", "Z"
+        iso_exercised_at = (
+            exercised_at.astimezone(UTC).isoformat().replace("+00:00", "Z")
         )
 
     return {

--- a/tests/unit/test_dr_status_route.py
+++ b/tests/unit/test_dr_status_route.py
@@ -1,0 +1,274 @@
+"""Tests for /api/dashboard/dr-status (petrosa_k8s#743, P9-AC5.c)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.api.app import create_app
+from data_manager.api.routes.dr_status import RESTORE_EXERCISES_COLLECTION
+
+
+class _FakeCursor:
+    """Minimal motor-cursor shim — supports the same `sort` chaining the
+    real route uses via the `find_one({}, sort=[(...)])` path. Most of
+    the route's read path goes through `find_one`, not `find`, so the
+    cursor surface stays small."""
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    def __aiter__(self):  # pragma: no cover — not used by dr-status route
+        return iter(self._docs)
+
+
+class _FakeCollection:
+    def __init__(self) -> None:
+        self.docs: list[dict] = []
+
+    async def find_one(self, query: dict, sort=None):
+        docs = list(self.docs)
+        if sort:
+            field, direction = sort[0]
+            docs.sort(key=lambda d: d.get(field, 0), reverse=direction < 0)
+        if not docs:
+            return None
+        # Mirror the route's filter (always empty {} here).
+        return dict(docs[0])
+
+    async def insert_one(self, doc: dict):
+        doc = dict(doc)
+        if "_id" not in doc:
+            doc["_id"] = f"_autogen-{len(self.docs)}"
+        self.docs.append(doc)
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self._collections: dict[str, _FakeCollection] = {}
+
+    def __getitem__(self, name: str) -> _FakeCollection:
+        return self._collections.setdefault(name, _FakeCollection())
+
+
+class _FakeMongoAdapter:
+    def __init__(self) -> None:
+        self.db = _FakeDb()
+
+
+class _FakeDbManager:
+    def __init__(self) -> None:
+        self.mongodb_adapter = _FakeMongoAdapter()
+        self.mysql_adapter = None
+
+
+@pytest.fixture
+def wired_app():
+    original = api_module.db_manager
+    fake = _FakeDbManager()
+    api_module.db_manager = fake
+    try:
+        yield fake
+    finally:
+        api_module.db_manager = original
+
+
+@pytest.fixture
+def client():
+    return TestClient(create_app())
+
+
+# ---------------------------------------------------------------------------
+# Empty-collection case
+# ---------------------------------------------------------------------------
+
+
+def test_dr_status_returns_all_nulls_when_collection_empty(wired_app, client):
+    resp = client.get("/api/dashboard/dr-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "last_exercise_at": None,
+        "last_exercise_outcome": None,
+        "days_since_last_exercise": None,
+        "snapshot_id": None,
+        "operator": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path — recent pass row
+# ---------------------------------------------------------------------------
+
+
+def test_dr_status_returns_latest_pass(wired_app, client):
+    fake_db = wired_app
+    col = fake_db.mongodb_adapter.db[RESTORE_EXERCISES_COLLECTION]
+    # Insert two rows; expect the newer one (sort=exercised_at desc).
+    older = datetime(2026, 1, 15, 3, 0, tzinfo=UTC)
+    newer = datetime(2026, 4, 15, 3, 0, tzinfo=UTC)
+    import asyncio
+
+    async def seed():
+        await col.insert_one(
+            {
+                "exercised_at": older,
+                "outcome": "pass",
+                "snapshot_id": "audit-trail/2026-01-15-abc.archive.gz",
+                "operator": "ops@petrosa",
+            }
+        )
+        await col.insert_one(
+            {
+                "exercised_at": newer,
+                "outcome": "pass",
+                "snapshot_id": "audit-trail/2026-04-15-def.archive.gz",
+                "operator": "restore-exercise-cronjob",
+            }
+        )
+
+    asyncio.run(seed())
+
+    resp = client.get("/api/dashboard/dr-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["last_exercise_outcome"] == "pass"
+    assert body["snapshot_id"] == "audit-trail/2026-04-15-def.archive.gz"
+    assert body["operator"] == "restore-exercise-cronjob"
+    assert body["last_exercise_at"] is not None
+    assert body["last_exercise_at"].startswith("2026-04-15")
+    assert isinstance(body["days_since_last_exercise"], int)
+    assert body["days_since_last_exercise"] >= 0
+
+
+def test_dr_status_returns_recent_fail(wired_app, client):
+    """A failed exercise must surface as outcome='fail' so the dashboard
+    can render the red badge that NFR-R6 AC5 calls for."""
+    fake_db = wired_app
+    col = fake_db.mongodb_adapter.db[RESTORE_EXERCISES_COLLECTION]
+    import asyncio
+
+    async def seed():
+        await col.insert_one(
+            {
+                "exercised_at": datetime.now(UTC) - timedelta(days=5),
+                "outcome": "fail",
+                "snapshot_id": "audit-trail/2026-05-24-ghi.archive.gz",
+                "operator": "restore-exercise-cronjob",
+            }
+        )
+
+    asyncio.run(seed())
+
+    resp = client.get("/api/dashboard/dr-status")
+    body = resp.json()
+    assert body["last_exercise_outcome"] == "fail"
+    assert body["days_since_last_exercise"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Cadence breach — last exercise older than NFR-R6 AC5's 90d window
+# ---------------------------------------------------------------------------
+
+
+def test_dr_status_reports_age_days_when_breaching_90d(wired_app, client):
+    fake_db = wired_app
+    col = fake_db.mongodb_adapter.db[RESTORE_EXERCISES_COLLECTION]
+    import asyncio
+
+    async def seed():
+        await col.insert_one(
+            {
+                "exercised_at": datetime.now(UTC) - timedelta(days=120),
+                "outcome": "pass",
+                "snapshot_id": "audit-trail/stale.archive.gz",
+                "operator": "ops",
+            }
+        )
+
+    asyncio.run(seed())
+
+    resp = client.get("/api/dashboard/dr-status")
+    body = resp.json()
+    # We don't break the contract over a stale exercise — that's the
+    # dashboard's job to render. Just expose the truth.
+    assert body["days_since_last_exercise"] >= 120
+    assert body["last_exercise_outcome"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Defensive — string-encoded `exercised_at` from an ad-hoc script
+# ---------------------------------------------------------------------------
+
+
+def test_dr_status_handles_iso_string_exercised_at(wired_app, client):
+    fake_db = wired_app
+    col = fake_db.mongodb_adapter.db[RESTORE_EXERCISES_COLLECTION]
+    import asyncio
+
+    async def seed():
+        await col.insert_one(
+            {
+                "exercised_at": "2026-05-01T03:00:00Z",
+                "outcome": "pass",
+                "snapshot_id": "audit-trail/2026-05-01.archive.gz",
+                "operator": "ad-hoc-script",
+            }
+        )
+
+    asyncio.run(seed())
+
+    resp = client.get("/api/dashboard/dr-status")
+    body = resp.json()
+    assert body["last_exercise_at"] is not None
+    assert "2026-05-01" in body["last_exercise_at"]
+    assert isinstance(body["days_since_last_exercise"], int)
+
+
+def test_dr_status_handles_unparseable_exercised_at(wired_app, client):
+    """An ad-hoc row with a malformed timestamp doesn't crash the
+    dashboard — the field returns null, dashboard renders 'unknown'."""
+    fake_db = wired_app
+    col = fake_db.mongodb_adapter.db[RESTORE_EXERCISES_COLLECTION]
+    import asyncio
+
+    async def seed():
+        await col.insert_one(
+            {
+                "exercised_at": "not-a-timestamp",
+                "outcome": "pass",
+                "snapshot_id": "audit-trail/broken.archive.gz",
+                "operator": "broken-script",
+            }
+        )
+
+    asyncio.run(seed())
+
+    resp = client.get("/api/dashboard/dr-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["last_exercise_at"] is None
+    assert body["days_since_last_exercise"] is None
+    # Other fields still surfaced — outcome + operator are not parsed.
+    assert body["last_exercise_outcome"] == "pass"
+    assert body["operator"] == "broken-script"
+
+
+# ---------------------------------------------------------------------------
+# 503 when MongoDB is absent
+# ---------------------------------------------------------------------------
+
+
+def test_dr_status_503_when_mongo_unavailable(client):
+    original = api_module.db_manager
+    api_module.db_manager = None
+    try:
+        resp = client.get("/api/dashboard/dr-status")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert "mongodb" in body["detail"]["title"].lower()
+    finally:
+        api_module.db_manager = original


### PR DESCRIPTION
## Summary

AC5.c half of petrosa_k8s#743 — the data-manager dashboard surface for the 90-day audit-trail restore-exercise verdict. Pairs with petrosa_k8s#760 (the CronJob that writes the rows this endpoint reads).

## Endpoint

`GET /api/dashboard/dr-status` → reads the latest `restore_exercises` row sorted by `exercised_at` desc and returns:

```json
{
  "last_exercise_at":     "2026-04-15T03:00:00Z",
  "last_exercise_outcome": "pass",
  "days_since_last_exercise": 44,
  "snapshot_id":           "audit-trail/2026-04-15-abc.archive.gz",
  "operator":              "restore-exercise-cronjob"
}
```

All fields are `null` when the collection is empty (dashboard renders the 'never run' badge). 503 when MongoDB is unreachable.

## Files

- `data_manager/api/routes/dr_status.py` *(new, ~129 LoC)* — the route. Mounted at `/api/dashboard/dr-status` from `create_app()` (same in-path-prefix pattern as the leverage-bounds routes from PR #186).
- `data_manager/api/app.py` — adds `dr_status` to the imports + mounts the router.
- `tests/unit/test_dr_status_route.py` *(new, 7 tests)* — FastAPI TestClient against `create_app()` with in-memory Mongo. Covers: empty collection, recent pass, recent fail, 90d breach, ISO-string exercised_at (defensive against ad-hoc-written rows), unparseable timestamp (defensive — fields null, no crash), 503 when Mongo absent.

## Test results

```
.venv/bin/python -m pytest tests/unit/test_dr_status_route.py
7 passed in 0.74s

.venv/bin/python -m pytest tests/
883 passed, 3 skipped, 136 warnings in 11.24s

.venv/bin/python -m ruff check data_manager/api/routes/dr_status.py tests/unit/test_dr_status_route.py data_manager/api/app.py
All checks passed!
```

## References

- petrosa_k8s#743 (this closes AC5.c; AC5.a + AC5.b shipped via petrosa_k8s#760)
- Pattern: petrosa-data-manager#186 (leverage-bounds dashboard routes)
- PRD: NFR-R6 AC5+AC6 (90-day rehearsal cadence)