### PR TITLE
feat(193): publish envelopes.changed on accept/reject (P4.6-AC3 / FR62)

### DIFF
--- a/data_manager/api/routes/envelopes.py
+++ b/data_manager/api/routes/envelopes.py
@@ -27,9 +27,10 @@ Pydantic models with field descriptions (AC1.f).
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime
-from typing import Any
+from typing import Any, Protocol
 
 try:
     from datetime import UTC
@@ -62,6 +63,70 @@ router = APIRouter()
 
 ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION = "envelope_authorship_audit"
 """Mongo collection that captures every approve/reject action (AC1.g)."""
+
+ENVELOPES_CHANGED_NATS_SUBJECT = "envelopes.changed"
+"""Top-level NATS subject for envelope cache-bust events (P4.6-AC3, #193).
+
+Top-level (not ``.<key>``-suffixed): a single subscriber sees every event
+and filters client-side by ``strategy_or_portfolio_key``.
+"""
+
+
+# ── NATS publisher plumbing (parallel to leverage_bounds.set_*_publisher) ──
+
+
+class _NATSPublisher(Protocol):
+    async def publish(self, subject: str, payload: bytes) -> None: ...
+
+
+_publisher: _NATSPublisher | None = None
+
+
+def set_envelopes_changed_publisher(publisher: _NATSPublisher | None) -> None:
+    """Wire the NATS publisher used by accept/reject routes (call once at boot).
+
+    Tests inject a recording stub; passing ``None`` unwires the publisher
+    (the routes then complete normally but skip the NATS emit).
+    """
+    global _publisher
+    _publisher = publisher
+
+
+def _get_publisher() -> _NATSPublisher | None:
+    return _publisher
+
+
+async def _publish_envelopes_changed(payload: dict[str, Any]) -> bool:
+    """Best-effort NATS publish of an ``envelopes.changed`` event (AC3).
+
+    Returns ``True`` iff a publisher was wired AND the publish call did
+    not raise. All failures are logged but never propagated — the operator
+    request must succeed even when NATS is down.
+    """
+    publisher = _get_publisher()
+    if publisher is None:
+        logger.info(
+            "envelopes_changed.publish_skipped key=%s (no publisher wired)",
+            payload.get("strategy_or_portfolio_key"),
+        )
+        return False
+    try:
+        await publisher.publish(
+            ENVELOPES_CHANGED_NATS_SUBJECT, json.dumps(payload).encode()
+        )
+    except Exception as exc:  # noqa: BLE001 — never block the operator request
+        logger.warning(
+            "envelopes_changed.publish_failed key=%s error=%s",
+            payload.get("strategy_or_portfolio_key"),
+            exc,
+        )
+        return False
+    logger.info(
+        "envelopes_changed.published subject=%s key=%s",
+        ENVELOPES_CHANGED_NATS_SUBJECT,
+        payload.get("strategy_or_portfolio_key"),
+    )
+    return True
 
 
 # ── infrastructure helpers (parallel to leverage_bounds.py) ─────────────────
@@ -275,9 +340,21 @@ async def accept_envelope_change(
         rejection_reason=None,
     )
 
+    nats_published = await _publish_envelopes_changed(
+        {
+            "strategy_or_portfolio_key": change.strategy_or_portfolio_key,
+            "new_version": inserted.version,
+            "source": inserted.source,
+            "signed_action_id": req.signed_action_id,
+            "originating_characterization_revision": change.originating_characterization_revision,
+            "accepted_at": datetime.now(UTC).isoformat(),
+        }
+    )
+
     return {
         "change": resolved.model_dump(mode="json"),
         "envelope": inserted.model_dump(mode="json"),
+        "nats_published": nats_published,
     }
 
 
@@ -343,9 +420,21 @@ async def accept_envelope_change_with_modification(
         rejection_reason=None,
     )
 
+    nats_published = await _publish_envelopes_changed(
+        {
+            "strategy_or_portfolio_key": change.strategy_or_portfolio_key,
+            "new_version": inserted.version,
+            "source": inserted.source,
+            "signed_action_id": req.signed_action_id,
+            "originating_characterization_revision": change.originating_characterization_revision,
+            "accepted_at": datetime.now(UTC).isoformat(),
+        }
+    )
+
     return {
         "change": resolved.model_dump(mode="json"),
         "envelope": inserted.model_dump(mode="json"),
+        "nats_published": nats_published,
     }
 
 
@@ -399,4 +488,17 @@ async def reject_envelope_change(
         rejection_reason=req.rejection_reason,
     )
 
-    return {"change": resolved.model_dump(mode="json")}
+    nats_published = await _publish_envelopes_changed(
+        {
+            "strategy_or_portfolio_key": change.strategy_or_portfolio_key,
+            "status": "rejected",
+            "change_id": change_id,
+            "operator_id": req.operator_id,
+            "signed_action_id": req.signed_action_id,
+        }
+    )
+
+    return {
+        "change": resolved.model_dump(mode="json"),
+        "nats_published": nats_published,
+    }

