### PR TITLE
feat(188): versioned envelope store (FR62, P4.6-AC2)

### DIFF
--- a/data_manager/db/repositories/envelope_repository.py
+++ b/data_manager/db/repositories/envelope_repository.py
@@ -1,0 +1,255 @@
+"""Repository for the ``envelopes`` Mongo collection (#188, P4.6-AC2 / FR62).
+
+Versioned reads + writes for active envelopes, per ``strategy_or_portfolio_key``.
+
+  * :meth:`get_active_envelope` — newest version for a key (AC2.e).
+  * :meth:`get_version` — exact (key, version-int) lookup.
+  * :meth:`list_versions` — version numbers for a key, descending, for the
+    operator history pane.
+  * :meth:`insert_next_version` — write a new monotonically-versioned document
+    for a given key (AC2.b). Concurrency-safe via Mongo's unique ``_id``
+    constraint: two writers racing each other will each compute ``v<n>``,
+    but only one insert succeeds; the loser retries with ``v<n+1>``.
+  * :meth:`ensure_indexes` — create the compound
+    ``(strategy_or_portfolio_key, version DESC)`` index (AC2.d). Idempotent.
+
+Append-only by design (AC2.c): the repository exposes no update or delete
+methods. Old versions remain queryable for breach-event audit hydration
+in 692.6.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pymongo.errors import DuplicateKeyError
+
+from data_manager.db.repositories.base_repository import BaseRepository
+from data_manager.models.envelope import Envelope, EnvelopeSource
+
+if TYPE_CHECKING:
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+    from data_manager.db.mysql_adapter import MySQLAdapter
+
+logger = logging.getLogger(__name__)
+
+ENVELOPES_COLLECTION = "envelopes"
+"""Default collection name; overridable per-instance for tests."""
+
+_MAX_INSERT_RETRIES = 8
+"""Cap on racing-writer retries before surfacing the conflict as an error.
+
+The retry loop computes ``v<n+1>`` after each conflict, so 8 iterations
+covers 8 concurrent writers — well beyond realistic contention on the
+envelope-write path (operator approvals are human-paced; characterization
+is sequential per pipeline run).
+"""
+
+
+class EnvelopeRepository(BaseRepository):
+    """MongoDB-backed repository for versioned envelopes (per FR62)."""
+
+    def __init__(
+        self,
+        mysql_adapter: MySQLAdapter | None = None,
+        mongodb_adapter: MongoDBAdapter | None = None,
+        collection_name: str = ENVELOPES_COLLECTION,
+    ) -> None:
+        super().__init__(mysql_adapter=mysql_adapter, mongodb_adapter=mongodb_adapter)
+        self._collection_name = collection_name
+
+    def _collection(self):  # type: ignore[no-untyped-def]
+        if self.mongodb is None:  # pragma: no cover — wiring guard
+            raise RuntimeError("EnvelopeRepository requires a MongoDB adapter")
+        return self.mongodb.db[self._collection_name]
+
+    @staticmethod
+    def _doc_to_envelope(doc: dict[str, Any] | None) -> Envelope | None:
+        if doc is None:
+            return None
+        payload = {k: v for k, v in doc.items() if k != "_id"}
+        return Envelope.model_validate(payload)
+
+    async def ensure_indexes(self) -> None:
+        """Create the compound ``(strategy_or_portfolio_key, version DESC)`` index (AC2.d).
+
+        Idempotent — repeated calls are no-ops. Should be invoked once during
+        service startup (e.g. from ``data_manager.startup.ensure_collection_indexes``).
+        """
+        col = self._collection()
+        await col.create_index(
+            [("strategy_or_portfolio_key", 1), ("version", -1)],
+            name="strategy_or_portfolio_key_1_version_-1",
+            background=True,
+        )
+
+    async def get_active_envelope(
+        self, key: str
+    ) -> tuple[int, dict[str, Any], EnvelopeSource] | None:
+        """Return the latest envelope for ``key`` (AC2.e).
+
+        Returns a 3-tuple ``(version, value, source)`` for the highest-version
+        document with ``strategy_or_portfolio_key == key``, or ``None`` if no
+        envelope exists for that key.
+
+        Used by 692.3 consumers (decision-path envelope hydration) — the
+        return shape is the minimal contract that path needs.
+        """
+        col = self._collection()
+        doc = await col.find_one(
+            {"strategy_or_portfolio_key": key},
+            sort=[("version", -1)],
+        )
+        if doc is None:
+            return None
+        return doc["version"], doc["value"], doc["source"]
+
+    async def get_full_active_envelope(self, key: str) -> Envelope | None:
+        """Same as :meth:`get_active_envelope`, but returns the full Envelope model.
+
+        For consumers (e.g. 692.6 breach-event audit hydration) that need
+        ``signed_action_id`` / ``originating_characterization_revision`` /
+        ``operator_id``.
+        """
+        col = self._collection()
+        doc = await col.find_one(
+            {"strategy_or_portfolio_key": key},
+            sort=[("version", -1)],
+        )
+        return self._doc_to_envelope(doc)
+
+    async def get_version(self, key: str, version: int) -> Envelope | None:
+        """Exact (key, version) lookup for historical envelope queries."""
+        col = self._collection()
+        doc = await col.find_one({"strategy_or_portfolio_key": key, "version": version})
+        return self._doc_to_envelope(doc)
+
+    async def list_versions(self, key: str, limit: int = 50) -> list[int]:
+        """Version numbers for ``key`` in descending order (operator history pane).
+
+        ``limit`` defaults to 50 to keep the history-pane payload small;
+        callers needing the full history can pass a larger limit.
+        """
+        col = self._collection()
+        cursor = (
+            col.find(
+                {"strategy_or_portfolio_key": key},
+                projection={"version": 1, "_id": 0},
+            )
+            .sort("version", -1)
+            .limit(limit)
+        )
+        return [doc["version"] async for doc in cursor]
+
+    async def insert_next_version(self, envelope: Envelope) -> Envelope:
+        """Insert ``envelope`` at version = (latest-for-key + 1) (AC2.b).
+
+        The caller is responsible for setting every non-version, non-id
+        field on the ``envelope`` argument; this method:
+
+        * Computes the next ``version`` for ``envelope.strategy_or_portfolio_key``.
+        * Stamps ``envelope.version`` and ``envelope.envelope_id``.
+        * Inserts with the composite Mongo ``_id`` ``"<key>:v<n>"``.
+        * Retries on ``DuplicateKeyError`` (concurrent writer raced us) by
+          recomputing the next version, up to ``_MAX_INSERT_RETRIES``.
+
+        Returns the version-stamped, persisted model. Raises ``RuntimeError``
+        if the retry cap is exhausted (theoretically unreachable under
+        realistic contention; surfaces as a hard failure rather than a
+        silent slot collision).
+        """
+        col = self._collection()
+        key = envelope.strategy_or_portfolio_key
+
+        for attempt in range(_MAX_INSERT_RETRIES):
+            latest = await col.find_one(
+                {"strategy_or_portfolio_key": key},
+                sort=[("version", -1)],
+                projection={"version": 1, "_id": 0},
+            )
+            next_version = (latest["version"] + 1) if latest else 1
+
+            stamped = envelope.model_copy(
+                update={
+                    "version": next_version,
+                    "envelope_id": f"{key}:v{next_version}",
+                }
+            )
+            document = stamped.model_dump(mode="json")
+            document["_id"] = stamped.doc_id()
+            try:
+                await col.insert_one(document)
+                logger.info(
+                    "envelope.inserted key=%s version=%d source=%s signed_action_id=%s",
+                    key,
+                    next_version,
+                    stamped.source,
+                    stamped.signed_action_id,
+                )
+                return stamped
+            except DuplicateKeyError:
+                logger.warning(
+                    "envelope.insert.race key=%s version=%d attempt=%d — retrying",
+                    key,
+                    next_version,
+                    attempt + 1,
+                )
+                continue
+
+        raise RuntimeError(
+            f"envelope.insert.cap_exhausted key={key!r} after {_MAX_INSERT_RETRIES} attempts"
+        )
+
+    async def seed_legacy_characterization_envelopes(
+        self,
+        legacy_envelopes: list[tuple[str, dict[str, Any], str | None, str]],
+    ) -> int:
+        """One-shot migration helper (AC2.f).
+
+        Seeds existing characterization-derived envelopes — passed by the
+        caller as a list of ``(key, value, char_revision, signed_action_id)``
+        tuples — as ``version=1`` documents with ``source='characterization'``.
+
+        Skips any key that already has at least one document (idempotent,
+        re-runnable). Returns the count of envelopes actually seeded.
+
+        The caller is responsible for sourcing the legacy data — this
+        method intentionally does not query upstream collections so it
+        can be unit-tested without those dependencies, and so the data
+        flow is auditable.
+        """
+        col = self._collection()
+        seeded = 0
+        for key, value, char_revision, signed_action_id in legacy_envelopes:
+            existing = await col.find_one(
+                {"strategy_or_portfolio_key": key},
+                projection={"_id": 1},
+            )
+            if existing is not None:
+                continue
+            seed = Envelope(
+                envelope_id=f"{key}:v1",
+                version=1,
+                strategy_or_portfolio_key=key,
+                value=value,
+                source="characterization",
+                originating_characterization_revision=char_revision,
+                operator_id=None,
+                signed_action_id=signed_action_id,
+            )
+            document = seed.model_dump(mode="json")
+            document["_id"] = seed.doc_id()
+            try:
+                await col.insert_one(document)
+                seeded += 1
+            except DuplicateKeyError:
+                # Race with a live writer for the same key; skip and let
+                # the live write win (it's strictly newer than this seed).
+                logger.warning(
+                    "envelope.seed.race key=%s — skipped (live writer won)",
+                    key,
+                )
+                continue
+        logger.info("envelope.seed_legacy.complete seeded=%d", seeded)
+        return seeded

--- a/data_manager/models/envelope.py
+++ b/data_manager/models/envelope.py
@@ -1,0 +1,120 @@
+"""Versioned drawdown / portfolio envelopes (#188, P4.6-AC2 / FR62).
+
+Each accepted envelope (either characterization-derived or operator-approved
+via 692.1's signed-action approval API) writes a new monotonically-versioned
+document, keyed per ``strategy_or_portfolio_key``, to the ``envelopes``
+collection. Readers always fetch the latest version for a given key via
+:meth:`data_manager.db.repositories.envelope_repository.EnvelopeRepository.get_active_envelope`.
+
+Older versions are never mutated — operators (and the breach-event audit
+join in 692.6) can trace exactly which envelope was in force at any point
+in time, and the audit-trail carries the diff between versions.
+
+## Key shape decision (#188 AC2.a)
+
+The AC names the partitioning column ``strategy_or_portfolio_key`` without
+declaring whether it's a flat string or a structured composite. This model
+adopts **flat string** for parity with existing FR61 patterns
+(``LeverageBounds.per_strategy: dict[str, int]`` keys are flat strings).
+
+Recommended forms:
+
+* For a per-strategy envelope: ``"strategy:<strategy_id>"`` (e.g. ``"strategy:btc_momentum_v3"``).
+* For a portfolio-level envelope: ``"portfolio:<portfolio_id>"`` (e.g. ``"portfolio:operator-1"``).
+
+The repository does NOT enforce a prefix scheme — callers are responsible
+for choosing a stable, non-overlapping namespace. The compound index
+``(strategy_or_portfolio_key, version)`` makes lookups O(log n) regardless
+of the chosen scheme.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from pydantic import BaseModel, Field
+
+EnvelopeSource = Literal["characterization", "operator_approved"]
+
+
+class Envelope(BaseModel):
+    """A versioned snapshot of an active envelope (per AC2.a, P4.6-AC2 / FR62).
+
+    The Mongo ``_id`` of the persisted document is the composite
+    ``"<strategy_or_portfolio_key>:v<version>"``. The unique-id constraint
+    enforces AC2.b (strict monotonicity per key) — two writers racing for
+    the same ``v<n>`` cannot both succeed; the losing writer retries with
+    ``v<n+1>``. See :class:`EnvelopeRepository` for the retry loop.
+    """
+
+    envelope_id: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Stable identity for an envelope authored event. Suggested form: "
+            "``<strategy_or_portfolio_key>:v<version>``; the repository will "
+            "stamp it during insert."
+        ),
+    )
+    version: int = Field(..., ge=1, description="Monotonic version (1-based, per-key).")
+    strategy_or_portfolio_key: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Partition column. Flat string; see module docstring for the "
+            "recommended ``strategy:<id>`` / ``portfolio:<id>`` namespace."
+        ),
+    )
+    value: dict[str, Any] = Field(
+        ...,
+        description=(
+            "Schema-free envelope payload (caps, allowable drawdown, etc.). "
+            "Validated by consumers per their own contract; the store does "
+            "not assume a shape here."
+        ),
+    )
+    source: EnvelopeSource = Field(
+        ...,
+        description="Whether this envelope was characterization-derived or operator-approved.",
+    )
+    originating_characterization_revision: str | None = Field(
+        default=None,
+        description=(
+            "FR53 link — when ``source=='characterization'``, the revision id "
+            "of the characterization that produced this envelope. None for "
+            "``source=='operator_approved'`` (operator decision is the "
+            "originator of record)."
+        ),
+    )
+    operator_id: str | None = Field(
+        default=None,
+        description=(
+            "Operator identity for ``source=='operator_approved'`` envelopes. "
+            "None for characterization-derived ones."
+        ),
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="When this envelope version was written.",
+    )
+    signed_action_id: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Signed-action audit id (692.1 approval-API or the "
+            "characterization pipeline's signed-action id) that produced "
+            "this envelope. Joins this row to the FR12 audit trail."
+        ),
+    )
+
+    def doc_id(self) -> str:
+        """Mongo ``_id`` form (``"<key>:v<n>"``) used by the repository."""
+        return f"{self.strategy_or_portfolio_key}:v{self.version}"

