### PR TITLE
feat(dashboard): envelope-authorship backend API (#203)

### DIFF
--- a/data_manager/api/routes/dashboard.py
+++ b/data_manager/api/routes/dashboard.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
+from typing import Any
 
 try:
     from datetime import UTC
@@ -517,3 +518,114 @@ async def dashboard_strategy_lifecycle(
     payload.setdefault("strategy_id", strategy_id)
     payload["window"] = window
     return payload
+
+
+# ----------------------------------------------------------------------
+# Route: /envelope-authorship — P4.6-AC4.a / FR62 (#203).
+# Backend API for the operator dashboard envelope-authorship pane.
+# Returns the current active envelope per strategy_or_portfolio_key,
+# pending changes awaiting operator action, and the decided-history
+# tail (paginated via ?limit= + ?cursor=).
+# ----------------------------------------------------------------------
+
+
+@router.get("/envelope-authorship")
+async def get_envelope_authorship(
+    key: str | None = None,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """Return ``{current, pending, history}`` for the dashboard pane.
+
+    Query params (all optional):
+      * ``key`` — narrow all three buckets to one strategy_or_portfolio_key.
+      * ``limit`` — history page size (default 50, max 200, min 1).
+      * ``cursor`` — ISO-8601 ``resolution.decided_at`` of the last row
+        from the previous history page; returns rows strictly older.
+
+    Response shape::
+
+        {
+            "current": [Envelope, ...],
+            "pending": [PendingEnvelopeChange, ...],
+            "history": [PendingEnvelopeChange, ...],
+            "next_cursor": str | null,
+            "filters": {"key": str | null, "limit": int},
+        }
+    """
+    # Local imports avoid an import cycle at app boot (envelope routes
+    # import dashboard for nothing but the repos here are the same).
+    from data_manager.db.repositories.envelope_repository import EnvelopeRepository
+    from data_manager.db.repositories.pending_envelope_change_repository import (
+        PendingEnvelopeChangeRepository,
+    )
+
+    mongo = _require_mongo()
+    env_repo = EnvelopeRepository(mongodb_adapter=mongo)
+    pending_repo = PendingEnvelopeChangeRepository(mongodb_adapter=mongo)
+
+    clamped_limit = max(1, min(int(limit), 200))
+
+    try:
+        current = await env_repo.list_active_envelopes(key=key, limit=200)
+    except Exception as exc:
+        logger.error(
+            "dashboard_envelope_authorship_current_failed",
+            extra={"key": key, "error": str(exc)},
+            exc_info=True,
+        )
+        _raise_problem(
+            status=500,
+            title="envelope_authorship_current_failed",
+            detail="Failed to load active envelopes.",
+        )
+
+    try:
+        pending_rows = await pending_repo.list_pending(limit=200)
+        if key:
+            pending_rows = [
+                p for p in pending_rows if p.strategy_or_portfolio_key == key
+            ]
+    except Exception as exc:
+        logger.error(
+            "dashboard_envelope_authorship_pending_failed",
+            extra={"key": key, "error": str(exc)},
+            exc_info=True,
+        )
+        _raise_problem(
+            status=500,
+            title="envelope_authorship_pending_failed",
+            detail="Failed to load pending envelope changes.",
+        )
+
+    try:
+        history_rows, next_cursor = await pending_repo.list_decided(
+            key=key, limit=clamped_limit, cursor=cursor
+        )
+    except ValueError as exc:
+        # Bad cursor format → 400 (operator's fault, not ours).
+        _raise_problem(
+            status=400,
+            title="invalid_cursor",
+            detail=str(exc),
+        )
+    except Exception as exc:
+        logger.error(
+            "dashboard_envelope_authorship_history_failed",
+            extra={"key": key, "cursor": cursor, "error": str(exc)},
+            exc_info=True,
+        )
+        _raise_problem(
+            status=500,
+            title="envelope_authorship_history_failed",
+            detail="Failed to load decided envelope changes.",
+        )
+
+    # Pydantic models serialise via model_dump for stable JSON shape.
+    return {
+        "current": [e.model_dump(mode="json") for e in current],
+        "pending": [p.model_dump(mode="json") for p in pending_rows],
+        "history": [p.model_dump(mode="json") for p in history_rows],
+        "next_cursor": next_cursor,
+        "filters": {"key": key, "limit": clamped_limit},
+    }

--- a/data_manager/db/repositories/envelope_repository.py
+++ b/data_manager/db/repositories/envelope_repository.py
@@ -125,6 +125,48 @@ class EnvelopeRepository(BaseRepository):
         doc = await col.find_one({"strategy_or_portfolio_key": key, "version": version})
         return self._doc_to_envelope(doc)
 
+    async def list_active_envelopes(
+        self, *, key: str | None = None, limit: int = 200
+    ) -> list[Envelope]:
+        """Return the highest-version envelope per ``strategy_or_portfolio_key``.
+
+        Powers the dashboard ``current[]`` pane (P4.6-AC4.a / #203). When
+        ``key`` is supplied, the result is at most one element. When omitted,
+        returns one row per distinct key in the store, capped at ``limit``.
+
+        Implementation note: a simple ``$group``+``$first`` aggregation over
+        a sort by ``version DESC`` per key. Mongo doesn't directly support
+        "max-version per group" without a sort upstream — that's what the
+        pipeline does.
+        """
+        col = self._collection()
+        match: dict[str, Any] = {}
+        if key:
+            match["strategy_or_portfolio_key"] = key
+        pipeline: list[dict[str, Any]] = []
+        if match:
+            pipeline.append({"$match": match})
+        pipeline.extend(
+            [
+                {"$sort": {"strategy_or_portfolio_key": 1, "version": -1}},
+                {
+                    "$group": {
+                        "_id": "$strategy_or_portfolio_key",
+                        "doc": {"$first": "$ROOT"},
+                    }
+                },
+                {"$replaceRoot": {"newRoot": "$doc"}},
+                {"$sort": {"strategy_or_portfolio_key": 1}},
+                {"$limit": max(1, min(int(limit), 200))},
+            ]
+        )
+        out: list[Envelope] = []
+        async for doc in col.aggregate(pipeline):
+            env = self._doc_to_envelope(doc)
+            if env is not None:
+                out.append(env)
+        return out
+
     async def list_versions(self, key: str, limit: int = 50) -> list[int]:
         """Version numbers for ``key`` in descending order (operator history pane).
 

--- a/data_manager/db/repositories/pending_envelope_change_repository.py
+++ b/data_manager/db/repositories/pending_envelope_change_repository.py
@@ -15,6 +15,7 @@ first one.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from data_manager.db.repositories.base_repository import BaseRepository
@@ -95,6 +96,55 @@ class PendingEnvelopeChangeRepository(BaseRepository):
             name="strategy_or_portfolio_key_1_status_1",
             background=True,
         )
+
+    async def list_decided(
+        self,
+        *,
+        key: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> tuple[list[PendingEnvelopeChange], str | None]:
+        """List decided (accepted/rejected) envelope-change rows for the
+        dashboard history pane (P4.6-AC4.a / #203).
+
+        Sorted descending by ``resolution.decided_at``. The cursor is the
+        ISO-8601 ``decided_at`` value of the last row in the previous page —
+        callers paginate by passing it back as ``cursor`` to get rows older
+        than that timestamp.
+
+        ``limit`` is clamped to ``[1, 200]`` — the AC defines that range.
+        """
+        clamped = max(1, min(int(limit), 200))
+        col = self._collection()
+        query: dict[str, Any] = {"status": {"$in": ["accepted", "rejected"]}}
+        if key:
+            query["strategy_or_portfolio_key"] = key
+        if cursor:
+            # decided_at lives inside resolution sub-document; the cursor
+            # is interpreted as exclusive (returns rows strictly older).
+            try:
+                cursor_dt = datetime.fromisoformat(cursor.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError(
+                    f"cursor must be an ISO-8601 datetime; got {cursor!r}"
+                ) from exc
+            query["resolution.decided_at"] = {"$lt": cursor_dt}
+        # +1 to detect whether there's another page without a second query
+        mongo_cursor = (
+            col.find(query).sort("resolution.decided_at", -1).limit(clamped + 1)
+        )
+        rows: list[PendingEnvelopeChange] = []
+        async for doc in mongo_cursor:
+            change = self._doc_to_model(doc)
+            if change is not None:
+                rows.append(change)
+        next_cursor: str | None = None
+        if len(rows) > clamped:
+            rows = rows[:clamped]
+            tail = rows[-1]
+            if tail.resolution is not None:
+                next_cursor = tail.resolution.decided_at.isoformat()
+        return rows, next_cursor
 
     async def list_pending(self, limit: int = 200) -> list[PendingEnvelopeChange]:
         """Return all pending changes (AC1.a) in newest-first order.

--- a/tests/unit/test_dashboard_envelope_authorship_api.py
+++ b/tests/unit/test_dashboard_envelope_authorship_api.py
@@ -1,0 +1,311 @@
+"""Tests for ``GET /api/dashboard/envelope-authorship`` (P4.6-AC4.a / #203).
+
+Backend API surface that powers the operator dashboard envelope-authorship
+pane — returns the current active envelope per ``strategy_or_portfolio_key``,
+pending changes awaiting operator action, and the decided-history tail
+(paginated). API-only — no SPA changes here.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.api.app import create_app
+from data_manager.models.envelope import Envelope
+from data_manager.models.envelope_change import (
+    EnvelopeChangeResolution,
+    PendingEnvelopeChange,
+)
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    """Boot the FastAPI app with a fake mongodb_adapter wired in.
+
+    The route uses ``api_module.db_manager.mongodb_adapter`` via
+    ``_require_mongo`` — we just need that attribute to be truthy.
+    """
+    fake_db_manager = MagicMock()
+    fake_db_manager.mongodb_adapter = MagicMock()
+    monkeypatch.setattr(api_module, "db_manager", fake_db_manager)
+    app = create_app()
+    return TestClient(app)
+
+
+def _envelope(key: str, version: int, source: str = "operator_approved") -> Envelope:
+    return Envelope(
+        envelope_id=f"env-{key}-{version}",
+        strategy_or_portfolio_key=key,
+        version=version,
+        source=source,
+        value={"max_drawdown_pct": 5.0 + version},
+        originating_characterization_revision="rev-abc",
+        operator_id="alice" if source == "operator_approved" else None,
+        created_at=datetime(2026, 6, 1, 10, 0, 0, tzinfo=UTC),
+        signed_action_id="sa-1",
+    )
+
+
+def _pending_change(key: str, change_id: str) -> PendingEnvelopeChange:
+    return PendingEnvelopeChange(
+        change_id=change_id,
+        strategy_or_portfolio_key=key,
+        proposed_envelope_value={"max_drawdown_pct": 8.0},
+        originating_characterization_revision="rev-pending",
+        created_at=datetime(2026, 6, 1, 9, 0, 0, tzinfo=UTC),
+        status="pending",
+    )
+
+
+def _decided_change(
+    key: str, change_id: str, decided_at: datetime, status: str = "accepted"
+) -> PendingEnvelopeChange:
+    return PendingEnvelopeChange(
+        change_id=change_id,
+        strategy_or_portfolio_key=key,
+        proposed_envelope_value={"max_drawdown_pct": 6.5},
+        originating_characterization_revision="rev-decided",
+        created_at=datetime(2026, 6, 1, 9, 0, 0, tzinfo=UTC),
+        status=status,
+        resolution=EnvelopeChangeResolution(
+            operator_id="alice",
+            decided_at=decided_at,
+            signed_action_id="sa-decision-1",
+            rejection_reason="not viable" if status == "rejected" else None,
+        ),
+    )
+
+
+def _patch_repos(monkeypatch, *, current, pending, history, next_cursor=None):
+    """Stub EnvelopeRepository.list_active_envelopes + PendingEnvelopeChangeRepository.{list_pending,list_decided}."""
+    monkeypatch.setattr(
+        "data_manager.api.routes.dashboard.EnvelopeRepository.list_active_envelopes"
+        if False
+        else "data_manager.db.repositories.envelope_repository.EnvelopeRepository.list_active_envelopes",
+        AsyncMock(return_value=current),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_pending",
+        AsyncMock(return_value=pending),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_decided",
+        AsyncMock(return_value=(history, next_cursor)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4.a — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_returns_empty_buckets_when_no_data(client: TestClient, monkeypatch) -> None:
+    _patch_repos(monkeypatch, current=[], pending=[], history=[])
+    response = client.get("/api/dashboard/envelope-authorship")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["current"] == []
+    assert body["pending"] == []
+    assert body["history"] == []
+    assert body["next_cursor"] is None
+    assert body["filters"] == {"key": None, "limit": 50}
+
+
+def test_returns_all_three_buckets_populated(client: TestClient, monkeypatch) -> None:
+    current = [_envelope("strategy:momentum-v3", version=5)]
+    pending = [_pending_change("strategy:momentum-v3", "ch-pending-1")]
+    history = [
+        _decided_change(
+            "strategy:momentum-v3",
+            "ch-decided-1",
+            datetime(2026, 6, 1, 11, 0, 0, tzinfo=UTC),
+        )
+    ]
+    _patch_repos(monkeypatch, current=current, pending=pending, history=history)
+
+    response = client.get("/api/dashboard/envelope-authorship")
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["current"]) == 1
+    assert body["current"][0]["version"] == 5
+    assert body["current"][0]["source"] == "operator_approved"
+    assert len(body["pending"]) == 1
+    assert body["pending"][0]["change_id"] == "ch-pending-1"
+    assert body["pending"][0]["status"] == "pending"
+    assert len(body["history"]) == 1
+    assert body["history"][0]["change_id"] == "ch-decided-1"
+    assert body["history"][0]["status"] == "accepted"
+
+
+# ---------------------------------------------------------------------------
+# AC4.a.1 — key filter
+# ---------------------------------------------------------------------------
+
+
+def test_key_filter_passed_through_to_repos(client: TestClient, monkeypatch) -> None:
+    """The ``?key=`` query param must be forwarded to all three repo calls so
+    each bucket gets narrowed to the same key (no cross-bucket drift)."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_list_active(self, *, key=None, limit=200):
+        captured["current_key"] = key
+        return [_envelope("strategy:momentum-v3", version=3)]
+
+    async def _fake_list_pending(self, limit=200):
+        # list_pending doesn't take a key arg — the route filters in Python.
+        return [_pending_change("strategy:momentum-v3", "ch-pending-1")]
+
+    async def _fake_list_decided(self, *, key=None, limit=50, cursor=None):
+        captured["history_key"] = key
+        captured["history_limit"] = limit
+        return [], None
+
+    monkeypatch.setattr(
+        "data_manager.db.repositories.envelope_repository.EnvelopeRepository.list_active_envelopes",
+        _fake_list_active,
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_pending",
+        _fake_list_pending,
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_decided",
+        _fake_list_decided,
+    )
+
+    response = client.get("/api/dashboard/envelope-authorship?key=strategy:momentum-v3")
+    assert response.status_code == 200
+    assert captured == {
+        "current_key": "strategy:momentum-v3",
+        "history_key": "strategy:momentum-v3",
+        "history_limit": 50,
+    }
+    body = response.json()
+    assert body["filters"] == {"key": "strategy:momentum-v3", "limit": 50}
+
+
+# ---------------------------------------------------------------------------
+# Pagination cursor round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_history_pagination_returns_next_cursor(
+    client: TestClient, monkeypatch
+) -> None:
+    decided_at = datetime(2026, 6, 1, 8, 0, 0, tzinfo=UTC)
+    history = [_decided_change("k", f"ch-{i}", decided_at) for i in range(3)]
+    next_cursor = decided_at.isoformat()
+    _patch_repos(
+        monkeypatch,
+        current=[],
+        pending=[],
+        history=history,
+        next_cursor=next_cursor,
+    )
+
+    response = client.get("/api/dashboard/envelope-authorship?limit=3")
+    body = response.json()
+    assert body["next_cursor"] == next_cursor
+    assert body["filters"]["limit"] == 3
+
+
+def test_history_cursor_round_trip(client: TestClient, monkeypatch) -> None:
+    """Caller passes the previous page's next_cursor back as ``cursor`` to
+    get older rows — the value flows through the route to the repo."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_list_decided(self, *, key=None, limit=50, cursor=None):
+        captured["cursor"] = cursor
+        return [], None
+
+    monkeypatch.setattr(
+        "data_manager.db.repositories.envelope_repository.EnvelopeRepository.list_active_envelopes",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_pending",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_decided",
+        _fake_list_decided,
+    )
+
+    response = client.get(
+        "/api/dashboard/envelope-authorship",
+        params={"cursor": "2026-06-01T08:00:00+00:00"},
+    )
+    assert response.status_code == 200
+    assert captured["cursor"] == "2026-06-01T08:00:00+00:00"
+
+
+def test_bad_cursor_returns_400(client: TestClient, monkeypatch) -> None:
+    """A malformed cursor surfaces as RFC-7807 400, not 500. The repo raises
+    ValueError; the route maps it to ``invalid_cursor`` title."""
+
+    async def _fake_list_decided(self, *, key=None, limit=50, cursor=None):
+        raise ValueError("cursor must be an ISO-8601 datetime; got 'banana'")
+
+    monkeypatch.setattr(
+        "data_manager.db.repositories.envelope_repository.EnvelopeRepository.list_active_envelopes",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_pending",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_decided",
+        _fake_list_decided,
+    )
+
+    response = client.get("/api/dashboard/envelope-authorship?cursor=banana")
+    assert response.status_code == 400
+    assert response.json()["detail"]["title"] == "invalid_cursor"
+
+
+def test_limit_clamped_to_max_200(client: TestClient, monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def _fake_list_decided(self, *, key=None, limit=50, cursor=None):
+        captured["limit"] = limit
+        return [], None
+
+    monkeypatch.setattr(
+        "data_manager.db.repositories.envelope_repository.EnvelopeRepository.list_active_envelopes",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_pending",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.pending_envelope_change_repository.PendingEnvelopeChangeRepository.list_decided",
+        _fake_list_decided,
+    )
+
+    response = client.get("/api/dashboard/envelope-authorship?limit=999")
+    body = response.json()
+    assert response.status_code == 200
+    assert captured["limit"] == 200
+    assert body["filters"]["limit"] == 200
+
+
+# ---------------------------------------------------------------------------
+# 503 on Mongo unavailability
+# ---------------------------------------------------------------------------
+
+
+def test_503_when_mongo_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(api_module, "db_manager", None)
+    app = create_app()
+    client = TestClient(app)
+    response = client.get("/api/dashboard/envelope-authorship")
+    assert response.status_code == 503
+    assert response.json()["detail"]["title"] == "database_unavailable"


### PR DESCRIPTION
Implements **P4.6-AC4.a / FR62 (#203)**. New `GET /api/dashboard/envelope-authorship` endpoint that returns `{current, pending, history}` for the operator dashboard envelope-authorship pane.

API-only — no SPA changes. The SPA leaf (AC4.b/c/d) and its image-build pipeline dependency (#657) are tracked separately.

## Closes
Closes #203

## What changed

### `data_manager/db/repositories/envelope_repository.py`
- New `list_active_envelopes(key=None, limit=200)` — returns the highest-version envelope per `strategy_or_portfolio_key` via a Mongo sort+group aggregation. When `key` is supplied, the result is at most one element; otherwise one row per distinct key, capped at `limit`.

### `data_manager/db/repositories/pending_envelope_change_repository.py`
- New `list_decided(key, limit, cursor)` — returns decided (`accepted`/`rejected`) changes sorted descending by `resolution.decided_at`. Paginated via the previous page's last `decided_at` as exclusive cursor. Limit clamped to `[1, 200]`. Raises `ValueError` on malformed cursor → route maps to RFC-7807 400.

### `data_manager/api/routes/dashboard.py`
- New `GET /api/dashboard/envelope-authorship` composing the three buckets + `next_cursor` + `filters`.
- Optional `?key=` narrows all three buckets to one `strategy_or_portfolio_key`.
- Error mapping: `invalid_cursor=400`, `*_failed=500`, `database_unavailable=503` — all RFC-7807 problem JSON.

## Tests

`tests/unit/test_dashboard_envelope_authorship_api.py` — 8 unit tests:
- empty result
- three buckets populated (current + pending + history)
- `?key=` forwarded to all repo calls (no cross-bucket drift)
- history pagination returns `next_cursor`
- cursor round-trip (caller passes back to get older rows)
- bad cursor → 400 `invalid_cursor`
- `limit` clamped to 200
- 503 on Mongo unavailability

Full local suite: **951 passed**, 3 skipped.