### PR TITLE
feat(187): envelope-approval API endpoints (P4.6-AC1 / FR62)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -24,6 +24,7 @@ from data_manager.api.routes import (
     data,
     dr_status,
     drawdown,
+    envelopes,
     fidelity,
     generic,
     health,
@@ -162,6 +163,9 @@ def create_app() -> FastAPI:
     # dr_status route also carries the /api/dashboard prefix in-path
     # (#743 / P9-AC5.c).
     app.include_router(dr_status.router, tags=["Dashboard"])
+    # Operator envelope-approval workflow (#187, P4.6-AC1 / FR62) — routes
+    # embed the /api/envelopes prefix in-path.
+    app.include_router(envelopes.router, tags=["Envelopes"])
 
     # New API routes
     app.include_router(generic.router, tags=["Generic CRUD"])

--- a/data_manager/api/routes/envelopes.py
+++ b/data_manager/api/routes/envelopes.py
@@ -1,0 +1,402 @@
+"""Operator envelope-approval endpoints (#187, P4.6-AC1 / FR62).
+
+Four endpoints mounted under ``/api/envelopes``:
+
+  * ``GET  /pending``                            — list pending proposals (AC1.a)
+  * ``POST /{change_id}/accept``                 — accept as-is (AC1.b)
+  * ``POST /{change_id}/accept-with-modification`` — accept w/ overrides (AC1.c)
+  * ``POST /{change_id}/reject``                 — reject w/ rationale (AC1.d)
+
+Each resolution endpoint:
+
+  1. Loads the pending change (404 if missing, 409 if already resolved).
+  2. (Accept variants only) writes a new versioned :class:`Envelope` row
+     via :class:`EnvelopeRepository.insert_next_version` — the value is
+     the proposed envelope merged with any operator overrides.
+  3. Marks the pending change as ``accepted`` / ``rejected`` with a
+     resolution sub-document carrying ``operator_id`` + ``signed_action_id``
+     (AC1.e — signed-action capture).
+  4. Best-effort emits one document to the ``envelope_authorship_audit``
+     Mongo collection so post-hoc analysis is unambiguous (AC1.g — FR24
+     audit-trail join). Failures in the audit emit are logged but never
+     block the operator request.
+
+OpenAPI documentation is generated from these handlers' type hints +
+Pydantic models with field descriptions (AC1.f).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from fastapi import APIRouter, HTTPException, Path
+
+import data_manager.api.app as api_module
+from data_manager.db.repositories.envelope_repository import EnvelopeRepository
+from data_manager.db.repositories.pending_envelope_change_repository import (
+    PendingChangeAlreadyResolvedError,
+    PendingChangeNotFoundError,
+    PendingEnvelopeChangeRepository,
+)
+from data_manager.models.envelope import Envelope
+from data_manager.models.envelope_change import (
+    AcceptEnvelopeChangeRequest,
+    AcceptWithModificationRequest,
+    EnvelopeChangeResolution,
+    PendingEnvelopeChange,
+    RejectEnvelopeChangeRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION = "envelope_authorship_audit"
+"""Mongo collection that captures every approve/reject action (AC1.g)."""
+
+
+# ── infrastructure helpers (parallel to leverage_bounds.py) ─────────────────
+
+
+def _require_mongo():  # type: ignore[no-untyped-def]
+    if not api_module.db_manager or not getattr(
+        api_module.db_manager, "mongodb_adapter", None
+    ):
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "title": "MongoDB unavailable",
+                "detail": "data-manager is not connected to MongoDB",
+            },
+        )
+    return api_module.db_manager.mongodb_adapter
+
+
+def _pending_repo() -> PendingEnvelopeChangeRepository:
+    return PendingEnvelopeChangeRepository(mongodb_adapter=_require_mongo())
+
+
+def _envelope_repo() -> EnvelopeRepository:
+    return EnvelopeRepository(mongodb_adapter=_require_mongo())
+
+
+async def _persist_audit_event(
+    mongo,  # type: ignore[no-untyped-def]
+    *,
+    change_id: str,
+    kind: str,
+    operator_id: str,
+    signed_action_id: str,
+    strategy_or_portfolio_key: str,
+    originating_characterization_revision: str,
+    before_envelope_version: int | None,
+    after_envelope_version: int | None,
+    proposed_envelope_value: dict[str, Any],
+    accepted_envelope_value: dict[str, Any] | None,
+    modification_overrides: dict[str, Any] | None,
+    rejection_reason: str | None,
+) -> None:
+    """Best-effort emit to ``envelope_authorship_audit`` (AC1.g).
+
+    Mirrors the shape of ``leverage_bounds_audit`` (#182): a wide flat
+    document with a discriminator ``kind`` and full before/after snapshots
+    so downstream queries don't need to rejoin the source collections.
+    """
+    doc = {
+        "kind": kind,
+        "change_id": change_id,
+        "operator_id": operator_id,
+        "signed_action_id": signed_action_id,
+        "strategy_or_portfolio_key": strategy_or_portfolio_key,
+        "originating_characterization_revision": originating_characterization_revision,
+        "before_envelope_version": before_envelope_version,
+        "after_envelope_version": after_envelope_version,
+        "proposed_envelope_value": proposed_envelope_value,
+        "accepted_envelope_value": accepted_envelope_value,
+        "modification_overrides": modification_overrides,
+        "rejection_reason": rejection_reason,
+        "logged_at": datetime.now(UTC).isoformat(),
+    }
+    try:
+        await mongo.db[ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION].insert_one(doc)
+    except Exception as exc:  # noqa: BLE001 — never block the operator request
+        logger.warning(
+            "envelope_authorship_audit.insert_failed change_id=%s kind=%s error=%s",
+            change_id,
+            kind,
+            exc,
+        )
+
+
+def _merge_overrides(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    """Shallow merge ``overrides`` onto ``base``; top-level keys in
+    ``overrides`` replace those in ``base``. Documented in
+    ``AcceptWithModificationRequest.modification_overrides``."""
+    merged = dict(base)
+    merged.update(overrides)
+    return merged
+
+
+async def _load_pending_or_raise(
+    change_id: str,
+    pending_repo: PendingEnvelopeChangeRepository,
+) -> PendingEnvelopeChange:
+    """Load a pending change; 404 if missing, 409 if already resolved."""
+    change = await pending_repo.get(change_id)
+    if change is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "title": "pending envelope change not found",
+                "detail": f"no document with change_id={change_id!r}",
+            },
+        )
+    if change.status != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "title": "pending envelope change already resolved",
+                "detail": f"change_id={change_id!r} status={change.status}",
+            },
+        )
+    return change
+
+
+async def _write_envelope_from_acceptance(
+    change: PendingEnvelopeChange,
+    *,
+    value: dict[str, Any],
+    operator_id: str,
+    signed_action_id: str,
+    envelope_repo: EnvelopeRepository,
+) -> Envelope:
+    """Persist the accepted envelope as a new versioned Envelope row (P4.6-AC2 link)."""
+    candidate = Envelope(
+        envelope_id=f"{change.strategy_or_portfolio_key}:vNEW",  # overridden by repo
+        version=1,  # overridden by repo
+        strategy_or_portfolio_key=change.strategy_or_portfolio_key,
+        value=value,
+        source="operator_approved",
+        originating_characterization_revision=change.originating_characterization_revision,
+        operator_id=operator_id,
+        signed_action_id=signed_action_id,
+    )
+    return await envelope_repo.insert_next_version(candidate)
+
+
+# ── routes ──────────────────────────────────────────────────────────────────
+
+
+@router.get("/api/envelopes/pending")
+async def list_pending_envelope_changes(limit: int = 200) -> dict[str, Any]:
+    """List all pending envelope changes awaiting operator review (AC1.a).
+
+    Returns newest-first. ``limit`` caps the response (default 200) to
+    bound the worst case.
+    """
+    repo = _pending_repo()
+    pending = await repo.list_pending(limit=limit)
+    return {
+        "pending": [change.model_dump(mode="json") for change in pending],
+        "count": len(pending),
+    }
+
+
+@router.post("/api/envelopes/{change_id}/accept")
+async def accept_envelope_change(
+    req: AcceptEnvelopeChangeRequest,
+    change_id: str = Path(..., min_length=1),
+) -> dict[str, Any]:
+    """Accept a pending change as-is (AC1.b).
+
+    Side effects:
+      1. Writes a new ``Envelope`` row at the next version for the key,
+         with ``value`` = proposed envelope value, ``source='operator_approved'``.
+      2. Flips the pending change to ``status='accepted'`` with the
+         resolution sub-document (operator + signed-action).
+      3. Emits an ``envelope_authorship_audit`` document (AC1.g).
+    """
+    mongo = _require_mongo()
+    pending_repo = PendingEnvelopeChangeRepository(mongodb_adapter=mongo)
+    envelope_repo = EnvelopeRepository(mongodb_adapter=mongo)
+
+    change = await _load_pending_or_raise(change_id, pending_repo)
+    inserted = await _write_envelope_from_acceptance(
+        change,
+        value=change.proposed_envelope_value,
+        operator_id=req.operator_id,
+        signed_action_id=req.signed_action_id,
+        envelope_repo=envelope_repo,
+    )
+    resolution = EnvelopeChangeResolution(
+        operator_id=req.operator_id,
+        signed_action_id=req.signed_action_id,
+        modification_overrides=None,
+        rejection_reason=None,
+    )
+
+    try:
+        resolved = await pending_repo.resolve(
+            change_id, target_status="accepted", resolution=resolution
+        )
+    except PendingChangeNotFoundError as exc:  # pragma: no cover — caught earlier
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except PendingChangeAlreadyResolvedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "title": "race: pending change resolved by another operator",
+                "detail": str(exc),
+            },
+        ) from exc
+
+    await _persist_audit_event(
+        mongo,
+        change_id=change_id,
+        kind="envelope_change_accepted",
+        operator_id=req.operator_id,
+        signed_action_id=req.signed_action_id,
+        strategy_or_portfolio_key=change.strategy_or_portfolio_key,
+        originating_characterization_revision=change.originating_characterization_revision,
+        before_envelope_version=change.current_envelope_version,
+        after_envelope_version=inserted.version,
+        proposed_envelope_value=change.proposed_envelope_value,
+        accepted_envelope_value=inserted.value,
+        modification_overrides=None,
+        rejection_reason=None,
+    )
+
+    return {
+        "change": resolved.model_dump(mode="json"),
+        "envelope": inserted.model_dump(mode="json"),
+    }
+
+
+@router.post("/api/envelopes/{change_id}/accept-with-modification")
+async def accept_envelope_change_with_modification(
+    req: AcceptWithModificationRequest,
+    change_id: str = Path(..., min_length=1),
+) -> dict[str, Any]:
+    """Accept a pending change with operator overrides (AC1.c).
+
+    ``modification_overrides`` is shallow-merged onto
+    ``proposed_envelope_value`` (top-level keys win) and the result is
+    persisted as the new ``Envelope.value``.
+    """
+    mongo = _require_mongo()
+    pending_repo = PendingEnvelopeChangeRepository(mongodb_adapter=mongo)
+    envelope_repo = EnvelopeRepository(mongodb_adapter=mongo)
+
+    change = await _load_pending_or_raise(change_id, pending_repo)
+    merged_value = _merge_overrides(
+        change.proposed_envelope_value, req.modification_overrides
+    )
+    inserted = await _write_envelope_from_acceptance(
+        change,
+        value=merged_value,
+        operator_id=req.operator_id,
+        signed_action_id=req.signed_action_id,
+        envelope_repo=envelope_repo,
+    )
+    resolution = EnvelopeChangeResolution(
+        operator_id=req.operator_id,
+        signed_action_id=req.signed_action_id,
+        modification_overrides=req.modification_overrides,
+        rejection_reason=None,
+    )
+
+    try:
+        resolved = await pending_repo.resolve(
+            change_id, target_status="accepted", resolution=resolution
+        )
+    except PendingChangeAlreadyResolvedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "title": "race: pending change resolved by another operator",
+                "detail": str(exc),
+            },
+        ) from exc
+
+    await _persist_audit_event(
+        mongo,
+        change_id=change_id,
+        kind="envelope_change_accepted_with_modification",
+        operator_id=req.operator_id,
+        signed_action_id=req.signed_action_id,
+        strategy_or_portfolio_key=change.strategy_or_portfolio_key,
+        originating_characterization_revision=change.originating_characterization_revision,
+        before_envelope_version=change.current_envelope_version,
+        after_envelope_version=inserted.version,
+        proposed_envelope_value=change.proposed_envelope_value,
+        accepted_envelope_value=inserted.value,
+        modification_overrides=req.modification_overrides,
+        rejection_reason=None,
+    )
+
+    return {
+        "change": resolved.model_dump(mode="json"),
+        "envelope": inserted.model_dump(mode="json"),
+    }
+
+
+@router.post("/api/envelopes/{change_id}/reject")
+async def reject_envelope_change(
+    req: RejectEnvelopeChangeRequest,
+    change_id: str = Path(..., min_length=1),
+) -> dict[str, Any]:
+    """Reject a pending change with operator rationale (AC1.d).
+
+    No new ``Envelope`` row is written — the active envelope (if any)
+    remains in force.
+    """
+    mongo = _require_mongo()
+    pending_repo = PendingEnvelopeChangeRepository(mongodb_adapter=mongo)
+
+    change = await _load_pending_or_raise(change_id, pending_repo)
+    resolution = EnvelopeChangeResolution(
+        operator_id=req.operator_id,
+        signed_action_id=req.signed_action_id,
+        modification_overrides=None,
+        rejection_reason=req.rejection_reason,
+    )
+
+    try:
+        resolved = await pending_repo.resolve(
+            change_id, target_status="rejected", resolution=resolution
+        )
+    except PendingChangeAlreadyResolvedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "title": "race: pending change resolved by another operator",
+                "detail": str(exc),
+            },
+        ) from exc
+
+    await _persist_audit_event(
+        mongo,
+        change_id=change_id,
+        kind="envelope_change_rejected",
+        operator_id=req.operator_id,
+        signed_action_id=req.signed_action_id,
+        strategy_or_portfolio_key=change.strategy_or_portfolio_key,
+        originating_characterization_revision=change.originating_characterization_revision,
+        before_envelope_version=change.current_envelope_version,
+        after_envelope_version=None,
+        proposed_envelope_value=change.proposed_envelope_value,
+        accepted_envelope_value=None,
+        modification_overrides=None,
+        rejection_reason=req.rejection_reason,
+    )
+
+    return {"change": resolved.model_dump(mode="json")}

--- a/data_manager/db/repositories/pending_envelope_change_repository.py
+++ b/data_manager/db/repositories/pending_envelope_change_repository.py
@@ -1,0 +1,192 @@
+"""Repository for the ``pending_envelope_changes`` Mongo collection (#187, P4.6-AC1 / FR62).
+
+Reads + status-transitions for envelope-change proposals awaiting
+operator approval. Pairs with :mod:`data_manager.db.repositories.envelope_repository`
+(which stores the *accepted* versioned envelopes) and with
+:mod:`data_manager.api.routes.envelopes` (which exposes the operator
+endpoints).
+
+Append-only with respect to ``change_id``: status moves are in-place
+updates that gate on ``status == 'pending'``, so a second concurrent
+resolution attempt fails fast rather than silently overwriting the
+first one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from data_manager.db.repositories.base_repository import BaseRepository
+from data_manager.models.envelope_change import (
+    EnvelopeChangeResolution,
+    PendingEnvelopeChange,
+)
+
+if TYPE_CHECKING:
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+    from data_manager.db.mysql_adapter import MySQLAdapter
+
+logger = logging.getLogger(__name__)
+
+PENDING_ENVELOPE_CHANGES_COLLECTION = "pending_envelope_changes"
+"""Default collection name; overridable per-instance for tests."""
+
+
+class PendingChangeNotFoundError(LookupError):
+    """Raised when the operator references a ``change_id`` that does not exist."""
+
+
+class PendingChangeAlreadyResolvedError(RuntimeError):
+    """Raised when the operator tries to resolve a change that's already non-pending.
+
+    Carries the existing ``status`` and ``resolution`` so the route can
+    return a useful 409 response.
+    """
+
+    def __init__(self, change_id: str, status: str) -> None:
+        super().__init__(
+            f"pending envelope change {change_id!r} already resolved (status={status})"
+        )
+        self.change_id = change_id
+        self.status = status
+
+
+class PendingEnvelopeChangeRepository(BaseRepository):
+    """MongoDB-backed repository for pending envelope-change proposals (FR62)."""
+
+    def __init__(
+        self,
+        mysql_adapter: MySQLAdapter | None = None,
+        mongodb_adapter: MongoDBAdapter | None = None,
+        collection_name: str = PENDING_ENVELOPE_CHANGES_COLLECTION,
+    ) -> None:
+        super().__init__(mysql_adapter=mysql_adapter, mongodb_adapter=mongodb_adapter)
+        self._collection_name = collection_name
+
+    def _collection(self):  # type: ignore[no-untyped-def]
+        if self.mongodb is None:  # pragma: no cover — wiring guard
+            raise RuntimeError(
+                "PendingEnvelopeChangeRepository requires a MongoDB adapter"
+            )
+        return self.mongodb.db[self._collection_name]
+
+    @staticmethod
+    def _doc_to_model(doc: dict[str, Any] | None) -> PendingEnvelopeChange | None:
+        if doc is None:
+            return None
+        payload = {k: v for k, v in doc.items() if k != "_id"}
+        return PendingEnvelopeChange.model_validate(payload)
+
+    async def ensure_indexes(self) -> None:
+        """Create the indexes that back the operator-facing queries.
+
+        Idempotent. Invoked once during service startup from
+        :mod:`data_manager.leader_election`.
+        """
+        col = self._collection()
+        await col.create_index(
+            [("status", 1), ("created_at", -1)],
+            name="status_1_created_at_-1",
+            background=True,
+        )
+        await col.create_index(
+            [("strategy_or_portfolio_key", 1), ("status", 1)],
+            name="strategy_or_portfolio_key_1_status_1",
+            background=True,
+        )
+
+    async def list_pending(self, limit: int = 200) -> list[PendingEnvelopeChange]:
+        """Return all pending changes (AC1.a) in newest-first order.
+
+        ``limit`` caps the response size; the operator UI page is bounded
+        and the worst case (every strategy/portfolio key pending at once)
+        is still in the low hundreds — the cap prevents accidental
+        unbounded scans rather than gating routine reads.
+        """
+        col = self._collection()
+        cursor = col.find({"status": "pending"}).sort("created_at", -1).limit(limit)
+        results: list[PendingEnvelopeChange] = []
+        async for doc in cursor:
+            change = self._doc_to_model(doc)
+            if change is not None:
+                results.append(change)
+        return results
+
+    async def get(self, change_id: str) -> PendingEnvelopeChange | None:
+        """Look up one change by id. Returns ``None`` if not found."""
+        col = self._collection()
+        doc = await col.find_one({"_id": change_id})
+        return self._doc_to_model(doc)
+
+    async def insert(self, change: PendingEnvelopeChange) -> PendingEnvelopeChange:
+        """Persist a new pending change.
+
+        Provided for producers (and tests). Not used by the operator-facing
+        route handlers in #187 — those only read + resolve.
+        """
+        col = self._collection()
+        doc = change.model_dump(mode="json")
+        doc["_id"] = change.change_id
+        await col.insert_one(doc)
+        logger.info(
+            "pending_envelope_change.inserted change_id=%s key=%s char_rev=%s",
+            change.change_id,
+            change.strategy_or_portfolio_key,
+            change.originating_characterization_revision,
+        )
+        return change
+
+    async def resolve(
+        self,
+        change_id: str,
+        *,
+        target_status: str,
+        resolution: EnvelopeChangeResolution,
+    ) -> PendingEnvelopeChange:
+        """Transition a pending change to ``accepted`` or ``rejected``.
+
+        The update is gated on ``status == 'pending'`` so a concurrent
+        second-resolver gets a deterministic conflict (``PendingChangeAlreadyResolvedError``)
+        instead of silently overwriting the first resolver's outcome.
+
+        Raises:
+            PendingChangeNotFoundError: no document with ``change_id``.
+            PendingChangeAlreadyResolvedError: the change is not pending.
+        """
+        if target_status not in ("accepted", "rejected"):
+            raise ValueError(
+                f"target_status must be 'accepted' or 'rejected', not {target_status!r}"
+            )
+
+        col = self._collection()
+        # Conditional update — only flip status if still pending.
+        update_result = await col.update_one(
+            {"_id": change_id, "status": "pending"},
+            {
+                "$set": {
+                    "status": target_status,
+                    "resolution": resolution.model_dump(mode="json"),
+                }
+            },
+        )
+
+        if update_result.matched_count == 1:
+            doc = await col.find_one({"_id": change_id})
+            model = self._doc_to_model(doc)
+            assert model is not None  # noqa: S101 — just-updated doc must exist
+            logger.info(
+                "pending_envelope_change.resolved change_id=%s status=%s operator=%s",
+                change_id,
+                target_status,
+                resolution.operator_id,
+            )
+            return model
+
+        # No match — either missing or already resolved. Disambiguate.
+        existing = await col.find_one({"_id": change_id}, projection={"status": 1})
+        if existing is None:
+            raise PendingChangeNotFoundError(change_id)
+        raise PendingChangeAlreadyResolvedError(
+            change_id=change_id, status=existing.get("status", "unknown")
+        )

--- a/data_manager/models/envelope_change.py
+++ b/data_manager/models/envelope_change.py
@@ -1,0 +1,221 @@
+"""Pending envelope-change proposals awaiting operator approval (#187, P4.6-AC1 / FR62).
+
+A ``PendingEnvelopeChange`` is the consumer-half of the FR62 authorship
+workflow. Producers (e.g. the characterization pipeline; see EPIC #692
+sibling ACs) write one document per detected divergence between the
+characterization-derived envelope and the active operator-approved
+envelope for a given ``strategy_or_portfolio_key``. Operators then
+review-and-resolve via the 4 endpoints in
+``data_manager.api.routes.envelopes``:
+
+* ``GET  /api/envelopes/pending``                          — AC1.a
+* ``POST /api/envelopes/{change_id}/accept``               — AC1.b
+* ``POST /api/envelopes/{change_id}/accept-with-modification``  — AC1.c
+* ``POST /api/envelopes/{change_id}/reject``               — AC1.d
+
+Resolution is captured in-place (status transitions ``pending`` →
+``accepted`` | ``rejected``) so the change history is self-contained;
+the resulting Envelope row is written to the
+:class:`data_manager.models.envelope.Envelope` versioned store
+(#188 / P4.6-AC2) by the route handler in the same request.
+
+Append-only with respect to ``change_id``: once resolved a document is
+not deleted, only marked. The operator history pane reads pending +
+recently resolved in one window.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from pydantic import BaseModel, Field, model_validator
+
+PendingChangeStatus = Literal["pending", "accepted", "rejected"]
+
+
+class EnvelopeChangeResolution(BaseModel):
+    """Sub-document capturing how a pending change was closed (AC1.b/c/d/e/g).
+
+    Populated only when ``status != 'pending'``. Carries the operator
+    identity + signed-action audit id required by AC1.e, plus
+    branch-specific fields:
+
+    * ``accept-as-is``:   ``modification_overrides=None``, ``rejection_reason=None``
+    * ``accept-with-modification``:  ``modification_overrides`` set
+    * ``reject``:  ``rejection_reason`` set
+    """
+
+    operator_id: str = Field(
+        ...,
+        min_length=1,
+        description="Identity of the operator that resolved this change (AC1.e).",
+    )
+    signed_action_id: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Audit identifier for the signed action that authorized the "
+            "resolution (AC1.e). Joined to the FR12 audit trail and to "
+            "the resulting :class:`Envelope.signed_action_id`."
+        ),
+    )
+    resolved_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="UTC timestamp the resolution was committed.",
+    )
+    modification_overrides: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "For ``accept-with-modification``: the operator-supplied "
+            "overrides merged into the proposed envelope before persisting. "
+            "Null for ``accept`` (as-is) and ``reject``."
+        ),
+    )
+    rejection_reason: str | None = Field(
+        default=None,
+        description=(
+            "For ``reject``: operator-supplied rationale (required, "
+            "AC1.d). Null for both accept variants."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_branch_fields(self) -> EnvelopeChangeResolution:
+        if (
+            self.modification_overrides is not None
+            and self.rejection_reason is not None
+        ):
+            raise ValueError(
+                "modification_overrides and rejection_reason are mutually exclusive"
+            )
+        return self
+
+
+class PendingEnvelopeChange(BaseModel):
+    """A proposed envelope change awaiting operator review.
+
+    The Mongo ``_id`` of the persisted document is ``change_id`` (UUID),
+    so duplicate writes are caller-controlled and idempotent.
+    """
+
+    change_id: str = Field(
+        ...,
+        min_length=1,
+        description="UUID identifier for the proposal (becomes the Mongo _id).",
+    )
+    strategy_or_portfolio_key: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Partition column matching the active Envelope's. Same flat "
+            "string convention as :mod:`data_manager.models.envelope`."
+        ),
+    )
+    proposed_envelope_value: dict[str, Any] = Field(
+        ...,
+        description=(
+            "The new envelope value the producer is proposing. "
+            "Schema-free; consumers validate their own contracts."
+        ),
+    )
+    current_envelope_version: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Version of the active Envelope this change supersedes "
+            "(None if no envelope yet exists for the key — first-ever "
+            "characterization-derived envelope)."
+        ),
+    )
+    current_envelope_value: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Snapshot of the active envelope value at the time the "
+            "proposal was filed (advisory only — operator UI reads this "
+            "to render a diff)."
+        ),
+    )
+    diverging_pct_per_strategy: dict[str, float] | None = Field(
+        default=None,
+        description=(
+            "Per-strategy divergence percentage (producer-computed). "
+            "Advisory for UI sorting / highlight. Null if not provided."
+        ),
+    )
+    originating_characterization_revision: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "FR53 cross-link: the characterization revision id that "
+            "produced this proposal. Required — every pending change "
+            "must trace back to a characterization revision."
+        ),
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="When the producer filed the proposal.",
+    )
+    status: PendingChangeStatus = Field(
+        default="pending",
+        description="Lifecycle state. Transitions are one-way out of 'pending'.",
+    )
+    resolution: EnvelopeChangeResolution | None = Field(
+        default=None,
+        description="Populated when status != 'pending'.",
+    )
+
+    @model_validator(mode="after")
+    def _resolution_matches_status(self) -> PendingEnvelopeChange:
+        if self.status == "pending" and self.resolution is not None:
+            raise ValueError("pending changes must not carry a resolution")
+        if self.status != "pending" and self.resolution is None:
+            raise ValueError("resolved changes must carry a resolution sub-document")
+        if self.status == "rejected" and self.resolution is not None:
+            if not self.resolution.rejection_reason:
+                raise ValueError("rejected changes require resolution.rejection_reason")
+        return self
+
+
+# ── Request DTOs for the route handlers ─────────────────────────────────────
+
+
+class AcceptEnvelopeChangeRequest(BaseModel):
+    """Body for ``POST /api/envelopes/{change_id}/accept`` (AC1.b)."""
+
+    operator_id: str = Field(..., min_length=1)
+    signed_action_id: str = Field(..., min_length=1)
+
+
+class AcceptWithModificationRequest(BaseModel):
+    """Body for ``POST /api/envelopes/{change_id}/accept-with-modification`` (AC1.c)."""
+
+    operator_id: str = Field(..., min_length=1)
+    signed_action_id: str = Field(..., min_length=1)
+    modification_overrides: dict[str, Any] = Field(
+        ...,
+        description=(
+            "Operator-supplied overrides merged into the proposed envelope. "
+            "Top-level keys in this dict replace the corresponding keys in "
+            "``proposed_envelope_value`` (shallow merge)."
+        ),
+    )
+
+
+class RejectEnvelopeChangeRequest(BaseModel):
+    """Body for ``POST /api/envelopes/{change_id}/reject`` (AC1.d)."""
+
+    operator_id: str = Field(..., min_length=1)
+    signed_action_id: str = Field(..., min_length=1)
+    rejection_reason: str = Field(
+        ...,
+        min_length=1,
+        description="Operator-supplied rationale; required by AC1.d.",
+    )

--- a/tests/unit/test_envelopes_api.py
+++ b/tests/unit/test_envelopes_api.py
@@ -1,0 +1,471 @@
+"""Tests for /api/envelopes routes (#187, P4.6-AC1 / FR62).
+
+Covers every AC of #187:
+
+* AC1.a — ``GET /api/envelopes/pending``: lists pending changes; empty
+  list when none exist; 503 when DB unavailable.
+* AC1.b — ``POST /api/envelopes/{change_id}/accept``: happy path writes
+  a new Envelope, flips status, emits audit; 404 on missing change_id;
+  409 when already-resolved.
+* AC1.c — ``POST /api/envelopes/{change_id}/accept-with-modification``:
+  merges overrides onto proposed value; rest mirrors AC1.b.
+* AC1.d — ``POST /api/envelopes/{change_id}/reject``: requires rationale;
+  flips status, emits audit; no new Envelope written.
+* AC1.e — Every resolution endpoint records ``operator_id`` and
+  ``signed_action_id``.
+* AC1.f — Validated implicitly via OpenAPI generation (handler
+  signatures + Pydantic models); explicitly via 422 on missing
+  ``operator_id`` body field.
+* AC1.g — Every action emits to ``envelope_authorship_audit``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.api.app import create_app
+from data_manager.api.routes.envelopes import ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION
+from data_manager.db.repositories.envelope_repository import ENVELOPES_COLLECTION
+from data_manager.db.repositories.pending_envelope_change_repository import (
+    PENDING_ENVELOPE_CHANGES_COLLECTION,
+)
+
+# ─── In-memory Mongo fake — mirrors tests/unit/test_leverage_bounds_routes.py,
+#     extended with update_one + projection support for our resolve() flow. ──
+
+
+class _FakeCursor:
+    def __init__(self, docs: list[dict[str, Any]], projection: dict | None = None):
+        self._docs = docs
+        self._sort_field: str | None = None
+        self._sort_direction = 1
+        self._limit: int | None = None
+        self._projection = projection
+        self._iter: Any = None
+
+    def sort(self, field, direction):
+        # Accept either ("field", 1) positional pair OR sort("field", 1)
+        # depending on which the repo uses.
+        self._sort_field = field
+        self._sort_direction = direction
+        return self
+
+    def limit(self, n):
+        self._limit = n
+        return self
+
+    def __aiter__(self):
+        docs = [dict(d) for d in self._docs]
+        if self._sort_field is not None:
+            docs.sort(
+                key=lambda d: d.get(self._sort_field, 0),
+                reverse=self._sort_direction < 0,
+            )
+        if self._limit is not None:
+            docs = docs[: self._limit]
+        if self._projection is not None:
+            keep = {k for k, v in self._projection.items() if v}
+            docs = [{k: v for k, v in d.items() if k in keep} for d in docs]
+        self._iter = iter(docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as e:
+            raise StopAsyncIteration from e
+
+
+class _UpdateResult:
+    def __init__(self, matched: int) -> None:
+        self.matched_count = matched
+
+
+class _FakeCollection:
+    def __init__(self) -> None:
+        self.docs: list[dict[str, Any]] = []
+
+    async def find_one(self, query: dict, sort=None, projection=None):
+        candidates = [d for d in self.docs if _matches(d, query)]
+        if sort:
+            field, direction = sort[0]
+            candidates.sort(key=lambda d: d.get(field, 0), reverse=direction < 0)
+        if not candidates:
+            return None
+        doc = dict(candidates[0])
+        if projection:
+            keep = {k for k, v in projection.items() if v}
+            doc = {k: v for k, v in doc.items() if k in keep or k == "_id"}
+            # _id default excluded only when explicitly set to 0/False
+            if projection.get("_id") in (0, False):
+                doc.pop("_id", None)
+        return doc
+
+    def find(self, query: dict, projection=None):
+        matched = [d for d in self.docs if _matches(d, query)]
+        return _FakeCursor(matched, projection=projection)
+
+    async def insert_one(self, doc: dict):
+        d = dict(doc)
+        if "_id" not in d:
+            d["_id"] = f"_autogen-{len(self.docs)}"
+        for existing in self.docs:
+            if existing.get("_id") == d["_id"]:
+                from pymongo.errors import DuplicateKeyError
+
+                raise DuplicateKeyError(f"duplicate key _id={d['_id']!r}")
+        self.docs.append(d)
+
+    async def update_one(self, query: dict, update: dict):
+        for d in self.docs:
+            if _matches(d, query):
+                if "$set" in update:
+                    d.update(update["$set"])
+                return _UpdateResult(matched=1)
+        return _UpdateResult(matched=0)
+
+    async def create_index(self, *args, **kwargs):  # noqa: ARG002
+        return None
+
+
+def _matches(doc: dict, query: dict) -> bool:
+    return all(doc.get(k) == v for k, v in query.items())
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self._collections: dict[str, _FakeCollection] = {}
+
+    def __getitem__(self, name: str) -> _FakeCollection:
+        return self._collections.setdefault(name, _FakeCollection())
+
+
+class _FakeMongoAdapter:
+    def __init__(self) -> None:
+        self.db = _FakeDb()
+
+
+class _FakeDbManager:
+    def __init__(self) -> None:
+        self.mongodb_adapter = _FakeMongoAdapter()
+        self.mysql_adapter = None
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def wired_app():
+    """Wire the in-memory Mongo into the app module for the duration of a test."""
+    original = api_module.db_manager
+    api_module.db_manager = _FakeDbManager()
+    try:
+        app = create_app()
+        client = TestClient(app)
+        # Stash the mongo handle for in-test seeding/inspection.
+        client.mongo = api_module.db_manager.mongodb_adapter  # type: ignore[attr-defined]
+        yield client
+    finally:
+        api_module.db_manager = original
+
+
+def _seed_pending(
+    mongo: _FakeMongoAdapter,
+    *,
+    change_id: str = "chg-1",
+    key: str = "strategy:btc_momentum_v3",
+    proposed: dict[str, Any] | None = None,
+    current_version: int | None = 3,
+    current_value: dict[str, Any] | None = None,
+    char_revision: str = "char-rev-42",
+    status: str = "pending",
+    resolution: dict | None = None,
+    created_at: str = "2026-05-29T10:00:00+00:00",
+) -> None:
+    """Insert a PendingEnvelopeChange document directly into the fake Mongo."""
+    doc = {
+        "_id": change_id,
+        "change_id": change_id,
+        "strategy_or_portfolio_key": key,
+        "proposed_envelope_value": proposed or {"max_drawdown_pct": 8.0},
+        "current_envelope_version": current_version,
+        "current_envelope_value": current_value or {"max_drawdown_pct": 5.0},
+        "diverging_pct_per_strategy": {key: 60.0},
+        "originating_characterization_revision": char_revision,
+        "created_at": created_at,
+        "status": status,
+        "resolution": resolution,
+    }
+    mongo.db[PENDING_ENVELOPE_CHANGES_COLLECTION].docs.append(doc)
+
+
+def _seed_existing_envelope(
+    mongo: _FakeMongoAdapter,
+    *,
+    key: str,
+    version: int,
+    value: dict[str, Any],
+) -> None:
+    """Seed a prior Envelope so next insert lands at version+1."""
+    doc = {
+        "_id": f"{key}:v{version}",
+        "envelope_id": f"{key}:v{version}",
+        "version": version,
+        "strategy_or_portfolio_key": key,
+        "value": value,
+        "source": "characterization",
+        "originating_characterization_revision": "char-rev-prior",
+        "operator_id": None,
+        "created_at": "2026-05-28T00:00:00+00:00",
+        "signed_action_id": "sa-prior",
+    }
+    mongo.db[ENVELOPES_COLLECTION].docs.append(doc)
+
+
+# ─── AC1.a — GET /api/envelopes/pending ──────────────────────────────────────
+
+
+def test_get_pending_returns_empty_when_no_changes(wired_app: TestClient) -> None:
+    r = wired_app.get("/api/envelopes/pending")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"pending": [], "count": 0}
+
+
+def test_get_pending_returns_seeded_change(wired_app: TestClient) -> None:
+    _seed_pending(wired_app.mongo, change_id="chg-1")
+    r = wired_app.get("/api/envelopes/pending")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 1
+    assert body["pending"][0]["change_id"] == "chg-1"
+    assert body["pending"][0]["status"] == "pending"
+
+
+def test_get_pending_excludes_already_resolved(wired_app: TestClient) -> None:
+    """Already-accepted/rejected changes don't surface on /pending."""
+    _seed_pending(
+        wired_app.mongo,
+        change_id="chg-old",
+        status="accepted",
+        resolution={
+            "operator_id": "op1",
+            "signed_action_id": "sa1",
+            "resolved_at": "2026-05-28T00:00:00+00:00",
+            "modification_overrides": None,
+            "rejection_reason": None,
+        },
+    )
+    _seed_pending(wired_app.mongo, change_id="chg-new")
+    r = wired_app.get("/api/envelopes/pending")
+    body = r.json()
+    assert body["count"] == 1
+    assert body["pending"][0]["change_id"] == "chg-new"
+
+
+def test_get_pending_503_when_db_unavailable() -> None:
+    original = api_module.db_manager
+    api_module.db_manager = None
+    try:
+        app = create_app()
+        client = TestClient(app)
+        r = client.get("/api/envelopes/pending")
+        assert r.status_code == 503
+        assert r.json()["detail"]["title"] == "MongoDB unavailable"
+    finally:
+        api_module.db_manager = original
+
+
+# ─── AC1.b — POST /accept ────────────────────────────────────────────────────
+
+
+def test_accept_happy_path_writes_envelope_flips_status_and_audits(
+    wired_app: TestClient,
+) -> None:
+    _seed_pending(
+        wired_app.mongo,
+        change_id="chg-1",
+        key="strategy:btc",
+        proposed={"max_drawdown_pct": 8.0},
+        current_version=2,
+    )
+    _seed_existing_envelope(
+        wired_app.mongo,
+        key="strategy:btc",
+        version=2,
+        value={"max_drawdown_pct": 5.0},
+    )
+
+    r = wired_app.post(
+        "/api/envelopes/chg-1/accept",
+        json={"operator_id": "alice", "signed_action_id": "sa-alpha"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    # New envelope written at version 3 (next after seeded 2).
+    assert body["envelope"]["version"] == 3
+    assert body["envelope"]["source"] == "operator_approved"
+    assert body["envelope"]["operator_id"] == "alice"
+    assert body["envelope"]["signed_action_id"] == "sa-alpha"
+    assert body["envelope"]["value"] == {"max_drawdown_pct": 8.0}
+
+    # Pending change flipped to accepted, carries the resolution.
+    assert body["change"]["status"] == "accepted"
+    assert body["change"]["resolution"]["operator_id"] == "alice"
+    assert body["change"]["resolution"]["modification_overrides"] is None
+
+    # Audit collection received exactly one row of the right kind (AC1.g).
+    audit_docs = wired_app.mongo.db[ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION].docs
+    assert len(audit_docs) == 1
+    audit = audit_docs[0]
+    assert audit["kind"] == "envelope_change_accepted"
+    assert audit["operator_id"] == "alice"
+    assert audit["signed_action_id"] == "sa-alpha"
+    assert audit["before_envelope_version"] == 2
+    assert audit["after_envelope_version"] == 3
+    assert audit["accepted_envelope_value"] == {"max_drawdown_pct": 8.0}
+
+
+def test_accept_404_when_change_missing(wired_app: TestClient) -> None:
+    r = wired_app.post(
+        "/api/envelopes/does-not-exist/accept",
+        json={"operator_id": "alice", "signed_action_id": "sa-alpha"},
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"]["title"] == "pending envelope change not found"
+
+
+def test_accept_409_when_already_resolved(wired_app: TestClient) -> None:
+    _seed_pending(
+        wired_app.mongo,
+        change_id="chg-1",
+        status="rejected",
+        resolution={
+            "operator_id": "op-prev",
+            "signed_action_id": "sa-prev",
+            "resolved_at": "2026-05-28T00:00:00+00:00",
+            "modification_overrides": None,
+            "rejection_reason": "stale characterization",
+        },
+    )
+    r = wired_app.post(
+        "/api/envelopes/chg-1/accept",
+        json={"operator_id": "alice", "signed_action_id": "sa-alpha"},
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["title"] == "pending envelope change already resolved"
+
+
+def test_accept_422_when_operator_id_missing(wired_app: TestClient) -> None:
+    """AC1.e — operator_id and signed_action_id are non-optional."""
+    _seed_pending(wired_app.mongo, change_id="chg-1")
+    r = wired_app.post(
+        "/api/envelopes/chg-1/accept",
+        json={"signed_action_id": "sa-only"},
+    )
+    assert r.status_code == 422
+
+
+# ─── AC1.c — POST /accept-with-modification ──────────────────────────────────
+
+
+def test_accept_with_modification_merges_overrides(
+    wired_app: TestClient,
+) -> None:
+    _seed_pending(
+        wired_app.mongo,
+        change_id="chg-mod",
+        key="strategy:eth",
+        proposed={"max_drawdown_pct": 8.0, "stop_loss_pct": 2.0},
+    )
+
+    r = wired_app.post(
+        "/api/envelopes/chg-mod/accept-with-modification",
+        json={
+            "operator_id": "bob",
+            "signed_action_id": "sa-mod",
+            "modification_overrides": {"max_drawdown_pct": 7.5},
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Overrides win on top-level keys; other keys passthrough.
+    assert body["envelope"]["value"] == {"max_drawdown_pct": 7.5, "stop_loss_pct": 2.0}
+    assert body["change"]["resolution"]["modification_overrides"] == {
+        "max_drawdown_pct": 7.5
+    }
+
+    audit_docs = wired_app.mongo.db[ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION].docs
+    assert len(audit_docs) == 1
+    assert audit_docs[0]["kind"] == "envelope_change_accepted_with_modification"
+    assert audit_docs[0]["modification_overrides"] == {"max_drawdown_pct": 7.5}
+
+
+def test_accept_with_modification_requires_overrides_body(
+    wired_app: TestClient,
+) -> None:
+    _seed_pending(wired_app.mongo, change_id="chg-mod")
+    r = wired_app.post(
+        "/api/envelopes/chg-mod/accept-with-modification",
+        json={"operator_id": "bob", "signed_action_id": "sa-mod"},
+    )
+    assert r.status_code == 422
+
+
+# ─── AC1.d — POST /reject ────────────────────────────────────────────────────
+
+
+def test_reject_writes_no_envelope_emits_audit_with_rationale(
+    wired_app: TestClient,
+) -> None:
+    _seed_pending(wired_app.mongo, change_id="chg-rej", key="strategy:doge")
+
+    r = wired_app.post(
+        "/api/envelopes/chg-rej/reject",
+        json={
+            "operator_id": "carol",
+            "signed_action_id": "sa-rej",
+            "rejection_reason": "characterization sample size too small",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["change"]["status"] == "rejected"
+    assert (
+        body["change"]["resolution"]["rejection_reason"]
+        == "characterization sample size too small"
+    )
+    # No Envelope was written.
+    assert wired_app.mongo.db[ENVELOPES_COLLECTION].docs == []
+    # But audit row was.
+    audit_docs = wired_app.mongo.db[ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION].docs
+    assert len(audit_docs) == 1
+    assert audit_docs[0]["kind"] == "envelope_change_rejected"
+    assert audit_docs[0]["after_envelope_version"] is None
+
+
+def test_reject_requires_rationale_body(wired_app: TestClient) -> None:
+    """AC1.d — rejection_reason is non-optional."""
+    _seed_pending(wired_app.mongo, change_id="chg-rej")
+    r = wired_app.post(
+        "/api/envelopes/chg-rej/reject",
+        json={"operator_id": "carol", "signed_action_id": "sa-rej"},
+    )
+    assert r.status_code == 422
+
+
+def test_reject_404_when_change_missing(wired_app: TestClient) -> None:
+    r = wired_app.post(
+        "/api/envelopes/missing/reject",
+        json={
+            "operator_id": "carol",
+            "signed_action_id": "sa-rej",
+            "rejection_reason": "n/a",
+        },
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

Closes #187 (P4.6-AC1 / FR62) — operator endpoints to review and resolve pending envelope-change proposals on the data-manager.

Mirrors the `leverage_bounds.py` route shape (#182) — same Mongo wiring, same audit-emit pattern (paired `_audit` collection), same 404/409/503/422 error semantics.

## Endpoints

| Method | Path | AC |
| --- | --- | --- |
| `GET` | `/api/envelopes/pending` | 1.a |
| `POST` | `/api/envelopes/{change_id}/accept` | 1.b |
| `POST` | `/api/envelopes/{change_id}/accept-with-modification` | 1.c |
| `POST` | `/api/envelopes/{change_id}/reject` | 1.d |

Each resolution endpoint:
1. Loads the pending change (404 missing, 409 already-resolved).
2. (Accept variants) writes a new versioned `Envelope` row via `EnvelopeRepository.insert_next_version` from #188; `source='operator_approved'`.
3. Flips the pending change to `accepted`/`rejected` with a resolution sub-doc carrying `operator_id` + `signed_action_id` (AC1.e).
4. Best-effort emit to `envelope_authorship_audit` Mongo collection — never blocks the operator request (AC1.g).

OpenAPI auto-generated from handler signatures + Pydantic models (AC1.f).

## Files

| Path | Purpose |
| --- | --- |
| `data_manager/models/envelope_change.py` | `PendingEnvelopeChange` + `EnvelopeChangeResolution` + 3 request DTOs |
| `data_manager/db/repositories/pending_envelope_change_repository.py` | Reads + status-transitions; race-safe via `update_one` gated on `status=='pending'` |
| `data_manager/api/routes/envelopes.py` | 4 endpoints + audit emit |
| `data_manager/api/app.py` | Register the router |
| `tests/unit/test_envelopes_api.py` | 13 tests covering happy-path + 404/409/422/503 + AC1.e/g |

## ACs

- [x] **AC1.a** `GET /api/envelopes/pending` returns all pending changes
- [x] **AC1.b** `POST /accept` accepts as-is, writes Envelope, flips status
- [x] **AC1.c** `POST /accept-with-modification` merges overrides onto proposed value
- [x] **AC1.d** `POST /reject` requires + records `rejection_reason`
- [x] **AC1.e** Every resolution captures `operator_id` + `signed_action_id`
- [x] **AC1.f** OpenAPI documented (FastAPI handler signatures + Pydantic field descriptions)
- [x] **AC1.g** Every action emits one row to `envelope_authorship_audit`

## Scope note

No producer currently writes pending records — that integration is a sibling EPIC #692 AC. Until producers come online `/pending` returns `[]`; the accept/reject endpoints are still functionally complete and tested via fixture-seeded docs.

The FR16 signed-action analog referenced in #692 isn't implemented anywhere in `petrosa-cio` yet (verified via grep). `operator_id` + `signed_action_id` are required request-body fields per the request-DTO contract; when the FR16 producer ships, the route can be extended to verify the signed-action server-side.

## Test results

- `pytest tests/`: **905 passed, 3 skipped** (no regressions)
- 13 new tests in `tests/unit/test_envelopes_api.py`
- `ruff check`: clean
- `ruff format`: clean

## Risk

Routes-only, no migrations. Auto-deploy via #713 is currently broken (see [petrosa_k8s#713](https://github.com/PetroSa2/petrosa_k8s/issues/713)) — merging this PR ships TS code to main but the image won't rebuild until #713 is fixed. No runtime risk from this PR in isolation.
