### PR TITLE
feat(200): expose GET /api/envelopes/active/{key} read route

### DIFF
--- a/data_manager/api/routes/envelopes.py
+++ b/data_manager/api/routes/envelopes.py
@@ -276,6 +276,43 @@ async def list_pending_envelope_changes(limit: int = 200) -> dict[str, Any]:
     }
 
 
+@router.get("/api/envelopes/active/{key}")
+async def get_active_envelope(
+    key: str = Path(..., min_length=1, description="strategy_or_portfolio_key"),
+) -> dict[str, Any]:
+    """Return the active (highest-version) envelope for ``key`` (#200).
+
+    Wraps :meth:`EnvelopeRepository.get_full_active_envelope` so out-of-process
+    consumers (cio envelope-fetch helper from #154, tradeengine FR30 wiring
+    from #421) can read the active envelope without sharing the Mongo
+    connection.
+
+    The repository returns the highest ``version`` regardless of ``source``
+    (AC3 of #154 — operator-approved precedence by version, not by source):
+    if an operator-approved ``v=4`` row exists and a characterization ``v=5``
+    arrives afterward, the read returns ``v=5``. That precedence-by-version
+    is intentional and is asserted by the cross-repo helper tests.
+
+    Responses:
+      * ``200`` — full ``Envelope`` document as JSON (envelope_id, version,
+        strategy_or_portfolio_key, value, source, originating_characterization_revision,
+        operator_id, created_at, signed_action_id).
+      * ``404`` — no envelope exists for the given key.
+      * ``503`` — MongoDB is unavailable (data-manager in limited mode).
+    """
+    repo = _envelope_repo()
+    envelope = await repo.get_full_active_envelope(key)
+    if envelope is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "title": "Envelope not found",
+                "detail": f"No envelope exists for strategy_or_portfolio_key={key!r}",
+            },
+        )
+    return envelope.model_dump(mode="json")
+
+
 @router.post("/api/envelopes/{change_id}/accept")
 async def accept_envelope_change(
     req: AcceptEnvelopeChangeRequest,

--- a/tests/unit/test_envelopes_api.py
+++ b/tests/unit/test_envelopes_api.py
@@ -618,3 +618,85 @@ def test_publisher_unwired_returns_nats_published_false(wired_app: TestClient) -
     assert r.json()["nats_published"] is False
     # Storage + audit still happen.
     assert len(wired_app.mongo.db[ENVELOPES_COLLECTION].docs) == 1
+
+
+# ─── #200 — GET /api/envelopes/active/{key} (read route for cio#154 unblock) ─
+
+
+def test_get_active_envelope_returns_seeded_envelope(wired_app: TestClient) -> None:
+    """AC1 + AC2 of #200: 200 with full Envelope shape when one exists."""
+    key = "strategy:btc_momentum_v3"
+    _seed_existing_envelope(
+        wired_app.mongo, key=key, version=5, value={"max_drawdown_pct": 6.5}
+    )
+
+    r = wired_app.get(f"/api/envelopes/active/{key}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # All Envelope fields present and JSON-serialized.
+    assert body["strategy_or_portfolio_key"] == key
+    assert body["version"] == 5
+    assert body["value"] == {"max_drawdown_pct": 6.5}
+    assert body["source"] == "characterization"
+    assert body["envelope_id"] == f"{key}:v5"
+    assert body["signed_action_id"] == "sa-prior"
+    assert "created_at" in body  # ISO-8601 string
+
+
+def test_get_active_envelope_returns_404_when_missing(wired_app: TestClient) -> None:
+    """AC1 of #200: 404 when no envelope exists for the key."""
+    r = wired_app.get("/api/envelopes/active/strategy:never_seeded")
+    assert r.status_code == 404
+    detail = r.json()["detail"]
+    assert "strategy:never_seeded" in detail["detail"]
+
+
+def test_get_active_envelope_returns_highest_version_regardless_of_source(
+    wired_app: TestClient,
+) -> None:
+    """AC3 of #200 (and the cio#154 precedence-by-version quirk):
+    operator_approved v=4 followed by characterization v=5 must return v=5.
+    The repository sorts by version desc; source is informational, not
+    used as a filter."""
+    key = "strategy:precedence_check"
+    # operator_approved v=4 (older)
+    wired_app.mongo.db[ENVELOPES_COLLECTION].docs.append(
+        {
+            "_id": f"{key}:v4",
+            "envelope_id": f"{key}:v4",
+            "version": 4,
+            "strategy_or_portfolio_key": key,
+            "value": {"max_drawdown_pct": 7.0},
+            "source": "operator_approved",
+            "originating_characterization_revision": None,
+            "operator_id": "alice",
+            "created_at": "2026-05-29T00:00:00+00:00",
+            "signed_action_id": "sa-op-v4",
+        }
+    )
+    # characterization v=5 (newer — wins)
+    _seed_existing_envelope(
+        wired_app.mongo, key=key, version=5, value={"max_drawdown_pct": 6.0}
+    )
+
+    r = wired_app.get(f"/api/envelopes/active/{key}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["version"] == 5
+    assert body["source"] == "characterization"
+    assert body["value"] == {"max_drawdown_pct": 6.0}
+
+
+def test_get_active_envelope_503_when_db_unavailable() -> None:
+    """AC1 of #200: 503 when MongoDB is unavailable (limited mode)."""
+    original = api_module.db_manager
+    api_module.db_manager = None
+    try:
+        app = create_app()
+        client = TestClient(app)
+        r = client.get("/api/envelopes/active/strategy:anything")
+        assert r.status_code == 503
+        detail = r.json()["detail"]
+        assert detail["title"] == "MongoDB unavailable"
+    finally:
+        api_module.db_manager = original


### PR DESCRIPTION
## Summary

Closes #200. Sibling unblock for [petrosa-cio#154](https://github.com/PetroSa2/petrosa-cio/issues/154) — the envelope-fetch helper there cannot reach `EnvelopeRepository.get_active_envelope` from a remote process without an HTTP read endpoint. The repository method already exists (shipped with #188); this PR just exposes it. Unblocks the downstream `cio#154 → tradeengine#421/#422/#423` chain.

## Changes

**`data_manager/api/routes/envelopes.py` (+44 lines):**

- New `GET /api/envelopes/active/{key}` handler — wraps `EnvelopeRepository.get_full_active_envelope`, returns the full `Envelope` Pydantic model as JSON (`envelope_id`, `version`, `strategy_or_portfolio_key`, `value`, `source`, `originating_characterization_revision`, `operator_id`, `created_at`, `signed_action_id`).
- Returns `404` when no envelope exists for the key.
- Returns `503` when MongoDB is unavailable — matches the existing limited-mode pattern used by the POST routes.

**`tests/unit/test_envelopes_api.py` (+75 lines, 4 new test cases):**

| Test | What it covers |
|---|---|
| `test_get_active_envelope_returns_seeded_envelope` | Happy path — 200 + correct shape with all Envelope fields |
| `test_get_active_envelope_returns_404_when_missing` | 404 with informative `detail.detail` referencing the key |
| `test_get_active_envelope_returns_highest_version_regardless_of_source` | **Locks in the cio#154 precedence-by-version contract**: operator_approved v=4 + characterization v=5 → v=5 wins, because the repository sorts by version desc and `source` is informational, not a filter. Regression-guards a future "let's filter by source" mistake. |
| `test_get_active_envelope_503_when_db_unavailable` | Limited-mode coverage |

## Verification

- Focused tests: `pytest -k "active"` — **4/4 pass**
- Full suite: `pytest tests/` — **936 passed, 3 skipped, 0 failed** (was 932 — +4 from new tests)
- `ruff check` + `ruff format --check` — clean

## Out of scope

- Caching / TTL on the consumer side — that lives in cio#154 AC3.a.
- Cache-bust on `envelopes.changed` — already shipped via #193/#196.
- OpenAPI Pydantic response model annotation (the route's return is the JSON dict, which gets the right schema via the model's `.model_dump`) — can be tightened later if cio#154 wants codegen against the schema.
