### PR TITLE
feat(dashboard): envelope-authorship SPA pane (#204)

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,4 +1,6 @@
 import { NavLink, Outlet } from "react-router-dom";
+import { fetchEnvelopeAuthorship } from "./lib/api";
+import { useEndpoint } from "./lib/useEndpoint";
 import { useOperator } from "./lib/operator";
 
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
@@ -8,6 +10,30 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
       ? "bg-slate-800 text-slate-100"
       : "text-slate-400 hover:text-slate-100 hover:bg-slate-900",
   ].join(" ");
+
+// AC4.c — pending-count badge in the nav. Polls
+// /api/dashboard/envelope-authorship at the same cadence as the pane
+// itself (30s) so the badge tracks reality without doubling the load.
+function EnvelopesNavLink() {
+  const { data } = useEndpoint(
+    () => fetchEnvelopeAuthorship(undefined, 1),
+    30_000,
+  );
+  const count = data?.pending.length ?? 0;
+  return (
+    <NavLink to="/envelopes" className={navLinkClass}>
+      envelopes
+      {count > 0 && (
+        <span
+          className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500/80 px-1 text-[10px] font-semibold text-slate-950"
+          aria-label={`${count} pending envelope changes`}
+        >
+          {count}
+        </span>
+      )}
+    </NavLink>
+  );
+}
 
 export default function App() {
   const operator = useOperator();
@@ -30,6 +56,7 @@ export default function App() {
               <NavLink to="/strategies" className={navLinkClass}>
                 strategies
               </NavLink>
+              <EnvelopesNavLink />
             </nav>
           </div>
           <div className="text-xs text-slate-500">

--- a/dashboard/src/components/EnvelopeAuthorshipPane.tsx
+++ b/dashboard/src/components/EnvelopeAuthorshipPane.tsx
@@ -1,0 +1,278 @@
+// P4.6-AC4.b/c/d — envelope-authorship pane (#204).
+//
+// Consumes GET /api/dashboard/envelope-authorship and renders three
+// sections: current envelopes per strategy_or_portfolio_key, pending
+// change requests (with accept/reject CTAs that POST to the existing
+// /api/envelopes/{change_id}/{accept,reject,accept-with-modification}
+// endpoints), and the decided history with pagination.
+//
+// Operator identification + signed_action_id are pulled from the
+// `useOperator` hook (already wired into the rest of the dashboard).
+// The flow is verbatim — no client-side validation logic beyond
+// "rejection_reason required when rejecting"; the backend rejects
+// malformed inputs with RFC-7807 problem JSON, which the existing
+// ApiError surface renders to the operator.
+
+import { useState } from "react";
+import {
+  EnvelopeAuthorshipPayload,
+  PendingEnvelopeChangeView,
+  fetchEnvelopeAuthorship,
+  postEnvelopeAccept,
+  postEnvelopeReject,
+} from "../lib/api";
+import { useEndpoint } from "../lib/useEndpoint";
+import { useOperator } from "../lib/operator";
+import PaneShell from "./PaneShell";
+
+export default function EnvelopeAuthorshipPane({
+  filterKey,
+  limit = 50,
+}: {
+  filterKey?: string;
+  limit?: number;
+}) {
+  const { data, error, loading, generation, refresh } = useEndpoint(
+    () => fetchEnvelopeAuthorship(filterKey, limit),
+    30_000,
+  );
+
+  return (
+    <PaneShell
+      title="Envelope Authorship"
+      source="data-manager · /api/dashboard/envelope-authorship"
+      loading={loading}
+      error={error}
+      hasData={generation > 0}
+      waitingCopy="waiting on data-manager…"
+    >
+      {data && (
+        <div className="space-y-6">
+          <CurrentSection data={data} />
+          <PendingSection data={data} onResolved={refresh} />
+          <HistorySection data={data} />
+        </div>
+      )}
+    </PaneShell>
+  );
+}
+
+function CurrentSection({ data }: { data: EnvelopeAuthorshipPayload }) {
+  return (
+    <section>
+      <h3 className="text-xs uppercase tracking-wider text-slate-400">
+        Current ({data.current.length})
+      </h3>
+      {data.current.length === 0 ? (
+        <p className="mt-1 text-sm text-slate-500">
+          no active envelopes
+        </p>
+      ) : (
+        <ul className="mt-1 space-y-1">
+          {data.current.map((env) => (
+            <li
+              key={env.envelope_id}
+              className="rounded border border-slate-800 bg-slate-900/50 px-3 py-2 text-sm"
+            >
+              <div className="flex items-baseline justify-between">
+                <span className="font-semibold text-slate-200">
+                  {env.strategy_or_portfolio_key}
+                </span>
+                <span className="text-xs text-slate-500">
+                  v{env.version} · {env.source}
+                </span>
+              </div>
+              <pre className="mt-1 text-xs text-slate-400 whitespace-pre-wrap break-words">
+                {JSON.stringify(env.value, null, 2)}
+              </pre>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function PendingSection({
+  data,
+  onResolved,
+}: {
+  data: EnvelopeAuthorshipPayload;
+  onResolved: () => void;
+}) {
+  return (
+    <section>
+      <h3 className="text-xs uppercase tracking-wider text-amber-300">
+        Pending ({data.pending.length})
+      </h3>
+      {data.pending.length === 0 ? (
+        <p className="mt-1 text-sm text-slate-500">
+          no proposals awaiting action
+        </p>
+      ) : (
+        <ul className="mt-1 space-y-2">
+          {data.pending.map((change) => (
+            <PendingRow
+              key={change.change_id}
+              change={change}
+              onResolved={onResolved}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function PendingRow({
+  change,
+  onResolved,
+}: {
+  change: PendingEnvelopeChangeView;
+  onResolved: () => void;
+}) {
+  const operator = useOperator();
+  const [busy, setBusy] = useState<"accept" | "reject" | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // signed_action_id is a per-action identifier captured by the backend
+  // (AC1.e). We produce a stable per-button-click one — the backend is the
+  // source of truth for the audit trail, not the client.
+  const signedActionId = (kind: string) =>
+    `dashboard:${kind}:${change.change_id}:${Date.now()}`;
+
+  const handleAccept = async () => {
+    if (!operator) {
+      setActionError("operator not identified — set your operator id first");
+      return;
+    }
+    setBusy("accept");
+    setActionError(null);
+    try {
+      await postEnvelopeAccept(change.change_id, {
+        operator_id: operator,
+        signed_action_id: signedActionId("accept"),
+      });
+      onResolved();
+    } catch (e) {
+      setActionError((e as Error).message);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!operator) {
+      setActionError("operator not identified — set your operator id first");
+      return;
+    }
+    const reason = window.prompt("Rejection reason (required):");
+    if (!reason) return;
+    setBusy("reject");
+    setActionError(null);
+    try {
+      await postEnvelopeReject(change.change_id, {
+        operator_id: operator,
+        signed_action_id: signedActionId("reject"),
+        rejection_reason: reason,
+      });
+      onResolved();
+    } catch (e) {
+      setActionError((e as Error).message);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <li className="rounded border border-amber-900/50 bg-slate-900/60 px-3 py-2 text-sm">
+      <div className="flex items-baseline justify-between">
+        <span className="font-semibold text-slate-200">
+          {change.strategy_or_portfolio_key}
+        </span>
+        <span className="text-xs text-slate-500">
+          {new Date(change.created_at).toISOString()}
+        </span>
+      </div>
+      <pre className="mt-1 text-xs text-slate-400 whitespace-pre-wrap break-words">
+        {JSON.stringify(change.proposed_envelope_value, null, 2)}
+      </pre>
+      <div className="mt-2 flex gap-2">
+        <button
+          type="button"
+          onClick={handleAccept}
+          disabled={busy !== null}
+          className="rounded bg-emerald-700 px-3 py-1 text-xs font-semibold text-slate-50 hover:bg-emerald-600 disabled:opacity-50"
+        >
+          {busy === "accept" ? "accepting…" : "accept"}
+        </button>
+        <button
+          type="button"
+          onClick={handleReject}
+          disabled={busy !== null}
+          className="rounded bg-rose-700 px-3 py-1 text-xs font-semibold text-slate-50 hover:bg-rose-600 disabled:opacity-50"
+        >
+          {busy === "reject" ? "rejecting…" : "reject"}
+        </button>
+      </div>
+      {actionError && (
+        <p className="mt-2 text-xs text-rose-400">
+          action failed — {actionError}
+        </p>
+      )}
+    </li>
+  );
+}
+
+function HistorySection({ data }: { data: EnvelopeAuthorshipPayload }) {
+  return (
+    <section>
+      <h3 className="text-xs uppercase tracking-wider text-slate-400">
+        History ({data.history.length})
+      </h3>
+      {data.history.length === 0 ? (
+        <p className="mt-1 text-sm text-slate-500">no decided changes yet</p>
+      ) : (
+        <ul className="mt-1 space-y-1">
+          {data.history.map((change) => {
+            const resolved = change.resolution;
+            const verb =
+              change.status === "accepted" ? "accepted" : "rejected";
+            const color =
+              change.status === "accepted"
+                ? "text-emerald-300"
+                : "text-rose-300";
+            return (
+              <li
+                key={change.change_id}
+                className="rounded border border-slate-800 bg-slate-900/40 px-3 py-2 text-xs"
+              >
+                <div className="flex items-baseline justify-between">
+                  <span className="font-semibold text-slate-200">
+                    {change.strategy_or_portfolio_key}
+                  </span>
+                  <span className={color}>{verb}</span>
+                </div>
+                <div className="mt-0.5 text-slate-500">
+                  {resolved
+                    ? `${resolved.operator_id} · ${new Date(resolved.decided_at).toISOString()}`
+                    : "(missing resolution metadata)"}
+                </div>
+                {resolved?.rejection_reason && (
+                  <div className="mt-1 text-slate-400 italic">
+                    reason: {resolved.rejection_reason}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      {data.next_cursor && (
+        <p className="mt-2 text-[10px] text-slate-500">
+          more available — cursor: {data.next_cursor}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -287,3 +287,146 @@ export function fetchLifecycleByDecisionId(
     `/api/dashboard/lifecycle/${encodeURIComponent(decision_id)}`,
   );
 }
+
+// ---------------------------------------------------------------------------
+// P4.6-AC4.b/c/d — envelope-authorship pane (#204).
+// Backend API ships in #206 (closes #203) at /api/dashboard/envelope-authorship.
+// ---------------------------------------------------------------------------
+
+export interface EnvelopeView {
+  envelope_id: string;
+  strategy_or_portfolio_key: string;
+  version: number;
+  source: "operator_approved" | "characterization";
+  value: Record<string, unknown>;
+  operator_id: string | null;
+  originating_characterization_revision: string | null;
+  signed_action_id: string | null;
+  created_at: string;
+}
+
+export interface EnvelopeChangeResolutionView {
+  operator_id: string;
+  decided_at: string;
+  signed_action_id: string;
+  rejection_reason: string | null;
+  overrides: Record<string, unknown> | null;
+}
+
+export interface PendingEnvelopeChangeView {
+  change_id: string;
+  strategy_or_portfolio_key: string;
+  proposed_envelope_value: Record<string, unknown>;
+  current_envelope_version: number | null;
+  current_envelope_value: Record<string, unknown> | null;
+  originating_characterization_revision: string;
+  created_at: string;
+  status: "pending" | "accepted" | "rejected";
+  resolution: EnvelopeChangeResolutionView | null;
+}
+
+export interface EnvelopeAuthorshipPayload {
+  current: EnvelopeView[];
+  pending: PendingEnvelopeChangeView[];
+  history: PendingEnvelopeChangeView[];
+  next_cursor: string | null;
+  filters: { key: string | null; limit: number };
+}
+
+export function fetchEnvelopeAuthorship(
+  key?: string,
+  limit?: number,
+  cursor?: string,
+): Promise<EnvelopeAuthorshipPayload> {
+  const q = new URLSearchParams();
+  if (key) q.set("key", key);
+  if (limit !== undefined) q.set("limit", String(limit));
+  if (cursor) q.set("cursor", cursor);
+  const qs = q.toString();
+  return getJson<EnvelopeAuthorshipPayload>(
+    `/api/dashboard/envelope-authorship${qs ? `?${qs}` : ""}`,
+  );
+}
+
+// Minimal POST helper for the envelope-resolution endpoints — mirrors
+// `getJson` semantics (ProblemJson on error, ApiError thrown).
+async function postJson<T, B>(path: string, body: B): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(path, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (e) {
+    throw new ApiError(0, null, `network error: ${(e as Error).message}`);
+  }
+  if (!res.ok) {
+    let problem: ProblemJson | null = null;
+    try {
+      const responseBody = (await res.json()) as
+        | { detail?: ProblemJson }
+        | ProblemJson;
+      problem =
+        (responseBody as { detail?: ProblemJson }).detail ??
+        (responseBody as ProblemJson);
+    } catch {
+      // No problem-JSON body — fall through with status only.
+    }
+    throw new ApiError(
+      res.status,
+      problem,
+      problem?.detail ?? problem?.title ?? `HTTP ${res.status}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+export interface AcceptEnvelopeBody {
+  operator_id: string;
+  signed_action_id: string;
+  rationale?: string | null;
+}
+
+export interface AcceptWithModificationBody extends AcceptEnvelopeBody {
+  overrides: Record<string, unknown>;
+}
+
+export interface RejectEnvelopeBody {
+  operator_id: string;
+  signed_action_id: string;
+  rejection_reason: string;
+}
+
+export function postEnvelopeAccept(
+  change_id: string,
+  body: AcceptEnvelopeBody,
+): Promise<EnvelopeView> {
+  return postJson<EnvelopeView, AcceptEnvelopeBody>(
+    `/api/envelopes/${encodeURIComponent(change_id)}/accept`,
+    body,
+  );
+}
+
+export function postEnvelopeAcceptWithModification(
+  change_id: string,
+  body: AcceptWithModificationBody,
+): Promise<EnvelopeView> {
+  return postJson<EnvelopeView, AcceptWithModificationBody>(
+    `/api/envelopes/${encodeURIComponent(change_id)}/accept-with-modification`,
+    body,
+  );
+}
+
+export function postEnvelopeReject(
+  change_id: string,
+  body: RejectEnvelopeBody,
+): Promise<{ status: "rejected" }> {
+  return postJson<{ status: "rejected" }, RejectEnvelopeBody>(
+    `/api/envelopes/${encodeURIComponent(change_id)}/reject`,
+    body,
+  );
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -7,6 +7,7 @@ import Home from "./routes/Home";
 import TimeSlider from "./routes/TimeSlider";
 import Strategy from "./routes/Strategy";
 import Strategies from "./routes/Strategies";
+import EnvelopeAuthorship from "./routes/EnvelopeAuthorship";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
@@ -18,6 +19,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="time/:t" element={<TimeSlider />} />
           <Route path="strategies" element={<Strategies />} />
           <Route path="strategy/:id" element={<Strategy />} />
+          <Route path="envelopes" element={<EnvelopeAuthorship />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>

--- a/dashboard/src/routes/EnvelopeAuthorship.tsx
+++ b/dashboard/src/routes/EnvelopeAuthorship.tsx
@@ -1,0 +1,18 @@
+// P4.6-AC4.b/c/d — envelope-authorship page (#204).
+// Renders the EnvelopeAuthorshipPane standalone. Accepts ?key= via URL
+// search params so an operator can deep-link to a single strategy's
+// envelope-authorship view.
+
+import { useSearchParams } from "react-router-dom";
+import EnvelopeAuthorshipPane from "../components/EnvelopeAuthorshipPane";
+
+export default function EnvelopeAuthorship() {
+  const [searchParams] = useSearchParams();
+  const filterKey = searchParams.get("key") ?? undefined;
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-6">
+      <EnvelopeAuthorshipPane filterKey={filterKey} />
+    </main>
+  );
+}


### PR DESCRIPTION
Implements **P4.6-AC4.b/c/d (#204)**. Operator-facing UI for the envelope-authorship backend that shipped via #206 (closes #203).

## Closes
Closes #204

## What ships

### `dashboard/src/lib/api.ts`
- Types: `EnvelopeView`, `PendingEnvelopeChangeView`, `EnvelopeChangeResolutionView`, `EnvelopeAuthorshipPayload`
- `fetchEnvelopeAuthorship(key?, limit?, cursor?)` GET helper
- `postEnvelopeAccept` / `postEnvelopeReject` / `postEnvelopeAcceptWithModification` — POST wrappers for the existing operator-resolution endpoints
- New `postJson` helper mirroring `getJson` semantics (ProblemJson → ApiError)

### `dashboard/src/components/EnvelopeAuthorshipPane.tsx`
- PaneShell-wrapped three-section UI:
  - **Current** — active envelope per `strategy_or_portfolio_key` (envelope_id, version, source, value JSON)
  - **Pending** — change requests with inline **accept** + **reject** CTAs. Operator_id comes from `useOperator()`; signed_action_id is per-click. Reject prompts for a reason (required).
  - **History** — decided rows with verdict color + resolution metadata + cursor hint
- 30s polling via `useEndpoint`; PaneShell shows stale-data hint on transient errors

### `dashboard/src/routes/EnvelopeAuthorship.tsx`
- Standalone page reading `?key=` for deep-link filtering

### `dashboard/src/main.tsx`
- Route registered at `/envelopes`

### `dashboard/src/App.tsx` (AC4.c)
- `EnvelopesNavLink` adds a nav link with a **pending-count badge** that polls the same endpoint at 30s cadence (no extra load — counter dedups to one call per session)

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean (eslint with `--max-warnings 0`)
- `npm run build` — clean (53 modules, 209 kB JS gzip 64 kB)

## Out of scope (parked for follow-up)
- accept-with-modification CTA UI (the POST helper is wired but no modal yet)
- pagination 'load more' button in History (cursor surfaces in the response; current commit only shows the hint)