### PR TITLE
fix(713): move docker-build jobs to ubuntu-latest (restore dashboard image pipeline)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,9 @@ jobs:
   build-and-push:
     name: Build & Push
     needs: create-release
-    runs-on: petrosa-org-runners
+    # Docker build requires /var/run/docker.sock which petrosa-org-runners lack.
+    # Convention across the Petrosa fleet: ubuntu-latest for image builds.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -112,7 +114,8 @@ jobs:
     name: Build & Push Dashboard
     needs: [create-release, detect-changes]
     if: needs.detect-changes.outputs.dashboard == 'true'
-    runs-on: petrosa-org-runners
+    # Docker build — same reason as build-and-push above.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -114,3 +114,5 @@ The Helm chart, ingress, and `apply-k8s-changes.yml` wiring live in the
 sibling ticket
 [#655](https://github.com/PetroSa2/petrosa_k8s/issues/655) under
 `petrosa_k8s/k8s/dashboard/`. This package only produces the image.
+
+<!-- Build pipeline restored 2026-05-29 via petrosa_k8s#713 — see deploy.yml runner fix. -->


### PR DESCRIPTION
## Summary

Closes PetroSa2/petrosa_k8s#713 — `petrosa-dashboard` pod in `ImagePullBackOff` for 3+ days because `yurisa2/petrosa-dashboard:latest` was never pushed (Docker Hub repo 404). Also closes the silent regression that has zero-ed out **every** Deploy run on `main` since 2026-05-22 (15/15 RED at `setup-qemu-action`).

## Root cause

`build-and-push` and `build-and-push-dashboard` jobs were running on `petrosa-org-runners` (the self-hosted ARC pool, no Docker daemon). The QEMU/Buildx step fails:

```
failed to connect to the docker API at unix:///var/run/docker.sock: no such file or directory
##[error]The process '/usr/bin/docker' failed with exit code 1
```

This matches the established memory note `project_cicd_audit_may2026`: "ARC can't docker-build". Every other Petrosa service correctly uses `ubuntu-latest` for Docker-build jobs — `data-manager` was the lone outlier.

## Fix

Two-line `runs-on:` flip on the two image-build jobs. All other jobs (`detect-changes`, `create-release`, `gitops-update*`, `notify`, `cleanup`) stay on `petrosa-org-runners` — they don't need Docker and the ARC pool's faster startup is a win for them.

Also touches `dashboard/README.md` so the first push trips the `detect-changes.outputs.dashboard == 'true'` filter, which triggers `build-and-push-dashboard` to publish the long-missing `yurisa2/petrosa-dashboard:latest`. The follow-on `gitops-update-dashboard` job commits the version tag to `petrosa_k8s/k8s/dashboard/deployment.yaml`, GitOps auto-applies, and the cluster's ImagePullBackOff resolves.

## Diff

```diff
@@ build-and-push @@
-    runs-on: petrosa-org-runners
+    # Docker build requires /var/run/docker.sock which petrosa-org-runners lack.
+    # Convention across the Petrosa fleet: ubuntu-latest for image builds.
+    runs-on: ubuntu-latest

@@ build-and-push-dashboard @@
-    runs-on: petrosa-org-runners
+    # Docker build — same reason as build-and-push above.
+    runs-on: ubuntu-latest
```

Plus a one-line comment appended to `dashboard/README.md`.

## Risk

This is restorative — the dashboard has been down 3+ days and Deploy has been broken for 7+ days. Merge auto-applies via GitOps:
1. `build-and-push` builds `yurisa2/petrosa-data-manager:<version>` (will include the envelope-approval API just shipped via PR #191).
2. `build-and-push-dashboard` builds `yurisa2/petrosa-dashboard:<version>`.
3. `gitops-update*` jobs commit version-tag updates to `petrosa_k8s/k8s/{data-manager,dashboard}/`.
4. `apply-k8s-changes.yml` (per memory `project_petrosa_k8s_gitops_auto_apply`) auto-applies to prod.

The data-manager image will replace whatever stale tag is currently in cluster, restoring API parity with `main` (incl. PR #191's envelope-approval routes). The dashboard image will exist for the first time and resolve the ImagePullBackOff.

## Operator note

`petrosa_k8s#713` had `impl_repo=PetroSa2/petrosa_k8s` which I'll correct to `PetroSa2/petrosa-data-manager` post-merge per the convention shipped in #659. The actual fix lives in this repo because the broken pipeline lives in this repo.
