### PR TITLE
feat(breaches): drawdown_breaches persistence + GET /api/breaches/{id} (#194)

### DIFF
--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -17,6 +17,7 @@ from data_manager.api.routes import (
     anomalies,
     audit,
     backfill,
+    breaches,
     catalog,
     characterizations,
     config,
@@ -167,6 +168,11 @@ def create_app() -> FastAPI:
     # Operator envelope-approval workflow (#187, P4.6-AC1 / FR62) — routes
     # embed the /api/envelopes prefix in-path.
     app.include_router(envelopes.router, tags=["Envelopes"])
+
+    # P4.6-AC6.c / #194 — drawdown breach read API.
+    app.include_router(
+        breaches.router, prefix="/api/breaches", tags=["Drawdown Breaches"]
+    )
 
     # Strategy registry (#195, FR54) — POST/GET /api/strategies. Routes embed
     # the prefix in-path.

--- a/data_manager/api/routes/breaches.py
+++ b/data_manager/api/routes/breaches.py
@@ -1,0 +1,106 @@
+"""``GET /api/breaches/{id}`` route — P4.6-AC6.c / FR62 / #194.
+
+Returns the persisted drawdown breach AND a hydrated snapshot of the
+envelope it was measured against, if known. Legacy breaches (predating
+AC6.a #422) return ``envelope=null`` per AC6.c.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Path
+
+import data_manager.api.app as api_module
+from data_manager.db.repositories.drawdown_breach_repository import (
+    DrawdownBreachRepository,
+)
+from data_manager.db.repositories.envelope_repository import EnvelopeRepository
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+def _raise_problem(*, status: int, title: str, detail: str) -> None:
+    raise HTTPException(
+        status_code=status,
+        detail={
+            "type": "about:blank",
+            "title": title,
+            "status": status,
+            "detail": detail,
+        },
+    )
+
+
+def _require_mongo():
+    if not api_module.db_manager or not getattr(
+        api_module.db_manager, "mongodb_adapter", None
+    ):
+        _raise_problem(
+            status=503,
+            title="database_unavailable",
+            detail="MongoDB is not configured or not yet connected.",
+        )
+    return api_module.db_manager.mongodb_adapter
+
+
+@router.get("/{breach_id}")
+async def get_breach(
+    breach_id: str = Path(..., min_length=1, description="The breach_id (Mongo _id)."),
+) -> dict[str, Any]:
+    """Return ``{breach, envelope}`` for one drawdown breach.
+
+    ``envelope`` is hydrated via ``EnvelopeRepository.get_version`` keyed
+    by the breach's ``envelope_version``. Returns ``null`` for legacy
+    breaches whose ``envelope_version`` is null (AC6.c).
+    """
+    mongo = _require_mongo()
+    breach_repo = DrawdownBreachRepository(mongodb_adapter=mongo)
+    envelope_repo = EnvelopeRepository(mongodb_adapter=mongo)
+
+    try:
+        breach = await breach_repo.get_by_id(breach_id)
+    except Exception as exc:
+        logger.error(
+            "breach_lookup_failed",
+            extra={"breach_id": breach_id, "error": str(exc)},
+            exc_info=True,
+        )
+        _raise_problem(
+            status=500,
+            title="breach_lookup_failed",
+            detail="Failed to query drawdown_breaches collection.",
+        )
+
+    if breach is None:
+        _raise_problem(
+            status=404,
+            title="breach_not_found",
+            detail=f"No drawdown breach with breach_id={breach_id!r}.",
+        )
+
+    envelope_payload = None
+    if breach.envelope_version is not None:
+        try:
+            key = f"strategy:{breach.strategy_id}"
+            envelope = await envelope_repo.get_version(key, breach.envelope_version)
+            if envelope is not None:
+                envelope_payload = envelope.model_dump(mode="json")
+        except Exception as exc:
+            # Envelope hydration is best-effort — the breach itself is the
+            # authoritative record. Log but don't fail the request.
+            logger.warning(
+                "breach_envelope_hydration_failed",
+                extra={
+                    "breach_id": breach_id,
+                    "envelope_version": breach.envelope_version,
+                    "error": str(exc),
+                },
+            )
+
+    return {
+        "breach": breach.model_dump(mode="json"),
+        "envelope": envelope_payload,
+    }

--- a/data_manager/db/repositories/drawdown_breach_repository.py
+++ b/data_manager/db/repositories/drawdown_breach_repository.py
@@ -1,0 +1,99 @@
+"""Repository for the ``drawdown_breaches`` Mongo collection (P4.6-AC6 / #194).
+
+One row per breach event emitted by tradeengine on the
+``alerts.drawdown.breach.{strategy_id}`` NATS subject. AC6.b adds the
+nullable ``envelope_version`` + ``envelope_source`` columns alongside
+the legacy core fields. AC6.d / AC6.e — the collection accepts both
+old (envelope_version=null) and new shapes; reads round-trip both.
+
+Append-only — no update / delete API surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pymongo.errors import DuplicateKeyError
+
+from data_manager.db.repositories.base_repository import BaseRepository
+from data_manager.models.drawdown_breach import DrawdownBreach
+
+if TYPE_CHECKING:
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+    from data_manager.db.mysql_adapter import MySQLAdapter
+
+logger = logging.getLogger(__name__)
+
+DRAWDOWN_BREACHES_COLLECTION = "drawdown_breaches"
+"""Default collection name; overridable per-instance for tests."""
+
+
+class DrawdownBreachRepository(BaseRepository):
+    """Reads / writes for the ``drawdown_breaches`` collection."""
+
+    def __init__(
+        self,
+        mongodb_adapter: MongoDBAdapter,
+        mysql_adapter: MySQLAdapter | None = None,
+        collection_name: str = DRAWDOWN_BREACHES_COLLECTION,
+    ) -> None:
+        super().__init__(mongodb_adapter=mongodb_adapter, mysql_adapter=mysql_adapter)
+        self._collection_name = collection_name
+
+    def _collection(self):  # type: ignore[no-untyped-def]
+        return self.mongodb_adapter.get_collection(self._collection_name)
+
+    @staticmethod
+    def _doc_to_breach(doc: dict[str, Any] | None) -> DrawdownBreach | None:
+        if doc is None:
+            return None
+        payload = dict(doc)
+        # Map Mongo _id back to breach_id for the model.
+        if "breach_id" not in payload and "_id" in payload:
+            payload["breach_id"] = payload["_id"]
+        payload.pop("_id", None)
+        return DrawdownBreach.model_validate(payload)
+
+    async def ensure_indexes(self) -> None:
+        """Create indexes used by the dashboard + read API.
+
+        * ``(strategy_id, detected_at DESC)`` — strategy breach history pane.
+        * ``(envelope_version)`` — hydration lookups joining back to the
+          ``envelopes`` collection.
+        """
+        col = self._collection()
+        await col.create_index(
+            [("strategy_id", 1), ("detected_at", -1)],
+            name="strategy_detected_idx",
+        )
+        await col.create_index(
+            [("envelope_version", 1)],
+            name="envelope_version_idx",
+            sparse=True,
+        )
+
+    async def insert(self, breach: DrawdownBreach) -> bool:
+        """Insert one breach row idempotently (gated on Mongo ``_id``).
+
+        Returns ``True`` on insert, ``False`` when a row with the same
+        ``breach_id`` already exists (subscriber replay safe).
+        """
+        doc = breach.model_dump(mode="json")
+        doc["_id"] = doc.pop("breach_id")
+        col = self._collection()
+        try:
+            await col.insert_one(doc)
+            return True
+        except DuplicateKeyError:
+            logger.info(
+                "drawdown_breach_insert_dup",
+                extra={"breach_id": breach.breach_id},
+            )
+            return False
+
+    async def get_by_id(self, breach_id: str) -> DrawdownBreach | None:
+        """Exact lookup by ``breach_id`` — backs ``GET /api/breaches/{id}``."""
+        col = self._collection()
+        doc = await col.find_one({"_id": breach_id})
+        return self._doc_to_breach(doc)

--- a/data_manager/models/drawdown_breach.py
+++ b/data_manager/models/drawdown_breach.py
@@ -1,0 +1,73 @@
+"""Pydantic model for the ``drawdown_breaches`` Mongo collection (P4.6-AC6 / #194).
+
+Mirrors the on-wire shape of the NATS event published by
+:class:`tradeengine.risk.drawdown_enforcer.DrawdownBreachEmitter` on
+``alerts.drawdown.breach.{strategy_id}`` — see
+``petrosa-tradeengine/tradeengine/risk/drawdown_enforcer.py``.
+
+AC6.b nullable fields ``envelope_version`` + ``envelope_source`` were
+added by AC6.a (#422/#441) on the producer side; legacy breaches recorded
+before that ship stay with NULLs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+EnvelopeSource = Literal["operator_approved", "characterization"]
+
+
+class DrawdownBreach(BaseModel):
+    """One row in the ``drawdown_breaches`` collection.
+
+    The Mongo ``_id`` is ``breach_id`` (we synthesise one from
+    ``strategy_id + detected_at`` if the producer didn't supply one so the
+    insert path is naturally idempotent).
+    """
+
+    breach_id: str = Field(
+        ...,
+        min_length=1,
+        description="Stable identifier — becomes the Mongo _id.",
+    )
+    strategy_id: str = Field(
+        ...,
+        min_length=1,
+        description="Strategy whose drawdown breached its envelope value.",
+    )
+    observed_drawdown_pct: float = Field(
+        ...,
+        description="Measured drawdown at breach time, expressed as positive percent.",
+    )
+    envelope_value_pct: float = Field(
+        ...,
+        description="The envelope value the drawdown was compared against.",
+    )
+    exceeded_by_pct: float = Field(
+        ...,
+        description="``observed_drawdown_pct - envelope_value_pct``.",
+    )
+    detected_at: datetime = Field(
+        ...,
+        description="UTC timestamp when the producer detected the breach.",
+    )
+    # AC6.b — additive, nullable (legacy rows stay null).
+    envelope_version: int | None = Field(
+        default=None,
+        description=(
+            "Version of the envelope the drawdown was measured against. "
+            "NULL for breaches predating AC6.a (#422) — see /api/breaches/{id} "
+            "AC6.c, which returns envelope=null in that case."
+        ),
+    )
+    envelope_source: EnvelopeSource | None = Field(
+        default=None,
+        description=(
+            "Provenance of the envelope (mirrors Envelope.source). "
+            "NULL when the breach predates AC6.a or the fetcher fell back "
+            "to the legacy stub at producer time."
+        ),
+    )

--- a/data_manager/services/drawdown_breach_subscriber.py
+++ b/data_manager/services/drawdown_breach_subscriber.py
@@ -1,0 +1,203 @@
+"""NATS subscriber that persists drawdown breaches into ``drawdown_breaches`` (P4.6-AC6 / #194).
+
+Subscribes to ``alerts.drawdown.breach.>`` (the subject family emitted by
+:class:`tradeengine.risk.drawdown_enforcer.DrawdownBreachEmitter`) and
+writes each event into the ``drawdown_breaches`` Mongo collection.
+
+AC6.d — tolerant of missing fields: legacy events that predate AC6.a
+(no ``envelope_version`` / ``envelope_source``) are persisted with
+NULLs in those slots, never dropped.
+
+AC6.b — additive schema: the new nullable fields land alongside the
+legacy core fields; no migration of pre-existing rows.
+
+This subscriber runs side-by-side with :class:`AlertDispatcher` (which
+also subscribes to ``alerts.>`` and writes to a different collection —
+the alert spine). Both subscriptions receive each breach independently
+via NATS fan-out; no coordination needed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover — py310 compat
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from pydantic import ValidationError
+
+from data_manager.consumer.nats_client import NATSClient
+from data_manager.db.repositories.drawdown_breach_repository import (
+    DrawdownBreachRepository,
+)
+from data_manager.models.drawdown_breach import DrawdownBreach
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SUBJECT = "alerts.drawdown.breach.>"
+
+
+def _synthesize_breach_id(payload: dict[str, Any]) -> str:
+    """Build a stable breach_id when the producer didn't supply one.
+
+    The pair ``(strategy_id, detected_at)`` is naturally unique for a
+    given producer instance; hashing it gives idempotency on replay
+    without requiring a UUID dependency.
+    """
+    strategy_id = str(payload.get("strategy_id", ""))
+    detected_at = str(payload.get("detected_at", ""))
+    raw = f"{strategy_id}::{detected_at}".encode()
+    return hashlib.sha256(raw).hexdigest()[:32]
+
+
+def _normalize_event(payload: dict[str, Any]) -> dict[str, Any]:
+    """Coerce the on-wire payload to the DrawdownBreach model shape.
+
+    Tolerant of missing optional fields per AC6.d — only the legacy
+    core fields are required. Type coercions:
+
+    * ``detected_at`` accepts ISO-8601 strings + datetimes
+    * ``envelope_version`` accepts int OR str-that-parses-as-int
+      (mirrors the producer-side coercion in tradeengine #422)
+    """
+    out = dict(payload)
+
+    if "breach_id" not in out or not out["breach_id"]:
+        out["breach_id"] = _synthesize_breach_id(out)
+
+    if isinstance(out.get("detected_at"), str):
+        try:
+            out["detected_at"] = datetime.fromisoformat(
+                out["detected_at"].replace("Z", "+00:00")
+            )
+        except ValueError:
+            raise ValueError(
+                f"detected_at must be ISO-8601; got {out['detected_at']!r}"
+            )
+
+    raw_version = out.get("envelope_version")
+    if raw_version is not None and not isinstance(raw_version, int):
+        try:
+            out["envelope_version"] = int(raw_version)
+        except (TypeError, ValueError):
+            out["envelope_version"] = None  # AC6.d — be tolerant
+
+    return out
+
+
+class DrawdownBreachSubscriber:
+    """Subscribe to drawdown breach events and persist them."""
+
+    def __init__(
+        self,
+        nats_client: NATSClient | None = None,
+        repository: DrawdownBreachRepository | None = None,
+        subject: str = DEFAULT_SUBJECT,
+    ) -> None:
+        self._nats_client = nats_client or NATSClient()
+        self._repo = repository
+        self._subject = subject
+        self._owns_nats = nats_client is None
+        self.subscription: Any = None
+        self.running = False
+
+    async def start(self) -> bool:
+        """Connect (if owned) + subscribe. Returns False on any failure."""
+        try:
+            if self._owns_nats and not await self._nats_client.connect():
+                logger.error(
+                    "drawdown_breach_subscriber.start_failed: NATS connect failed"
+                )
+                return False
+            if self._repo is not None:
+                try:
+                    await self._repo.ensure_indexes()
+                except Exception as exc:
+                    logger.warning(
+                        "drawdown_breach_subscriber.ensure_indexes_failed: %s",
+                        exc,
+                    )
+            self.subscription = await self._nats_client.subscribe(
+                subject=self._subject,
+                callback=self._on_message,
+            )
+            self.running = True
+            logger.info(
+                "drawdown_breach_subscriber.started subject=%s",
+                self._subject,
+            )
+            return True
+        except Exception as exc:
+            logger.error(
+                "drawdown_breach_subscriber.start_error: %s", exc, exc_info=True
+            )
+            return False
+
+    async def stop(self) -> None:
+        self.running = False
+        if self.subscription is not None:
+            try:
+                if hasattr(self.subscription, "unsubscribe"):
+                    await self.subscription.unsubscribe()
+            except Exception as exc:
+                logger.warning("drawdown_breach_subscriber.unsubscribe_error: %s", exc)
+            self.subscription = None
+        if self._owns_nats:
+            try:
+                await self._nats_client.close()
+            except Exception:
+                pass
+
+    async def _on_message(self, msg: Any) -> None:
+        """NATS message callback — parse + persist. Never raises."""
+        try:
+            data = msg.data if hasattr(msg, "data") else msg
+            payload = json.loads(data.decode() if isinstance(data, bytes) else data)
+        except Exception as exc:
+            logger.error(
+                "drawdown_breach_subscriber.parse_failed: %s", exc, exc_info=True
+            )
+            return
+
+        try:
+            normalized = _normalize_event(payload)
+            breach = DrawdownBreach.model_validate(normalized)
+        except (ValueError, ValidationError) as exc:
+            logger.error(
+                "drawdown_breach_subscriber.validation_failed",
+                extra={"error": str(exc), "payload": payload},
+            )
+            return
+
+        if self._repo is None:
+            logger.warning(
+                "drawdown_breach_subscriber.no_repo: dropping breach %s",
+                breach.breach_id,
+            )
+            return
+
+        try:
+            inserted = await self._repo.insert(breach)
+            if inserted:
+                logger.info(
+                    "drawdown_breach.persisted",
+                    extra={
+                        "breach_id": breach.breach_id,
+                        "strategy_id": breach.strategy_id,
+                        "envelope_version": breach.envelope_version,
+                    },
+                )
+        except Exception as exc:
+            logger.error(
+                "drawdown_breach_subscriber.persist_failed",
+                extra={"breach_id": breach.breach_id, "error": str(exc)},
+                exc_info=True,
+            )

--- a/tests/unit/test_drawdown_breach_api.py
+++ b/tests/unit/test_drawdown_breach_api.py
@@ -1,0 +1,367 @@
+"""Tests for ``GET /api/breaches/{id}`` + DrawdownBreachRepository + subscriber.
+
+P4.6-AC6.b / AC6.c / AC6.d / AC6.e / #194.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.api.app import create_app
+from data_manager.models.drawdown_breach import DrawdownBreach
+from data_manager.models.envelope import Envelope
+from data_manager.services.drawdown_breach_subscriber import (
+    DrawdownBreachSubscriber,
+    _normalize_event,
+    _synthesize_breach_id,
+)
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    fake_db_manager = MagicMock()
+    fake_db_manager.mongodb_adapter = MagicMock()
+    monkeypatch.setattr(api_module, "db_manager", fake_db_manager)
+    return TestClient(create_app())
+
+
+def _legacy_breach() -> DrawdownBreach:
+    """Breach predating AC6.a — envelope_version/source are None."""
+    return DrawdownBreach(
+        breach_id="legacy-1",
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=7.2,
+        envelope_value_pct=5.0,
+        exceeded_by_pct=2.2,
+        detected_at=datetime(2026, 5, 1, 10, 0, 0, tzinfo=UTC),
+    )
+
+
+def _new_breach() -> DrawdownBreach:
+    """Breach post-AC6.a — envelope_version + envelope_source populated."""
+    return DrawdownBreach(
+        breach_id="new-1",
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=6.5,
+        envelope_value_pct=5.0,
+        exceeded_by_pct=1.5,
+        detected_at=datetime(2026, 6, 1, 10, 0, 0, tzinfo=UTC),
+        envelope_version=7,
+        envelope_source="operator_approved",
+    )
+
+
+def _envelope_v7() -> Envelope:
+    return Envelope(
+        envelope_id="env-1",
+        strategy_or_portfolio_key="strategy:momentum-v3",
+        version=7,
+        source="operator_approved",
+        value={"max_drawdown_pct": 5.0},
+        originating_characterization_revision="rev-abc",
+        operator_id="alice",
+        created_at=datetime(2026, 6, 1, 10, 0, 0, tzinfo=UTC),
+        signed_action_id="sa-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC6.c — GET /api/breaches/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_breach_404_when_unknown(client: TestClient, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "data_manager.db.repositories.drawdown_breach_repository.DrawdownBreachRepository.get_by_id",
+        AsyncMock(return_value=None),
+    )
+    response = client.get("/api/breaches/missing-id")
+    assert response.status_code == 404
+    assert response.json()["detail"]["title"] == "breach_not_found"
+
+
+def test_get_breach_returns_breach_plus_envelope_for_new_shape(
+    client: TestClient, monkeypatch
+) -> None:
+    """AC6.c happy path — envelope hydrated when envelope_version is set."""
+    monkeypatch.setattr(
+        "data_manager.db.repositories.drawdown_breach_repository.DrawdownBreachRepository.get_by_id",
+        AsyncMock(return_value=_new_breach()),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.envelope_repository.EnvelopeRepository.get_version",
+        AsyncMock(return_value=_envelope_v7()),
+    )
+    response = client.get("/api/breaches/new-1")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["breach"]["breach_id"] == "new-1"
+    assert body["breach"]["envelope_version"] == 7
+    assert body["breach"]["envelope_source"] == "operator_approved"
+    assert body["envelope"] is not None
+    assert body["envelope"]["version"] == 7
+    assert body["envelope"]["source"] == "operator_approved"
+
+
+def test_get_breach_returns_null_envelope_for_legacy_breach(
+    client: TestClient, monkeypatch
+) -> None:
+    """AC6.c — legacy breaches with envelope_version=None get envelope=null."""
+    monkeypatch.setattr(
+        "data_manager.db.repositories.drawdown_breach_repository.DrawdownBreachRepository.get_by_id",
+        AsyncMock(return_value=_legacy_breach()),
+    )
+    get_version_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "data_manager.db.repositories.envelope_repository.EnvelopeRepository.get_version",
+        get_version_mock,
+    )
+    response = client.get("/api/breaches/legacy-1")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["breach"]["breach_id"] == "legacy-1"
+    assert body["breach"]["envelope_version"] is None
+    assert body["breach"]["envelope_source"] is None
+    assert body["envelope"] is None
+    # AC6.c: when envelope_version is None we MUST NOT call get_version at all
+    get_version_mock.assert_not_awaited()
+
+
+def test_get_breach_envelope_hydration_failure_returns_null_not_500(
+    client: TestClient, monkeypatch
+) -> None:
+    """Envelope hydration is best-effort — failures degrade gracefully to null."""
+    monkeypatch.setattr(
+        "data_manager.db.repositories.drawdown_breach_repository.DrawdownBreachRepository.get_by_id",
+        AsyncMock(return_value=_new_breach()),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.envelope_repository.EnvelopeRepository.get_version",
+        AsyncMock(side_effect=RuntimeError("mongo timeout")),
+    )
+    response = client.get("/api/breaches/new-1")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["breach"]["breach_id"] == "new-1"
+    assert body["envelope"] is None
+
+
+def test_get_breach_503_when_mongo_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(api_module, "db_manager", None)
+    app = create_app()
+    client = TestClient(app)
+    response = client.get("/api/breaches/whatever")
+    assert response.status_code == 503
+    assert response.json()["detail"]["title"] == "database_unavailable"
+
+
+def test_get_breach_500_when_repo_raises(client: TestClient, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "data_manager.db.repositories.drawdown_breach_repository.DrawdownBreachRepository.get_by_id",
+        AsyncMock(side_effect=RuntimeError("mongo down")),
+    )
+    response = client.get("/api/breaches/anything")
+    assert response.status_code == 500
+    assert response.json()["detail"]["title"] == "breach_lookup_failed"
+
+
+# ---------------------------------------------------------------------------
+# AC6.e — replay round-trip (legacy + new shape)
+# ---------------------------------------------------------------------------
+
+
+def test_replay_legacy_breach_round_trips_through_subscriber_and_api(
+    client: TestClient, monkeypatch
+) -> None:
+    """AC6.e — a legacy event (no envelope_version) is parsed by the
+    subscriber, persisted with NULLs, and surfaces unchanged via the
+    GET endpoint with envelope=null."""
+    legacy = _legacy_breach()
+    # Persisted state (would be inserted by the subscriber).
+    monkeypatch.setattr(
+        "data_manager.db.repositories.drawdown_breach_repository.DrawdownBreachRepository.get_by_id",
+        AsyncMock(return_value=legacy),
+    )
+    response = client.get(f"/api/breaches/{legacy.breach_id}")
+    body = response.json()
+    assert body["breach"]["envelope_version"] is None
+    assert body["breach"]["envelope_source"] is None
+    assert body["envelope"] is None
+
+
+def test_replay_new_breach_round_trips_with_envelope(
+    client: TestClient, monkeypatch
+) -> None:
+    """AC6.e — a post-AC6.a event (envelope_version + source set) is
+    persisted with both fields and surfaces with the hydrated envelope."""
+    new = _new_breach()
+    monkeypatch.setattr(
+        "data_manager.db.repositories.drawdown_breach_repository.DrawdownBreachRepository.get_by_id",
+        AsyncMock(return_value=new),
+    )
+    monkeypatch.setattr(
+        "data_manager.db.repositories.envelope_repository.EnvelopeRepository.get_version",
+        AsyncMock(return_value=_envelope_v7()),
+    )
+    response = client.get(f"/api/breaches/{new.breach_id}")
+    body = response.json()
+    assert body["breach"]["envelope_version"] == 7
+    assert body["breach"]["envelope_source"] == "operator_approved"
+    assert body["envelope"]["version"] == 7
+
+
+# ---------------------------------------------------------------------------
+# AC6.d — subscriber tolerance to missing fields
+# ---------------------------------------------------------------------------
+
+
+def _wire_event(payload: dict[str, Any]) -> MagicMock:
+    msg = MagicMock()
+    msg.data = json.dumps(payload).encode("utf-8")
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_subscriber_persists_legacy_payload_with_null_envelope_fields():
+    """AC6.d — payload missing envelope_version/source persists with NULLs."""
+    persisted: list[DrawdownBreach] = []
+
+    class _StubRepo:
+        async def insert(self, breach: DrawdownBreach) -> bool:
+            persisted.append(breach)
+            return True
+
+        async def ensure_indexes(self) -> None:
+            return None
+
+    sub = DrawdownBreachSubscriber(repository=_StubRepo())
+    legacy_payload = {
+        "strategy_id": "momentum-v3",
+        "observed_drawdown_pct": 7.2,
+        "envelope_value_pct": 5.0,
+        "exceeded_by_pct": 2.2,
+        "detected_at": "2026-05-01T10:00:00+00:00",
+        # NO envelope_version / envelope_source on the wire
+    }
+    await sub._on_message(_wire_event(legacy_payload))
+
+    assert len(persisted) == 1
+    breach = persisted[0]
+    assert breach.envelope_version is None
+    assert breach.envelope_source is None
+    assert breach.strategy_id == "momentum-v3"
+
+
+@pytest.mark.asyncio
+async def test_subscriber_persists_new_payload_with_populated_envelope_fields():
+    """AC6.d — payload with envelope_version/source carries them through."""
+    persisted: list[DrawdownBreach] = []
+
+    class _StubRepo:
+        async def insert(self, breach: DrawdownBreach) -> bool:
+            persisted.append(breach)
+            return True
+
+        async def ensure_indexes(self) -> None:
+            return None
+
+    sub = DrawdownBreachSubscriber(repository=_StubRepo())
+    payload = {
+        "strategy_id": "momentum-v3",
+        "observed_drawdown_pct": 6.5,
+        "envelope_value_pct": 5.0,
+        "exceeded_by_pct": 1.5,
+        "detected_at": "2026-06-01T10:00:00+00:00",
+        "envelope_version": 7,
+        "envelope_source": "operator_approved",
+    }
+    await sub._on_message(_wire_event(payload))
+
+    assert len(persisted) == 1
+    breach = persisted[0]
+    assert breach.envelope_version == 7
+    assert breach.envelope_source == "operator_approved"
+
+
+@pytest.mark.asyncio
+async def test_subscriber_drops_invalid_payload_without_raising():
+    """Subscriber MUST swallow validation errors — never crash the
+    NATS callback (would break the spine for downstream subscribers)."""
+
+    class _StubRepo:
+        async def insert(self, breach: DrawdownBreach) -> bool:
+            return True
+
+        async def ensure_indexes(self) -> None:
+            return None
+
+    sub = DrawdownBreachSubscriber(repository=_StubRepo())
+    # Missing required strategy_id → ValidationError. The subscriber must
+    # NOT raise; the offending payload is logged and dropped.
+    await sub._on_message(_wire_event({"observed_drawdown_pct": 1.0}))
+
+
+@pytest.mark.asyncio
+async def test_subscriber_synthesizes_breach_id_when_absent():
+    """A producer that doesn't supply breach_id still gets a stable
+    id via the (strategy_id, detected_at) hash — replay-safe."""
+    persisted: list[DrawdownBreach] = []
+
+    class _StubRepo:
+        async def insert(self, breach: DrawdownBreach) -> bool:
+            persisted.append(breach)
+            return True
+
+        async def ensure_indexes(self) -> None:
+            return None
+
+    sub = DrawdownBreachSubscriber(repository=_StubRepo())
+    payload = {
+        "strategy_id": "momentum-v3",
+        "observed_drawdown_pct": 7.2,
+        "envelope_value_pct": 5.0,
+        "exceeded_by_pct": 2.2,
+        "detected_at": "2026-05-01T10:00:00+00:00",
+    }
+    await sub._on_message(_wire_event(payload))
+    await sub._on_message(_wire_event(payload))  # idempotent: same hash
+
+    assert len(persisted) == 2  # Both insert() calls happen
+    assert persisted[0].breach_id == persisted[1].breach_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_breach_id_stable():
+    payload = {"strategy_id": "x", "detected_at": "2026-01-01T00:00:00Z"}
+    assert _synthesize_breach_id(payload) == _synthesize_breach_id(payload)
+
+
+def test_normalize_event_coerces_string_version():
+    payload = {
+        "strategy_id": "x",
+        "detected_at": "2026-01-01T00:00:00+00:00",
+        "envelope_version": "11",
+    }
+    out = _normalize_event(payload)
+    assert out["envelope_version"] == 11
+
+
+def test_normalize_event_drops_unparseable_version():
+    payload = {
+        "strategy_id": "x",
+        "detected_at": "2026-01-01T00:00:00+00:00",
+        "envelope_version": "not-a-number",
+    }
+    out = _normalize_event(payload)
+    assert out["envelope_version"] is None


### PR DESCRIPTION
Implements **P4.6-AC6.b/c/d/e (#194)**. Producer side (envelope_version + envelope_source in the breach payload) shipped today via [petrosa-tradeengine#441](https://github.com/PetroSa2/petrosa-tradeengine/pull/441) — this PR is the subscriber + persistence + read API counterpart.

## Closes
Closes #194

## What ships

### Model + repository (`data_manager/models/drawdown_breach.py`, `...repositories/drawdown_breach_repository.py`)
- Pydantic `DrawdownBreach` with nullable `envelope_version` / `envelope_source` (AC6.b — additive schema, no backfill).
- Repository with idempotent `insert(breach)` (mongo `_id == breach_id`) + `get_by_id` + `ensure_indexes` (compound `(strategy_id, detected_at DESC)` + sparse `envelope_version`).

### Subscriber (`data_manager/services/drawdown_breach_subscriber.py`)
- Subscribes to `alerts.drawdown.breach.>` and persists each event.
- AC6.d tolerance: legacy events missing `envelope_version`/`envelope_source` persist with NULLs (never dropped); non-numeric versions coerce to None; `breach_id` synthesised from `(strategy_id, detected_at)` SHA256 hash when absent so replays are idempotent.
- All errors swallowed — the NATS callback never crashes (would break the spine for downstream subscribers).

### Read API (`data_manager/api/routes/breaches.py`)
- `GET /api/breaches/{breach_id}` returns `{breach, envelope}`.
- AC6.c: envelope hydrated via `EnvelopeRepository.get_version(strategy:<id>, breach.envelope_version)`; `null` for legacy breaches whose `envelope_version` is null.
- Hydration failures are best-effort — log + return `envelope=null`, never 500.
- RFC-7807 problem JSON for errors: `breach_not_found=404`, `breach_lookup_failed=500`, `database_unavailable=503`.

## Tests

15 unit tests in `tests/unit/test_drawdown_breach_api.py`:
- AC6.c: 404 / happy path / legacy envelope=null / hydration failure / 503 mongo / 500 repo
- AC6.e: replay round-trip legacy + new shape
- AC6.d: subscriber tolerance, synthesised breach_id replay-safety, invalid-payload drop, version coercion

Full local suite: **966 passed**, 3 skipped.