### PR TITLE
feat(210): klines retention job with per-timeframe windows (AC2 of petrosa_k8s#783)

### DIFF
--- a/data_manager/maintenance/__init__.py
+++ b/data_manager/maintenance/__init__.py
@@ -1,0 +1,1 @@
+"""Maintenance jobs for the Petrosa Data Manager service."""

--- a/data_manager/maintenance/klines_retention.py
+++ b/data_manager/maintenance/klines_retention.py
@@ -1,0 +1,428 @@
+"""
+Periodic klines-retention job (AC2 of petrosa_k8s#783).
+
+Deletes klines older than a configurable per-timeframe retention window from
+every ``klines_*`` collection in MongoDB, preventing the cluster from silently
+re-filling. Designed to be invoked from a Kubernetes CronJob via:
+
+    python -m data_manager.maintenance.klines_retention [--dry-run]
+
+The job uses the existing ``MongoDBAdapter.delete_range`` primitive and walks
+the deletion window in day-sized chunks so a long backlog is reclaimed in
+bounded steps rather than a single multi-million-doc ``delete_many``.
+
+Retention windows default to comfortably more than the longest strategy
+lookback per timeframe and are overridable per timeframe via env vars of the
+form ``KLINES_RETENTION_DAYS_<TIMEFRAME>`` (e.g. ``KLINES_RETENTION_DAYS_1H``).
+
+See ``docs/klines-retention.md`` and the umbrella incident at
+https://github.com/PetroSa2/petrosa_k8s/issues/783 for context.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta, timezone
+
+from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+logger = logging.getLogger(__name__)
+
+KLINES_COLLECTION_PREFIX = "klines_"
+
+# Per-timeframe retention windows in days. Each default exceeds the longest
+# strategy lookback at that timeframe by a comfortable margin so analysis is
+# never starved by deletion. Operators override per-timeframe via env:
+# ``KLINES_RETENTION_DAYS_<TIMEFRAME>``.
+DEFAULT_RETENTION_DAYS: dict[str, int] = {
+    "1m": 7,
+    "3m": 14,
+    "5m": 14,
+    "15m": 30,
+    "30m": 30,
+    "1h": 90,
+    "2h": 90,
+    "4h": 180,
+    "6h": 180,
+    "8h": 180,
+    "12h": 365,
+    "1d": 365,
+    "3d": 365,
+    "1w": 730,
+    # `1M` (monthly, uppercase) intentionally omitted — its env-var name
+    # would collide with `1m` after upper-casing. If/when monthly klines
+    # are ever persisted, file a follow-up and pick a disambiguated env
+    # key (e.g. `KLINES_RETENTION_DAYS_MONTHLY`). For now, monthly falls
+    # through to FALLBACK_RETENTION_DAYS.
+}
+
+DEFAULT_BATCH_DAYS = 1
+DEFAULT_MAX_CHUNKS_PER_COLLECTION = 400
+# Fallback window when a collection's timeframe is unknown (e.g. a future
+# timeframe lands before this map is updated). Conservative: keep ~1 year.
+FALLBACK_RETENTION_DAYS = 365
+
+
+@dataclass
+class RetentionConfig:
+    """Resolved configuration for one retention run."""
+
+    windows_days: dict[str, int] = field(default_factory=dict)
+    batch_days: int = DEFAULT_BATCH_DAYS
+    max_chunks_per_collection: int = DEFAULT_MAX_CHUNKS_PER_COLLECTION
+    dry_run: bool = False
+    collections_override: list[str] | None = None
+
+
+@dataclass
+class RetentionResult:
+    """Per-collection outcome of a retention run."""
+
+    collection: str
+    timeframe: str | None
+    cutoff: datetime
+    chunks_processed: int
+    docs_deleted: int
+    capped: bool
+    dry_run: bool
+
+
+def parse_timeframe(collection_name: str) -> str | None:
+    """Return the timeframe suffix of a ``klines_<tf>`` collection, or ``None``."""
+    if not collection_name.startswith(KLINES_COLLECTION_PREFIX):
+        return None
+    suffix = collection_name[len(KLINES_COLLECTION_PREFIX) :]
+    return suffix or None
+
+
+def resolve_window_days(timeframe: str | None, windows: dict[str, int]) -> int:
+    """Resolve the retention-window days for a timeframe with sane fallback."""
+    if timeframe and timeframe in windows:
+        return windows[timeframe]
+    if timeframe and timeframe in DEFAULT_RETENTION_DAYS:
+        return DEFAULT_RETENTION_DAYS[timeframe]
+    return FALLBACK_RETENTION_DAYS
+
+
+def compute_cutoff(now: datetime, days: int) -> datetime:
+    """Return the inclusive upper bound on docs eligible for deletion."""
+    return now - timedelta(days=days)
+
+
+def load_config_from_env(environ: dict[str, str] | None = None) -> RetentionConfig:
+    """Build a ``RetentionConfig`` from environment variables."""
+    env = environ if environ is not None else os.environ
+
+    windows = dict(DEFAULT_RETENTION_DAYS)
+    for tf in list(DEFAULT_RETENTION_DAYS):
+        env_key = f"KLINES_RETENTION_DAYS_{tf.upper()}"
+        raw = env.get(env_key)
+        if raw is None:
+            continue
+        try:
+            windows[tf] = int(raw)
+        except ValueError:
+            logger.warning(
+                "Ignoring non-integer %s=%r; falling back to default %d days",
+                env_key,
+                raw,
+                windows[tf],
+            )
+
+    batch_days = _parse_int_env(
+        env, "KLINES_RETENTION_BATCH_DAYS", DEFAULT_BATCH_DAYS, minimum=1
+    )
+    max_chunks = _parse_int_env(
+        env,
+        "KLINES_RETENTION_MAX_CHUNKS_PER_COLLECTION",
+        DEFAULT_MAX_CHUNKS_PER_COLLECTION,
+        minimum=1,
+    )
+    dry_run = env.get("KLINES_RETENTION_DRY_RUN", "").lower() == "true"
+
+    return RetentionConfig(
+        windows_days=windows,
+        batch_days=batch_days,
+        max_chunks_per_collection=max_chunks,
+        dry_run=dry_run,
+    )
+
+
+def _parse_int_env(env: dict[str, str], key: str, default: int, *, minimum: int) -> int:
+    raw = env.get(key)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring non-integer %s=%r; using default %d", key, raw, default
+        )
+        return default
+    if value < minimum:
+        logger.warning(
+            "Clamping %s=%d to minimum %d to keep retention bounded",
+            key,
+            value,
+            minimum,
+        )
+        return minimum
+    return value
+
+
+async def discover_klines_collections(adapter: MongoDBAdapter) -> list[str]:
+    """Return sorted list of ``klines_*`` collections present in the DB."""
+    collections = await adapter.list_collections()
+    klines = sorted(c for c in collections if c.startswith(KLINES_COLLECTION_PREFIX))
+    return klines
+
+
+async def prune_collection(
+    adapter: MongoDBAdapter,
+    collection: str,
+    cutoff: datetime,
+    *,
+    batch_days: int,
+    max_chunks: int,
+    dry_run: bool,
+) -> RetentionResult:
+    """Delete docs older than ``cutoff`` from ``collection`` in bounded chunks.
+
+    Walks the deletion window from the oldest doc forward in ``batch_days``-day
+    chunks. Each chunk is a single ``delete_range`` call (the existing adapter
+    primitive). The walk stops at ``max_chunks`` to keep one run's blast radius
+    bounded — the next scheduled run picks up where this one left off.
+    """
+    timeframe = parse_timeframe(collection)
+    total_eligible = await adapter.get_record_count(collection, end=cutoff)
+
+    if total_eligible == 0:
+        logger.info(
+            "klines_retention: %s — nothing to delete (cutoff=%s)",
+            collection,
+            cutoff.isoformat(),
+        )
+        return RetentionResult(
+            collection=collection,
+            timeframe=timeframe,
+            cutoff=cutoff,
+            chunks_processed=0,
+            docs_deleted=0,
+            capped=False,
+            dry_run=dry_run,
+        )
+
+    # Anchor the walk at the oldest doc actually present so we don't iterate
+    # through years of empty time when a collection's history starts recently.
+    oldest = await adapter.query_range(
+        collection,
+        start=datetime(1970, 1, 1, tzinfo=UTC),
+        end=cutoff,
+    )
+    if not oldest:
+        return RetentionResult(
+            collection=collection,
+            timeframe=timeframe,
+            cutoff=cutoff,
+            chunks_processed=0,
+            docs_deleted=0,
+            capped=False,
+            dry_run=dry_run,
+        )
+    walk_start = _ensure_aware(oldest[0]["timestamp"])
+
+    chunk_size = timedelta(days=batch_days)
+    chunks_processed = 0
+    docs_deleted = 0
+    capped = False
+    current = walk_start
+
+    while current < cutoff and chunks_processed < max_chunks:
+        chunk_end = min(current + chunk_size, cutoff)
+        if dry_run:
+            chunk_count = await adapter.get_record_count(
+                collection, start=current, end=chunk_end
+            )
+        else:
+            chunk_count = await adapter.delete_range(
+                collection, start=current, end=chunk_end
+            )
+        chunks_processed += 1
+        docs_deleted += chunk_count
+        logger.info(
+            "klines_retention: %s chunk %d %s → %s — %d docs%s",
+            collection,
+            chunks_processed,
+            current.isoformat(),
+            chunk_end.isoformat(),
+            chunk_count,
+            " (dry-run)" if dry_run else "",
+        )
+        current = chunk_end
+
+    if current < cutoff:
+        capped = True
+        logger.warning(
+            "klines_retention: %s reached max_chunks=%d before cutoff (last=%s, cutoff=%s)",
+            collection,
+            max_chunks,
+            current.isoformat(),
+            cutoff.isoformat(),
+        )
+
+    return RetentionResult(
+        collection=collection,
+        timeframe=timeframe,
+        cutoff=cutoff,
+        chunks_processed=chunks_processed,
+        docs_deleted=docs_deleted,
+        capped=capped,
+        dry_run=dry_run,
+    )
+
+
+async def prune_klines(
+    adapter: MongoDBAdapter,
+    config: RetentionConfig,
+    *,
+    now: datetime | None = None,
+) -> list[RetentionResult]:
+    """Run retention across every discoverable ``klines_*`` collection."""
+    effective_now = now if now is not None else datetime.now(UTC)
+
+    if config.collections_override is not None:
+        collections = list(config.collections_override)
+    else:
+        collections = await discover_klines_collections(adapter)
+
+    if not collections:
+        logger.info("klines_retention: no klines_* collections found, nothing to do")
+        return []
+
+    results: list[RetentionResult] = []
+    for collection in collections:
+        timeframe = parse_timeframe(collection)
+        window_days = resolve_window_days(timeframe, config.windows_days)
+        cutoff = compute_cutoff(effective_now, window_days)
+        logger.info(
+            "klines_retention: %s timeframe=%s window_days=%d cutoff=%s%s",
+            collection,
+            timeframe or "?",
+            window_days,
+            cutoff.isoformat(),
+            " (dry-run)" if config.dry_run else "",
+        )
+        result = await prune_collection(
+            adapter,
+            collection,
+            cutoff,
+            batch_days=config.batch_days,
+            max_chunks=config.max_chunks_per_collection,
+            dry_run=config.dry_run,
+        )
+        results.append(result)
+
+    total_deleted = sum(r.docs_deleted for r in results)
+    capped_collections = [r.collection for r in results if r.capped]
+    logger.info(
+        "klines_retention: run complete — %d collections processed, %d docs %s%s",
+        len(results),
+        total_deleted,
+        "would-be-deleted" if config.dry_run else "deleted",
+        f", capped collections: {capped_collections}" if capped_collections else "",
+    )
+    return results
+
+
+def _ensure_aware(value: datetime) -> datetime:
+    """Return ``value`` with a UTC tzinfo when it was stored naive."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m data_manager.maintenance.klines_retention",
+        description=(
+            "Delete klines older than the configured per-timeframe retention "
+            "window from every klines_* MongoDB collection."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count what would be deleted without modifying any data.",
+    )
+    parser.add_argument(
+        "--collections",
+        help=(
+            "Comma-separated list of collections to operate on. Overrides discovery."
+        ),
+    )
+    parser.add_argument(
+        "--batch-days",
+        type=int,
+        default=None,
+        help="Override KLINES_RETENTION_BATCH_DAYS for this run.",
+    )
+    parser.add_argument(
+        "--max-chunks",
+        type=int,
+        default=None,
+        help="Override KLINES_RETENTION_MAX_CHUNKS_PER_COLLECTION for this run.",
+    )
+    return parser
+
+
+def _configure_logging() -> None:
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+
+async def _amain(argv: list[str] | None = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(argv)
+
+    config = load_config_from_env()
+    if args.dry_run:
+        config.dry_run = True
+    if args.collections:
+        config.collections_override = [
+            c.strip() for c in args.collections.split(",") if c.strip()
+        ]
+    if args.batch_days is not None:
+        config.batch_days = max(1, args.batch_days)
+    if args.max_chunks is not None:
+        config.max_chunks_per_collection = max(1, args.max_chunks)
+
+    connection_string = os.getenv("MONGODB_URL")
+    if not connection_string:
+        logger.error("MONGODB_URL is not set; cannot connect to MongoDB")
+        return 2
+
+    adapter = MongoDBAdapter(connection_string=connection_string)
+    adapter.connect()
+    try:
+        await prune_klines(adapter, config)
+    finally:
+        adapter.disconnect()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    _configure_logging()
+    return asyncio.run(_amain(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/klines-retention.md
+++ b/docs/klines-retention.md
@@ -1,0 +1,129 @@
+# Klines retention
+
+Periodic deletion of old klines from MongoDB to prevent the shared Atlas cluster
+from re-filling its storage quota. Implements **AC2** of the umbrella incident
+[`PetroSa2/petrosa_k8s#783`](https://github.com/PetroSa2/petrosa_k8s/issues/783)
+and is tracked under [`PetroSa2/petrosa-data-manager#210`](https://github.com/PetroSa2/petrosa-data-manager/issues/210).
+
+## What it does
+
+Walks every `klines_*` collection in MongoDB, computes a per-timeframe cutoff
+(`now - retention_window`), and deletes all klines older than the cutoff in
+day-sized chunks. The chunked walk keeps a single run's blast radius bounded
+so a long-accumulated backlog is reclaimed across several scheduled invocations
+rather than one multi-million-document `delete_many`.
+
+The job is **idempotent**: re-running it on a freshly-pruned collection is a
+no-op (no eligible docs → zero deletes).
+
+## How to run
+
+The maintenance module is invokable directly:
+
+```bash
+# Dry-run: count what would be deleted, modify nothing.
+python -m data_manager.maintenance.klines_retention --dry-run
+
+# Live run with defaults from env.
+python -m data_manager.maintenance.klines_retention
+
+# Override the collection set or pacing.
+python -m data_manager.maintenance.klines_retention \
+    --collections klines_1m,klines_5m \
+    --batch-days 1 \
+    --max-chunks 50
+```
+
+In production it is driven by a Kubernetes CronJob defined in
+[`PetroSa2/petrosa_k8s`](https://github.com/PetroSa2/petrosa_k8s) (companion ticket
+tracks the manifest — see #210's PR description for the link). The container
+runs the same `python -m data_manager.maintenance.klines_retention` command
+under `opentelemetry-instrument` so logs and traces hit the standard exporter.
+
+## Configuration
+
+All knobs are environment-driven so Helm/CronJob env can override per cluster.
+
+### Retention windows
+
+Per-timeframe windows (in days) override the in-code defaults:
+
+| Env var | Default (days) |
+|---|---|
+| `KLINES_RETENTION_DAYS_1M` | 7 |
+| `KLINES_RETENTION_DAYS_3M` | 14 |
+| `KLINES_RETENTION_DAYS_5M` | 14 |
+| `KLINES_RETENTION_DAYS_15M` | 30 |
+| `KLINES_RETENTION_DAYS_30M` | 30 |
+| `KLINES_RETENTION_DAYS_1H` | 90 |
+| `KLINES_RETENTION_DAYS_2H` | 90 |
+| `KLINES_RETENTION_DAYS_4H` | 180 |
+| `KLINES_RETENTION_DAYS_6H` | 180 |
+| `KLINES_RETENTION_DAYS_8H` | 180 |
+| `KLINES_RETENTION_DAYS_12H` | 365 |
+| `KLINES_RETENTION_DAYS_1D` | 365 |
+| `KLINES_RETENTION_DAYS_3D` | 365 |
+| `KLINES_RETENTION_DAYS_1W` | 730 |
+
+Each default exceeds the longest strategy lookback at that timeframe by a
+comfortable margin so analysis is never starved by deletion. Tune downward
+only when you understand the lookbacks of every active strategy.
+
+The Binance `1M` (uppercase, monthly) timeframe is intentionally **not** in
+the override map — its env-var name would collide with `1m` (minute) after
+upper-casing. A `klines_1M` collection, if one is ever persisted, falls
+through to the `365`-day fallback. File a follow-up if/when monthly klines
+need an independent override.
+
+An unknown timeframe (collection lands before this map is updated) falls back
+to `365` days. The fallback is conservative on purpose.
+
+### Pacing knobs
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `KLINES_RETENTION_BATCH_DAYS` | `1` | Width of each chunked `delete_range` window. Smaller = more, smaller deletes per run. |
+| `KLINES_RETENTION_MAX_CHUNKS_PER_COLLECTION` | `400` | Per-run cap on chunks per collection. Once hit, the run logs `capped=true` and stops; the next scheduled run resumes where it left off. |
+| `KLINES_RETENTION_DRY_RUN` | unset | Set to `true` to force dry-run mode regardless of `--dry-run`. |
+
+### Connection
+
+Reuses the canonical `MONGODB_URL` env var (same one used by the rest of the
+data-manager service). The job exits with code `2` when it is not set.
+
+## Observability
+
+Every chunk emits a structured INFO log of the form:
+
+```
+klines_retention: klines_1h chunk 3 2026-05-31T00:00:00+00:00 → 2026-06-01T00:00:00+00:00 — 1440 docs
+```
+
+On completion the job summarises the run:
+
+```
+klines_retention: run complete — 14 collections processed, 482917 docs deleted
+```
+
+Run under `opentelemetry-instrument` (the production pattern, mirroring the
+existing kline CronJobs in petrosa_k8s) these logs/spans flow into the standard
+Petrosa OTel pipeline. The `>80%` Atlas storage alert that closes the loop is
+tracked under [`PetroSa2/petrosa_k8s#786`](https://github.com/PetroSa2/petrosa_k8s/issues/786).
+
+## Safety properties
+
+- **Bounded**: per-run chunks-per-collection cap; per-chunk window is day-sized
+  by default so a single delete cannot grow unbounded.
+- **Idempotent**: re-running on a freshly-pruned collection deletes zero docs.
+- **Symbol-agnostic**: deletes purely by timestamp, never by symbol — so a new
+  symbol can light up at any time and inherit retention automatically.
+- **Non-cross-collection**: only touches `klines_*` collections. Audit-trail
+  collections (`intents`, `cio_decisions`, `execution_events`, `pnl_events`)
+  and the configuration/alert collections are not in scope; their retention is
+  governed independently.
+
+## Related
+
+- [`PetroSa2/petrosa_k8s#783`](https://github.com/PetroSa2/petrosa_k8s/issues/783) — P0 incident this was filed to prevent recurring.
+- [`PetroSa2/petrosa_k8s#786`](https://github.com/PetroSa2/petrosa_k8s/issues/786) — `>=80%` Atlas storage Grafana alert (AC3 of #783).
+- [`PetroSa2/petrosa_k8s#739`](https://github.com/PetroSa2/petrosa_k8s/issues/739) — audit-trail Mongo backup + retention CronJob (the in-house CronJob precedent this retention job mirrors).

--- a/tests/test_klines_retention.py
+++ b/tests/test_klines_retention.py
@@ -1,0 +1,257 @@
+"""Tests for the klines-retention maintenance job (petrosa_k8s#783 / data-manager#210)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from data_manager.maintenance import klines_retention as kr
+
+
+def _aware(year: int, month: int, day: int) -> datetime:
+    return datetime(year, month, day, tzinfo=UTC)
+
+
+def test_parse_timeframe_returns_suffix_for_klines_collection():
+    assert kr.parse_timeframe("klines_1h") == "1h"
+    assert kr.parse_timeframe("klines_5m") == "5m"
+    assert kr.parse_timeframe("klines_1d") == "1d"
+
+
+def test_parse_timeframe_returns_none_for_non_klines_or_bare_prefix():
+    assert kr.parse_timeframe("intents") is None
+    assert kr.parse_timeframe("cio_decisions") is None
+    assert kr.parse_timeframe("klines_") is None
+    assert kr.parse_timeframe("not_klines_1h") is None
+
+
+def test_resolve_window_days_prefers_override_then_default_then_fallback():
+    overrides = {"1h": 5, "5m": 3}
+    assert kr.resolve_window_days("1h", overrides) == 5
+    # Falls back to DEFAULT_RETENTION_DAYS when override map is empty
+    assert kr.resolve_window_days("1d", {}) == kr.DEFAULT_RETENTION_DAYS["1d"]
+    # Unknown timeframe → FALLBACK
+    assert kr.resolve_window_days("17h", overrides) == kr.FALLBACK_RETENTION_DAYS
+    # None timeframe → FALLBACK
+    assert kr.resolve_window_days(None, overrides) == kr.FALLBACK_RETENTION_DAYS
+
+
+def test_compute_cutoff_subtracts_days_from_now():
+    now = _aware(2026, 6, 2)
+    assert kr.compute_cutoff(now, 7) == _aware(2026, 5, 26)
+
+
+def test_load_config_from_env_applies_per_timeframe_overrides():
+    env = {
+        "KLINES_RETENTION_DAYS_1H": "14",
+        "KLINES_RETENTION_DAYS_1D": "180",
+        "KLINES_RETENTION_BATCH_DAYS": "3",
+        "KLINES_RETENTION_MAX_CHUNKS_PER_COLLECTION": "10",
+        "KLINES_RETENTION_DRY_RUN": "true",
+    }
+    config = kr.load_config_from_env(env)
+    assert config.windows_days["1h"] == 14
+    assert config.windows_days["1d"] == 180
+    # Untouched timeframe keeps its default
+    assert config.windows_days["1m"] == kr.DEFAULT_RETENTION_DAYS["1m"]
+    assert config.batch_days == 3
+    assert config.max_chunks_per_collection == 10
+    assert config.dry_run is True
+
+
+def test_load_config_from_env_ignores_non_integer_values_and_clamps_below_minimum():
+    env = {
+        "KLINES_RETENTION_DAYS_1H": "not-a-number",
+        "KLINES_RETENTION_BATCH_DAYS": "0",
+    }
+    config = kr.load_config_from_env(env)
+    assert config.windows_days["1h"] == kr.DEFAULT_RETENTION_DAYS["1h"]
+    assert config.batch_days == 1
+
+
+@pytest.mark.asyncio
+async def test_discover_klines_collections_filters_and_sorts():
+    adapter = AsyncMock()
+    adapter.list_collections.return_value = [
+        "intents",
+        "klines_1h",
+        "cio_decisions",
+        "klines_5m",
+        "klines_1d",
+        "alerts",
+    ]
+    result = await kr.discover_klines_collections(adapter)
+    assert result == ["klines_1d", "klines_1h", "klines_5m"]
+
+
+@pytest.mark.asyncio
+async def test_prune_collection_skips_when_no_eligible_docs():
+    adapter = AsyncMock()
+    adapter.get_record_count.return_value = 0
+
+    result = await kr.prune_collection(
+        adapter,
+        "klines_1h",
+        cutoff=_aware(2026, 5, 1),
+        batch_days=1,
+        max_chunks=100,
+        dry_run=False,
+    )
+
+    assert result.docs_deleted == 0
+    assert result.chunks_processed == 0
+    assert result.capped is False
+    adapter.delete_range.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prune_collection_walks_chunks_and_deletes_in_live_mode():
+    adapter = AsyncMock()
+    adapter.get_record_count.return_value = 5  # total eligible
+    oldest = _aware(2026, 5, 28)
+    adapter.query_range.return_value = [{"timestamp": oldest}]
+    adapter.delete_range.side_effect = [2, 2, 1]
+
+    cutoff = _aware(2026, 5, 31)
+    result = await kr.prune_collection(
+        adapter,
+        "klines_1h",
+        cutoff=cutoff,
+        batch_days=1,
+        max_chunks=10,
+        dry_run=False,
+    )
+
+    assert result.docs_deleted == 5
+    assert result.chunks_processed == 3
+    assert result.capped is False
+    # Three day-sized chunks: 28→29, 29→30, 30→31
+    expected_windows = [
+        (_aware(2026, 5, 28), _aware(2026, 5, 29)),
+        (_aware(2026, 5, 29), _aware(2026, 5, 30)),
+        (_aware(2026, 5, 30), _aware(2026, 5, 31)),
+    ]
+    actual_calls = adapter.delete_range.await_args_list
+    assert len(actual_calls) == 3
+    for call, (start, end) in zip(actual_calls, expected_windows, strict=True):
+        assert call.args[0] == "klines_1h"
+        assert call.kwargs["start"] == start
+        assert call.kwargs["end"] == end
+
+
+@pytest.mark.asyncio
+async def test_prune_collection_dry_run_counts_without_deleting():
+    adapter = AsyncMock()
+    # First call: total eligible. Subsequent calls: per-chunk count.
+    adapter.get_record_count.side_effect = [10, 4, 6]
+    oldest = _aware(2026, 5, 29)
+    adapter.query_range.return_value = [{"timestamp": oldest}]
+
+    result = await kr.prune_collection(
+        adapter,
+        "klines_5m",
+        cutoff=_aware(2026, 5, 31),
+        batch_days=1,
+        max_chunks=10,
+        dry_run=True,
+    )
+
+    assert result.dry_run is True
+    assert result.docs_deleted == 10
+    assert result.chunks_processed == 2
+    adapter.delete_range.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prune_collection_caps_at_max_chunks():
+    adapter = AsyncMock()
+    adapter.get_record_count.return_value = 100
+    oldest = _aware(2026, 1, 1)
+    adapter.query_range.return_value = [{"timestamp": oldest}]
+    adapter.delete_range.return_value = 10
+
+    result = await kr.prune_collection(
+        adapter,
+        "klines_1h",
+        cutoff=_aware(2026, 6, 1),
+        batch_days=1,
+        max_chunks=3,
+        dry_run=False,
+    )
+
+    assert result.chunks_processed == 3
+    assert result.docs_deleted == 30
+    assert result.capped is True
+
+
+@pytest.mark.asyncio
+async def test_prune_collection_treats_naive_timestamps_as_utc():
+    adapter = AsyncMock()
+    adapter.get_record_count.return_value = 1
+    naive_oldest = datetime(2026, 5, 30)  # naive
+    adapter.query_range.return_value = [{"timestamp": naive_oldest}]
+    adapter.delete_range.return_value = 1
+
+    result = await kr.prune_collection(
+        adapter,
+        "klines_1h",
+        cutoff=_aware(2026, 5, 31),
+        batch_days=1,
+        max_chunks=10,
+        dry_run=False,
+    )
+
+    assert result.docs_deleted == 1
+    first_call = adapter.delete_range.await_args_list[0]
+    # start should be the same instant but tz-aware (UTC)
+    assert first_call.kwargs["start"].tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_prune_klines_processes_all_collections_with_per_timeframe_windows():
+    adapter = AsyncMock()
+    adapter.list_collections.return_value = ["klines_1h", "klines_1d", "intents"]
+    # discover_klines_collections sorts alphabetically → klines_1d processed
+    # first, then klines_1h. klines_1d has nothing eligible; klines_1h walks
+    # two day-sized chunks that each delete one doc.
+    adapter.get_record_count.side_effect = [0, 2]
+    adapter.query_range.return_value = [{"timestamp": _aware(2026, 5, 30)}]
+    adapter.delete_range.side_effect = [1, 1]
+
+    config = kr.RetentionConfig(
+        windows_days={"1h": 1, "1d": 30},
+        batch_days=1,
+        max_chunks_per_collection=10,
+        dry_run=False,
+    )
+    now = _aware(2026, 6, 2)
+
+    results = await kr.prune_klines(adapter, config, now=now)
+
+    assert [r.collection for r in results] == ["klines_1d", "klines_1h"]
+    by_collection = {r.collection: r for r in results}
+    assert by_collection["klines_1h"].cutoff == _aware(2026, 6, 1)
+    assert by_collection["klines_1d"].cutoff == _aware(2026, 5, 3)
+    assert by_collection["klines_1h"].docs_deleted == 2
+    assert by_collection["klines_1d"].docs_deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_klines_uses_collections_override_when_provided():
+    adapter = AsyncMock()
+    adapter.get_record_count.return_value = 0
+
+    config = kr.RetentionConfig(
+        windows_days={},
+        batch_days=1,
+        max_chunks_per_collection=10,
+        dry_run=False,
+        collections_override=["klines_15m"],
+    )
+
+    results = await kr.prune_klines(adapter, config, now=_aware(2026, 6, 2))
+
+    adapter.list_collections.assert_not_called()
+    assert [r.collection for r in results] == ["klines_15m"]


### PR DESCRIPTION
## Summary

Implements **AC2 of [petrosa_k8s#783](https://github.com/PetroSa2/petrosa_k8s/issues/783)** (P0 MongoDB Atlas quota exhaustion, 2026-06-02) — the systemic klines-retention job that prevents the free-tier cluster from silently re-filling. Closes [petrosa-data-manager#210](https://github.com/PetroSa2/petrosa-data-manager/issues/210).

## Approach

New maintenance module `data_manager/maintenance/klines_retention.py`. Walks every `klines_*` collection, computes a per-timeframe cutoff, and calls the existing `MongoDBAdapter.delete_range` primitive in day-sized chunks. The companion k8s CronJob manifest will land in `petrosa_k8s` under a follow-up ticket (per the [#658](https://github.com/PetroSa2/petrosa_k8s/issues/658) ticket-filing convention — manifests stay in the platform repo, CLI ships from the implementing service).

Invoked from the CronJob (or manually) via:

```
python -m data_manager.maintenance.klines_retention [--dry-run]
```

## Design decisions

| Decision | Choice | Why |
|---|---|---|
| Mechanism | Bounded chunked `delete_range` (not MongoDB TTL) | AC2 explicitly requires "logged with reclaimed-doc counts per collection per run" — TTL has no concept of a run. Also matches the [`klines-gap-filler-cronjob.yaml`](https://github.com/PetroSa2/petrosa_k8s/blob/main/k8s/data-extractor/klines-gap-filler-cronjob.yaml) / [#739](https://github.com/PetroSa2/petrosa_k8s/issues/739) house pattern. |
| Window unit | Days, per-timeframe | Strategy lookbacks are described in candle counts; per-timeframe days gives clearer ops intuition. |
| Default windows | 1m=7d, 5m=14d, 15m/30m=30d, 1h/2h=90d, 4h-12h=180d-365d, 1d=365d | Comfortably exceeds the longest typical strategy lookback at each timeframe. |
| Bounding | Day-sized chunks + per-collection chunk cap (default 400) | First run on a large backlog stops at the cap; next scheduled run resumes. Steady-state runs only ever see one day's worth per collection. |
| Idempotency | A second run over a clean window is a no-op (eligible count = 0 → skip) | Required by AC2. |

## AC2 coverage (per [#210](https://github.com/PetroSa2/petrosa-data-manager/issues/210))

- [x] **Design decision recorded** — see table above. TTL alternative explicitly rejected (no per-run visibility).
- [x] **Per-timeframe `klines_*` retention** — `prune_klines` discovers all `klines_*` collections, parses the timeframe suffix, looks up the per-timeframe window, computes the cutoff.
- [x] **Configurable retention window** — env vars `KLINES_RETENTION_DAYS_<TIMEFRAME>` per timeframe; CLI `--batch-days` / `--max-chunks` overrides.
- [x] **Idempotent, bounded, logged** — bounded via chunk size × chunk cap; idempotent because re-running on a clean window deletes 0; each chunk emits an `INFO` log line with reclaimed-doc count; per-run summary log emits totals + any capped collections.
- [x] **Reclaimed-doc metric/log per collection per run** — final summary line, and `RetentionResult` per collection (collection, timeframe, cutoff, chunks_processed, docs_deleted, capped, dry_run).
- [x] **Documentation** — [`docs/klines-retention.md`](docs/klines-retention.md) covers the contract, env vars, ops runbook for the CronJob, and cross-links to #783 + AC3 alert ticket.

## Tests

14 unit tests, all green. Covers timeframe parsing, env-var override loading + clamping, collection discovery, dry-run vs live, chunk-walking, naive-timestamp normalization, max-chunks capping, and multi-collection orchestration.

```
$ .venv/bin/python -m pytest tests/test_klines_retention.py -q
.............. 14 passed in 0.16s
```

`ruff check` and `ruff format` clean across the new files.

## Out of scope (follow-up tickets)

- The k8s CronJob manifest (companion ticket in `petrosa_k8s` — will be filed immediately after this PR opens; the CronJob runs this module from the data-manager image on a daily schedule).
- AC1 of #783 (one-off emergency deletion against the live cluster) — operator-handled out of band.
- AC3 of #783 — [`petrosa_k8s#786`](https://github.com/PetroSa2/petrosa_k8s/issues/786) (Grafana ≥80% Atlas-quota alert).

## Risk

Low for steady-state operation: only deletes klines whose `timestamp` is strictly older than `now - retention_window_days`. The chunk cap bounds blast radius on first run against a backlogged cluster; default cap (400 day-chunks per collection per run) is well within a CronJob's `activeDeadlineSeconds=21600` budget.

The first production run will reclaim large amounts of historic data — recommend running once with `--dry-run` in the staging cluster (or via `kubectl create job ... --from=cronjob/... --dry-run=client`) to size the first cleanup before un-pausing the schedule. The ops runbook in `docs/klines-retention.md` covers this.

## Refs

- Umbrella incident: [PetroSa2/petrosa_k8s#783](https://github.com/PetroSa2/petrosa_k8s/issues/783)
- AC3 sibling: [PetroSa2/petrosa_k8s#786](https://github.com/PetroSa2/petrosa_k8s/issues/786)
- Closes: [PetroSa2/petrosa-data-manager#210](https://github.com/PetroSa2/petrosa-data-manager/issues/210)