--- a/tests/unit/test_envelopes_api.py
+++ b/tests/unit/test_envelopes_api.py
@@ -21,6 +21,7 @@ Covers every AC of #187:
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -28,7 +29,11 @@ from fastapi.testclient import TestClient
 
 import data_manager.api.app as api_module
 from data_manager.api.app import create_app
-from data_manager.api.routes.envelopes import ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION
+from data_manager.api.routes.envelopes import (
+    ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION,
+    ENVELOPES_CHANGED_NATS_SUBJECT,
+    set_envelopes_changed_publisher,
+)
 from data_manager.db.repositories.envelope_repository import ENVELOPES_COLLECTION
 from data_manager.db.repositories.pending_envelope_change_repository import (
     PENDING_ENVELOPE_CHANGES_COLLECTION,
@@ -158,19 +163,40 @@ class _FakeDbManager:
 # ─── Fixtures ────────────────────────────────────────────────────────────────
 
 
+class _RecordingPublisher:
+    """Captures (subject, payload-dict) tuples for assertion in tests."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict]] = []
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        self.published.append((subject, json.loads(payload.decode())))
+
+
+class _BrokenPublisher:
+    """Always raises — used to prove publish failures never break the operator request."""
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        raise RuntimeError("nats down")
+
+
 @pytest.fixture
 def wired_app():
-    """Wire the in-memory Mongo into the app module for the duration of a test."""
+    """Wire the in-memory Mongo + recording NATS publisher into the app module."""
     original = api_module.db_manager
     api_module.db_manager = _FakeDbManager()
+    publisher = _RecordingPublisher()
+    set_envelopes_changed_publisher(publisher)
     try:
         app = create_app()
         client = TestClient(app)
-        # Stash the mongo handle for in-test seeding/inspection.
+        # Stash handles for in-test seeding/inspection.
         client.mongo = api_module.db_manager.mongodb_adapter  # type: ignore[attr-defined]
+        client.publisher = publisher  # type: ignore[attr-defined]
         yield client
     finally:
         api_module.db_manager = original
+        set_envelopes_changed_publisher(None)
 
 
 def _seed_pending(
@@ -469,3 +495,126 @@ def test_reject_404_when_change_missing(wired_app: TestClient) -> None:
         },
     )
     assert r.status_code == 404
+
+
+# ─── AC3 / #193 — envelopes.changed NATS publisher ───────────────────────────
+
+
+def test_accept_publishes_envelopes_changed(wired_app: TestClient) -> None:
+    """AC3: successful accept emits envelopes.changed with the AC payload shape."""
+    _seed_pending(
+        wired_app.mongo,
+        change_id="chg-pub-1",
+        key="strategy:btc_pub",
+        proposed={"max_drawdown_pct": 7.5},
+        char_revision="char-rev-pub-1",
+    )
+
+    r = wired_app.post(
+        "/api/envelopes/chg-pub-1/accept",
+        json={"operator_id": "alice", "signed_action_id": "sa-pub-1"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["nats_published"] is True
+
+    assert len(wired_app.publisher.published) == 1
+    subject, payload = wired_app.publisher.published[0]
+    assert subject == ENVELOPES_CHANGED_NATS_SUBJECT
+    assert subject == "envelopes.changed"
+    assert payload["strategy_or_portfolio_key"] == "strategy:btc_pub"
+    assert isinstance(payload["new_version"], int)
+    assert payload["source"] == "operator_approved"
+    assert payload["signed_action_id"] == "sa-pub-1"
+    assert payload["originating_characterization_revision"] == "char-rev-pub-1"
+    assert payload["accepted_at"] is not None
+
+
+def test_accept_with_modification_publishes_envelopes_changed(
+    wired_app: TestClient,
+) -> None:
+    _seed_pending(
+        wired_app.mongo,
+        change_id="chg-pub-2",
+        key="strategy:eth_pub",
+        proposed={"max_drawdown_pct": 6.0, "vol_target": 0.1},
+        char_revision="char-rev-pub-2",
+    )
+
+    r = wired_app.post(
+        "/api/envelopes/chg-pub-2/accept-with-modification",
+        json={
+            "operator_id": "bob",
+            "signed_action_id": "sa-pub-2",
+            "modification_overrides": {"vol_target": 0.15},
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["nats_published"] is True
+
+    assert len(wired_app.publisher.published) == 1
+    subject, payload = wired_app.publisher.published[0]
+    assert subject == "envelopes.changed"
+    assert payload["strategy_or_portfolio_key"] == "strategy:eth_pub"
+    assert payload["source"] == "operator_approved"
+    assert payload["signed_action_id"] == "sa-pub-2"
+
+
+def test_reject_publishes_envelopes_changed_with_status_rejected(
+    wired_app: TestClient,
+) -> None:
+    _seed_pending(wired_app.mongo, change_id="chg-pub-3", key="strategy:doge_pub")
+
+    r = wired_app.post(
+        "/api/envelopes/chg-pub-3/reject",
+        json={
+            "operator_id": "carol",
+            "signed_action_id": "sa-pub-3",
+            "rejection_reason": "characterization sample too small",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["nats_published"] is True
+
+    assert len(wired_app.publisher.published) == 1
+    subject, payload = wired_app.publisher.published[0]
+    assert subject == "envelopes.changed"
+    assert payload["strategy_or_portfolio_key"] == "strategy:doge_pub"
+    assert payload["status"] == "rejected"
+    assert payload["change_id"] == "chg-pub-3"
+    assert payload["operator_id"] == "carol"
+    assert payload["signed_action_id"] == "sa-pub-3"
+    # Accept-only fields must be absent on reject payload (top-level filter)
+    assert "new_version" not in payload
+    assert "source" not in payload
+
+
+def test_broken_publisher_does_not_fail_accept(wired_app: TestClient) -> None:
+    """AC: publish failures are logged but never break the operator request."""
+    set_envelopes_changed_publisher(_BrokenPublisher())
+    _seed_pending(wired_app.mongo, change_id="chg-broken", key="strategy:broken")
+
+    r = wired_app.post(
+        "/api/envelopes/chg-broken/accept",
+        json={"operator_id": "alice", "signed_action_id": "sa-broken"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["nats_published"] is False
+    # Envelope + audit still landed even though publish raised.
+    assert len(wired_app.mongo.db[ENVELOPES_COLLECTION].docs) == 1
+    assert len(wired_app.mongo.db[ENVELOPE_AUTHORSHIP_AUDIT_COLLECTION].docs) == 1
+
+
+def test_publisher_unwired_returns_nats_published_false(wired_app: TestClient) -> None:
+    """No publisher wired → route still succeeds, returns nats_published=False."""
+    set_envelopes_changed_publisher(None)
+    _seed_pending(wired_app.mongo, change_id="chg-no-pub", key="strategy:noop")
+
+    r = wired_app.post(
+        "/api/envelopes/chg-no-pub/accept",
+        json={"operator_id": "alice", "signed_action_id": "sa-no-pub"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["nats_published"] is False
+    # Storage + audit still happen.
+    assert len(wired_app.mongo.db[ENVELOPES_COLLECTION].docs) == 1


### PR DESCRIPTION
## Summary

Closes #193 — producer side of the `envelopes.changed` cache-bust contract (P4.6-AC3 / FR62).

The operator envelope-approval API (#187, merged via [#191](https://github.com/PetroSa2/petrosa-data-manager/pull/191) 2026-05-29) shipped storage + accept/reject endpoints, but did not publish `envelopes.changed` on NATS — leaving the downstream cio/tradeengine envelope-fetch helpers without a hot-reload signal. This PR adds that publisher and wires it into all three resolution endpoints.

## What changed

`data_manager/api/routes/envelopes.py`:

* New `_NATSPublisher` Protocol + module-level `_publisher` slot.
* `set_envelopes_changed_publisher(publisher | None)` setter (mirror of `set_leverage_bounds_publisher` from #186).
* `_publish_envelopes_changed(payload) -> bool` best-effort helper. Returns `True` only when a publisher is wired AND `publish()` did not raise; all failures are logged but never propagated.
* Top-level subject constant `ENVELOPES_CHANGED_NATS_SUBJECT = "envelopes.changed"` — single subscriber sees every event, filters client-side by `strategy_or_portfolio_key`.
* The three resolution handlers now emit after their existing audit emit, before returning. Response gains `nats_published: bool` so operators see emit status without inspecting logs.

`tests/unit/test_envelopes_api.py`:

* `_RecordingPublisher` + `_BrokenPublisher` helpers.
* `wired_app` fixture now also wires a default recording publisher and exposes it via `client.publisher`; teardown restores the unwired state.
* Five new tests:
  * accept publishes with full AC payload
  * accept-with-modification publishes with the same shape
  * reject publishes the rejected-shape payload
  * broken publisher → `nats_published=false`, storage + audit still landed
  * unwired publisher → `nats_published=false`, route still 200

## Acceptance criteria

- [x] **Publish on accept (`accept` + `accept-with-modification`)** — payload: `{strategy_or_portfolio_key, new_version, source, signed_action_id, originating_characterization_revision, accepted_at}`
- [x] **Publish on reject** — payload: `{strategy_or_portfolio_key, status: "rejected", change_id, operator_id, signed_action_id}`
- [x] **NATS subject**: `envelopes.changed` (top-level)
- [x] **Best-effort**: failures logged, never break the HTTP response
- [x] **NATS publisher wiring**: `set_envelopes_changed_publisher` parallel to `set_leverage_bounds_publisher`
- [x] **Unit tests**: mocked publisher captures (subject, payload); per-endpoint publish assertions; broken-publisher resilience proven

## Out of scope (intentionally deferred)

- Consumer/subscriber side in cio and tradeengine — sibling leaves of EPIC #753.
- Boot-time wiring of `set_envelopes_changed_publisher(...)` in `data_manager/main.py` — mirrors #186's deferred pattern; tracked as the natural follow-up when the boot-side NATS publisher type is introduced.

## Validation

- `ruff check`: clean
- `ruff format`: clean
- `pytest tests/`: 910 passed, 3 skipped, 0 failed (full local suite)
- `pytest tests/unit/test_envelopes_api.py`: 18 passed (13 pre-existing + 5 new)
