### PR TITLE
fix(773): remove COPY public from dashboard Dockerfile (restore image build)

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -10,7 +10,6 @@ COPY tsconfig.json tsconfig.node.json vite.config.ts ./
 COPY tailwind.config.js postcss.config.js .eslintrc.cjs ./
 COPY index.html ./
 COPY src ./src
-COPY public ./public
 
 RUN npm run build
 


### PR DESCRIPTION
## Summary

Closes PetroSa2/petrosa_k8s#773 — `petrosa-dashboard` pod in `ImagePullBackOff` for 10 days because `yurisa2/petrosa-dashboard` doesn't exist on Docker Hub at all. Every `build-and-push-dashboard` run has failed at the same step since the dashboard was first committed on 2026-05-22.

## Root cause

`dashboard/Dockerfile` line 13 was `COPY public ./public` but `dashboard/public/` has never existed in this repo. Today's run [`26767631501`](https://github.com/PetroSa2/petrosa-data-manager/actions/runs/26767631501) (triggered by PR #208's dashboard envelope SPA merge) failed at:

```
#17 [builder 9/10] COPY public ./public
#17 ERROR: failed to calculate checksum of ref ...: "/public": not found
ERROR: failed to build: failed to solve: failed to compute cache key: ... "/public": not found
```

This bug has been present since the initial Dockerfile commit on 2026-05-22 but was masked by upstream failures:

1. **#657** (closed by PR #164, 2026-05-22) wired `build-and-push-dashboard` into `deploy.yml` — but every run died upstream at `setup-qemu` because the jobs were on the ARC pool (no docker socket).
2. **#713** (closed by PR #192, 2026-05-29) moved both image-build jobs to `ubuntu-latest`, restoring QEMU/Buildx — but the `detect-changes.outputs.dashboard == 'true'` gate didn't fire on most subsequent merges, so the dashboard build path stayed cold.
3. PR #208 (envelope SPA, today 2026-06-01) finally tripped the path filter — and the dashboard build executed, **failed at the COPY**, never pushed the image. Docker Hub still returns `object not found` for `yurisa2/petrosa-dashboard`.

## Fix

One-line removal of the broken `COPY public ./public` directive. Vite tolerates a missing `public/` directory (it's purely the static-passthrough slot) — verified with a local `npm run build` in this branch:

```
$ npm run build
> tsc --noEmit && vite build
vite v5.4.21 building for production...
✓ 53 modules transformed.
dist/index.html                   0.57 kB
dist/assets/index-BcE995wY.css   15.77 kB
dist/assets/index-CEIcerh0.js   209.14 kB
✓ built in 787ms
```

`.dockerignore` does not exclude `public/`, so this is genuinely the file not existing — not a copy-context issue.

```diff
@@ dashboard/Dockerfile @@
 COPY index.html ./
 COPY src ./src
-COPY public ./public
 
 RUN npm run build
```

## Expected post-merge chain

1. `build-and-push-dashboard` succeeds (detect-changes will fire on this PR — Dockerfile touched).
2. `yurisa2/petrosa-dashboard:1.2.20-r<run>-<sha>` is pushed to Docker Hub for the first time ever.
3. `gitops-update-dashboard` rewrites `petrosa_k8s/k8s/dashboard/deployment.yaml` from `:latest` to the immutable version tag — satisfies AC3 of the ticket (no floating `:latest` for GitOps).
4. `apply-k8s-changes.yml` (auto-apply per `project_petrosa_k8s_gitops_auto_apply` memory) rolls the Deployment.
5. `petrosa-dashboard` pod in `petrosa-apps` transitions `ImagePullBackOff` → `Running` (1/1).

## Acceptance criteria (from #773)

- [x] `yurisa2/petrosa-dashboard` image for the referenced tag exists in the registry and is pullable by the cluster — **post-merge via CI push.**
- [x] `petrosa-dashboard` pod is `Running` (1/1) in `petrosa-apps` — **post-merge via GitOps auto-apply.**
- [x] Deployment references an immutable, CI-published tag (not floating `:latest`) — **`gitops-update-dashboard` rewrites `:latest` → SemVer tag automatically.**
- [x] Root cause vs. #657 documented — see "Root cause" above. **#657's CI wiring was correct; the Dockerfile itself had a never-existed `public/` reference. Independent bug from the runner regression #713 fixed.**

## Risk

Restorative; the dashboard hasn't worked since it was committed. No code paths outside `dashboard/Dockerfile` are touched. Local build verified.

## Operator note

This ticket was filed in `petrosa_k8s` (`PetroSa2/petrosa_k8s#773`) with labels `bug | priority:medium | service:data-manager | effort:small` — none of `governance|epic|cross-repo|infra`, so per the #658 ticket-filing convention it should have been filed in `petrosa-data-manager`. `impl_repo=PetroSa2/petrosa-data-manager` rescues execution. Flagged in the MemPalace pre-flight comment on the issue.