--- a/tests/test_envelope_repository.py
+++ b/tests/test_envelope_repository.py
@@ -1,0 +1,221 @@
+"""Tests for EnvelopeRepository (#188, P4.6-AC2 / FR62)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from data_manager.db.repositories.envelope_repository import (
+    ENVELOPES_COLLECTION,
+    EnvelopeRepository,
+)
+from data_manager.models.envelope import Envelope
+
+
+def _build_envelope(
+    key: str = "strategy:btc_momentum_v3",
+    *,
+    version: int = 1,
+    source: str = "operator_approved",
+) -> Envelope:
+    return Envelope(
+        envelope_id=f"{key}:v{version}",
+        version=version,
+        strategy_or_portfolio_key=key,
+        value={"max_drawdown_pct": 5.0, "max_position_size": 25_000},
+        source=source,  # type: ignore[arg-type]
+        originating_characterization_revision=None,
+        operator_id="op-1" if source == "operator_approved" else None,
+        signed_action_id="signed-action-abc123",
+    )
+
+
+class _StubCursor:
+    """Async iterator stub for ``find().sort().limit()`` chains."""
+
+    def __init__(self, docs: list[dict[str, Any]]) -> None:
+        self._docs = list(docs)
+
+    def sort(self, *_args: Any, **_kwargs: Any) -> _StubCursor:
+        return self
+
+    def limit(self, _n: int) -> _StubCursor:
+        return self
+
+    def __aiter__(self) -> _StubCursor:
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        if not self._docs:
+            raise StopAsyncIteration
+        return self._docs.pop(0)
+
+
+@pytest.fixture
+def mock_mongo():
+    """A MagicMock that exposes ``db.envelopes`` with AsyncMock'd operations."""
+    mongo = MagicMock()
+    mongo.is_connected = True
+    mongo.db = MagicMock()
+    mongo.db[ENVELOPES_COLLECTION] = MagicMock()
+    col = mongo.db[ENVELOPES_COLLECTION]
+    col.find_one = AsyncMock(return_value=None)
+    col.insert_one = AsyncMock(return_value=None)
+    col.create_index = AsyncMock(return_value=None)
+    col.find = MagicMock(return_value=_StubCursor([]))
+    return mongo
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_creates_compound_index(mock_mongo):
+    """AC2.d — composite (strategy_or_portfolio_key, version DESC) index is created."""
+    repo = EnvelopeRepository(mongodb_adapter=mock_mongo)
+    await repo.ensure_indexes()
+    mock_mongo.db[ENVELOPES_COLLECTION].create_index.assert_awaited_once()
+    args, kwargs = mock_mongo.db[ENVELOPES_COLLECTION].create_index.call_args
+    assert args[0] == [("strategy_or_portfolio_key", 1), ("version", -1)]
+    assert kwargs["name"] == "strategy_or_portfolio_key_1_version_-1"
+
+
+@pytest.mark.asyncio
+async def test_get_active_envelope_returns_none_when_empty(mock_mongo):
+    """AC2.e — get_active_envelope returns None for an unknown key."""
+    repo = EnvelopeRepository(mongodb_adapter=mock_mongo)
+    mock_mongo.db[ENVELOPES_COLLECTION].find_one.return_value = None
+    result = await repo.get_active_envelope("strategy:unknown")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_active_envelope_returns_latest(mock_mongo):
+    """AC2.e — get_active_envelope returns (version, value, source) for the latest doc."""
+    envelope = _build_envelope(version=7, source="operator_approved")
+    stored = envelope.model_dump(mode="json")
+    stored["_id"] = envelope.doc_id()
+    mock_mongo.db[ENVELOPES_COLLECTION].find_one.return_value = stored
+
+    repo = EnvelopeRepository(mongodb_adapter=mock_mongo)
+    result = await repo.get_active_envelope("strategy:btc_momentum_v3")
+
+    assert result is not None
+    version, value, source = result
+    assert version == 7
+    assert value["max_drawdown_pct"] == 5.0
+    assert source == "operator_approved"
+
+    # The query MUST sort version desc — that's the contract that keeps
+    # AC2.b (monotonic versioning) intact for reads.
+    sort_arg = mock_mongo.db[ENVELOPES_COLLECTION].find_one.call_args.kwargs["sort"]
+    assert sort_arg == [("version", -1)]
+
+
+@pytest.mark.asyncio
+async def test_insert_next_version_stamps_v1_on_empty_key(mock_mongo):
+    """AC2.b — first insert for a new key gets version=1, deterministic doc_id."""
+    mock_mongo.db[ENVELOPES_COLLECTION].find_one.return_value = None
+    repo = EnvelopeRepository(mongodb_adapter=mock_mongo)
+
+    candidate = _build_envelope(
+        key="strategy:foo", version=999
+    )  # version pre-write is ignored
+    result = await repo.insert_next_version(candidate)
+
+    assert result.version == 1
+    assert result.envelope_id == "strategy:foo:v1"
+    assert result.doc_id() == "strategy:foo:v1"
+
+    # Persisted doc carries `_id` matching doc_id()
+    inserted_doc = mock_mongo.db[ENVELOPES_COLLECTION].insert_one.call_args.args[0]
+    assert inserted_doc["_id"] == "strategy:foo:v1"
+    assert inserted_doc["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_insert_next_version_increments_for_existing_key(mock_mongo):
+    """AC2.b — subsequent insert for an existing key gets latest+1."""
+    mock_mongo.db[ENVELOPES_COLLECTION].find_one.return_value = {"version": 3}
+    repo = EnvelopeRepository(mongodb_adapter=mock_mongo)
+
+    candidate = _build_envelope(key="strategy:foo", version=1)
+    result = await repo.insert_next_version(candidate)
+
+    assert result.version == 4
+    assert result.doc_id() == "strategy:foo:v4"
+
+
+@pytest.mark.asyncio
+async def test_insert_next_version_retries_on_duplicate_key(mock_mongo):
+    """AC2.b — racing writer that lost the v<n> insert retries at v<n+1>."""
+    # First find returns version=2, second returns version=3 (the racer landed at v3)
+    mock_mongo.db[ENVELOPES_COLLECTION].find_one.side_effect = [
+        {"version": 2},  # our compute → 3
+        {"version": 3},  # after dup error, recompute → 4
+    ]
+    mock_mongo.db[ENVELOPES_COLLECTION].insert_one.side_effect = [
+        DuplicateKeyError("dup v3"),  # racer won v3
+        None,  # we win v4
+    ]
+    repo = EnvelopeRepository(mongodb_adapter=mock_mongo)
+
+    result = await repo.insert_next_version(_build_envelope(key="strategy:foo"))
+
+    assert result.version == 4
+    assert mock_mongo.db[ENVELOPES_COLLECTION].insert_one.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_seed_legacy_skips_existing(mock_mongo):
+    """AC2.f — migration skips keys that already have at least one version."""
+    # First key already exists; second key is fresh.
+    mock_mongo.db[ENVELOPES_COLLECTION].find_one.side_effect = [
+        {"_id": "strategy:already:v5"},  # exists
+        None,  # fresh
+    ]
+    repo = EnvelopeRepository(mongodb_adapter=mock_mongo)
+
+    seeded = await repo.seed_legacy_characterization_envelopes(
+        [
+            ("strategy:already", {"a": 1}, "char-rev-1", "signed-1"),
+            ("strategy:fresh", {"b": 2}, "char-rev-2", "signed-2"),
+        ]
+    )
+
+    assert seeded == 1
+    inserted_doc = mock_mongo.db[ENVELOPES_COLLECTION].insert_one.call_args.args[0]
+    assert inserted_doc["strategy_or_portfolio_key"] == "strategy:fresh"
+    assert inserted_doc["source"] == "characterization"
+    assert inserted_doc["version"] == 1
+    assert inserted_doc["_id"] == "strategy:fresh:v1"
+
+
+@pytest.mark.asyncio
+async def test_list_versions_returns_descending(mock_mongo):
+    """list_versions returns version ints in descending order for an operator history pane."""
+    mock_mongo.db[ENVELOPES_COLLECTION].find.return_value = _StubCursor(
+        [{"version": 9}, {"version": 8}, {"version": 7}]
+    )
+    repo = EnvelopeRepository(mongodb_adapter=mock_mongo)
+
+    versions = await repo.list_versions("strategy:foo", limit=3)
+
+    assert versions == [9, 8, 7]
+
+
+@pytest.mark.asyncio
+async def test_envelope_repository_has_no_update_or_delete(mock_mongo):
+    """AC2.c — append-only contract: no UPDATE or DELETE method exists on the public API."""
+    repo = EnvelopeRepository(mongodb_adapter=mock_mongo)
+    public_methods = {
+        name
+        for name in dir(repo)
+        if not name.startswith("_") and callable(getattr(repo, name))
+    }
+    # The presence of these methods would break AC2.c. Explicit deny list keeps
+    # future refactors honest.
+    for forbidden in ("update_envelope", "delete_envelope", "update_one", "delete_one"):
+        assert forbidden not in public_methods, (
+            f"AC2.c violation: {forbidden!r} would mutate envelope history."
+        )


### PR DESCRIPTION
## What changed

Adds the `envelopes` MongoDB collection — versioned, per `strategy_or_portfolio_key`, append-only — that #692.1's approval API writes to and #692.3's consumers read from.

### Files

- **`data_manager/models/envelope.py`** — Pydantic `Envelope` model with every AC2.a field. Composite Mongo `_id` form `<key>:v<n>` so the unique-id constraint enforces per-key monotonicity at the storage layer (AC2.b backstop).
- **`data_manager/db/repositories/envelope_repository.py`** — `EnvelopeRepository` with:
  - `get_active_envelope(key) -> (version, value, source) | None` → **AC2.e** (the minimal contract for 692.3 decision-path hydration).
  - `get_full_active_envelope(key) -> Envelope | None` — full model for breach-event hydration (692.6 audit join).
  - `insert_next_version(envelope)` — racing-writer-safe via `DuplicateKeyError` retry loop → **AC2.b**.
  - `ensure_indexes()` — compound `(strategy_or_portfolio_key: 1, version: -1)` index → **AC2.d**. Idempotent.
  - `seed_legacy_characterization_envelopes(...)` → **AC2.f** migration helper. Idempotent; skips keys with existing data.
  - **No `update_*` / `delete_*` methods** → **AC2.c** (append-only at the API surface).
- **`tests/test_envelope_repository.py`** — 9 async tests, all passing. The last test (`test_envelope_repository_has_no_update_or_delete`) is a class-introspection guard that will fail if a future commit adds an update/delete method — that's how AC2.c is enforced going forward.

### Key shape decision (AC2.a ambiguity)

The AC names the partitioning column `strategy_or_portfolio_key` without saying whether it's a flat string or a structured composite. This PR lands the **flat-string** form to match the existing FR61 pattern (`LeverageBounds.per_strategy` keys are flat strings). The model docstring recommends `"strategy:<id>"` and `"portfolio:<id>"` namespaces — the repository does NOT enforce a prefix scheme, so the namespace remains a caller-side decision.

If 692.1 / 692.3 later require a structured key, that's a follow-up: change the model field type, add a serialization helper, keep the index column intact.

## Validation

- ✅ 9/9 envelope-repository tests pass (`.venv/bin/python -m pytest tests/test_envelope_repository.py -v`)
- ✅ Pre-commit hooks (ruff lint+format, mypy, gitleaks, bandit, secret detection, test assertions) — all pass
- ✅ Mirrors the proven leverage_bounds pattern shipped by #185 — same retry semantics, same `_id` shape conventions.

## What is NOT in this PR

- No new API endpoint — that's 692.1.
- No characterization-pipeline producer wiring — that's the FR53/FR62 producer side (already partially shipped by ta-analysis#250 + characterization integration).
- No actual seed data — `seed_legacy_characterization_envelopes` is a helper; the caller supplies the legacy list when the migration runs.
- No index-bootstrap call in `data_manager/startup.py` — left for the wiring follow-up; calling `ensure_indexes()` once at boot is the standard pattern but I didn't want this PR to touch startup wiring without a separate review.

## No-Admin certification

No required check is bypassed.

Closes #188.
