### PR TITLE
feat: read-only storage-inventory audit (data-manager half of petrosa_k8s#794)

### DIFF
--- a/data_manager/db/mongodb_adapter.py
+++ b/data_manager/db/mongodb_adapter.py
@@ -418,6 +418,140 @@ class MongoDBAdapter(BaseAdapter):
         except PyMongoError as e:
             raise DatabaseError(f"Failed to list collections: {e}") from e
 
+    # -------------------------------------------------------------------------
+    # Read-only introspection helpers (petrosa_k8s#794 storage-inventory audit)
+    #
+    # These methods issue ONLY MongoDB read commands (listDatabases, dbStats,
+    # collStats, list_collections with filter, find_one). They never write,
+    # update, drop, or otherwise mutate the cluster — and they accept an
+    # explicit `db_name` so the storage-inventory audit can iterate every
+    # database returned by `listDatabases`, not just the connected default.
+    # -------------------------------------------------------------------------
+
+    async def list_databases(self) -> list[dict[str, Any]]:
+        """Return every database the client can see via ``listDatabases``.
+
+        Includes ``local``/``admin``/``config`` system DBs because the audit
+        cares about oplog and system-DB storage too. Each entry has at least
+        ``name``, ``sizeOnDisk``, ``empty``.
+        """
+        if not self._connected:
+            raise DatabaseError("Not connected to database")
+
+        try:
+            result = await self.client.list_databases()
+            return list(result)
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to list databases: {e}") from e
+
+    async def db_stats(self, db_name: str) -> dict[str, Any]:
+        """Return ``dbStats`` for ``db_name``.
+
+        The verdict figure for Atlas-quota attribution is ``storageSize``
+        (compressed on-disk), NOT ``dataSize`` (logical). Both are returned
+        so callers can report each explicitly.
+        """
+        if not self._connected:
+            raise DatabaseError("Not connected to database")
+
+        try:
+            stats = await self.client[db_name].command("dbStats")
+            return dict(stats)
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to fetch dbStats for {db_name}: {e}") from e
+
+    async def coll_stats(self, db_name: str, collection: str) -> dict[str, Any]:
+        """Return ``collStats`` for one collection.
+
+        Falls back to a ``$collStats`` aggregation if the legacy ``collStats``
+        command is restricted by Atlas role — the aggregation surface has
+        broader cluster-monitor reach.
+        """
+        if not self._connected:
+            raise DatabaseError("Not connected to database")
+
+        target_db = self.client[db_name]
+        try:
+            stats = await target_db.command("collStats", collection)
+            return dict(stats)
+        except PyMongoError as exc:
+            try:
+                cursor = target_db[collection].aggregate(
+                    [{"$collStats": {"storageStats": {}}}]
+                )
+                docs = await cursor.to_list(length=1)
+                if docs:
+                    storage = dict(docs[0].get("storageStats", {}))
+                    storage["_via_aggregation"] = True
+                    return storage
+            except PyMongoError:
+                pass
+            raise DatabaseError(
+                f"Failed to fetch collStats for {db_name}.{collection}: {exc}"
+            ) from exc
+
+    async def is_timeseries(self, db_name: str, collection: str) -> bool:
+        """Return True when ``collection`` is a MongoDB time-series collection.
+
+        Time-series collections store their actual bytes in a hidden backing
+        ``system.buckets.<name>``; the audit must size BOTH the logical name
+        and the backing bucket or it under/over-counts ``klines_*``.
+        """
+        if not self._connected:
+            raise DatabaseError("Not connected to database")
+
+        try:
+            target_db = self.client[db_name]
+            spec = await target_db.list_collections(
+                filter={"name": collection}
+            ).to_list(length=1)
+        except PyMongoError as exc:
+            raise DatabaseError(
+                f"Failed to read collection spec for {db_name}.{collection}: {exc}"
+            ) from exc
+
+        if not spec:
+            return False
+        info = spec[0]
+        if info.get("type") == "timeseries":
+            return True
+        options = info.get("options") or {}
+        return "timeseries" in options
+
+    async def oplog_size(self) -> dict[str, Any]:
+        """Return ``collStats`` for ``local.oplog.rs`` (capped; invisible to the app)."""
+        if not self._connected:
+            raise DatabaseError("Not connected to database")
+        return await self.coll_stats("local", "oplog.rs")
+
+    async def newest_doc_age(self, db_name: str, collection: str) -> datetime | None:
+        """Best-effort newest-document timestamp across common time fields.
+
+        Tries ``timestamp``, ``time``, ``open_time``, ``created_at``, ``_id``
+        in order; returns the first hit or ``None`` if the collection is
+        empty / has no recognized time field.
+        """
+        if not self._connected:
+            raise DatabaseError("Not connected to database")
+
+        candidate_fields = ("timestamp", "time", "open_time", "created_at", "_id")
+        coll = self.client[db_name][collection]
+        for field in candidate_fields:
+            try:
+                doc = await coll.find_one(sort=[(field, -1)])
+            except PyMongoError:
+                continue
+            if not doc:
+                return None
+            value = doc.get(field)
+            if isinstance(value, datetime):
+                return value
+            if field == "_id" and value is not None:
+                generation = getattr(value, "generation_time", None)
+                if isinstance(generation, datetime):
+                    return generation
+        return None
+
     @staticmethod
     def _prepare_for_bson(doc: dict) -> dict:
         """

--- a/data_manager/db/mysql_adapter.py
+++ b/data_manager/db/mysql_adapter.py
@@ -551,3 +551,82 @@ class MySQLAdapter(BaseAdapter):
         if not self._connected:
             raise DatabaseError("Database is not connected")
         return self.engine
+
+
+# ---------------------------------------------------------------------------
+# Read-only introspection helpers (petrosa_k8s#794 storage-inventory audit)
+#
+# These module-level helpers DELIBERATELY bypass ``MySQLAdapter.connect()``
+# because that method runs ``_create_tables()`` → ``metadata.create_all`` —
+# DDL that would mutate the live schema before the audit issues its first
+# read. The storage-inventory module imports these directly and never calls
+# ``MySQLAdapter.connect()``; together with a ``SELECT``-only DB credential,
+# this is the two-layer read-only guarantee from petrosa_k8s#794 AC2/AC10.
+#
+# Excluded from `information_schema` enumeration: ``mysql``, ``information_schema``,
+# ``performance_schema``, ``sys`` — server-internal schemas the audit must not
+# touch.
+# ---------------------------------------------------------------------------
+
+_SYSTEM_SCHEMAS = frozenset(
+    {"mysql", "information_schema", "performance_schema", "sys"}
+)
+
+
+def create_read_only_engine(connection_string: str) -> "Engine":
+    """Build a bare SQLAlchemy engine that issues NO DDL on creation.
+
+    Unlike :meth:`MySQLAdapter.connect`, this helper does NOT call
+    ``_create_tables`` / ``metadata.create_all``. It only constructs the
+    engine. The caller is responsible for using a ``SELECT``-only DB
+    credential — that is the real safety guarantee; this function is the
+    code-level half (no DDL emitted by the data-manager codebase).
+    """
+    if not SQLALCHEMY_AVAILABLE:
+        raise ImportError(
+            "SQLAlchemy and MySQL driver required. "
+            "Install: pip install sqlalchemy pymysql"
+        )
+    return create_engine(
+        connection_string,
+        pool_pre_ping=True,
+        pool_size=2,
+        max_overflow=2,
+        pool_timeout=30,
+        connect_args={"charset": "utf8mb4", "autocommit": True},
+    )
+
+
+def list_schemas(engine: "Engine") -> list[str]:
+    """Return non-system schema names via ``information_schema.SCHEMATA``."""
+    stmt = sa.text(
+        "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA ORDER BY SCHEMA_NAME"
+    )
+    with engine.connect() as conn:
+        rows = conn.execute(stmt).fetchall()
+    return [r[0] for r in rows if r[0] not in _SYSTEM_SCHEMAS]
+
+
+def table_inventory(engine: "Engine", schema: str) -> list[dict[str, Any]]:
+    """Return per-table size info for ``schema`` via ``information_schema.TABLES``.
+
+    Each row carries ``TABLE_TYPE`` so callers can distinguish ``BASE TABLE``
+    from ``VIEW`` and avoid double-counting view bytes in storage totals
+    (petrosa_k8s#794 AC6). ``TABLE_ROWS`` is an InnoDB estimate — callers
+    should label it approximate; ``DATA_LENGTH``/``INDEX_LENGTH`` are the
+    storage verdict.
+    """
+    stmt = sa.text(
+        """
+        SELECT TABLE_NAME, TABLE_TYPE, TABLE_ROWS,
+               COALESCE(DATA_LENGTH, 0) AS DATA_LENGTH,
+               COALESCE(INDEX_LENGTH, 0) AS INDEX_LENGTH,
+               CREATE_TIME, UPDATE_TIME
+        FROM information_schema.TABLES
+        WHERE TABLE_SCHEMA = :schema
+        ORDER BY TABLE_NAME
+        """
+    )
+    with engine.connect() as conn:
+        rows = conn.execute(stmt, {"schema": schema}).mappings().fetchall()
+    return [dict(r) for r in rows]

--- a/data_manager/maintenance/storage_inventory.py
+++ b/data_manager/maintenance/storage_inventory.py
@@ -1,0 +1,844 @@
+"""
+Read-only storage-inventory audit (petrosa_k8s#794, leaf of #783).
+
+Enumerates every reachable MongoDB database + collection and every MySQL
+schema + table, attributing on-disk storage so the operator can root-cause
+the >400 MB residual after the manual klines cleanup that unblocked the P0
+storage incident.
+
+This module is **strictly read-only**. The guarantee is two layers:
+
+1. **Credential** (the real guarantee): the Job must connect with a
+   ``SELECT``-only MySQL user and a Mongo role limited to ``read`` +
+   ``listDatabases``/``clusterMonitor``. The module itself cannot enforce
+   this — only the operator provisioning the credential can.
+2. **Code-level**: this module issues ONLY ``listDatabases``/``dbStats``/
+   ``collStats``/``list_collections``/``find_one`` (Mongo) and
+   ``information_schema`` SELECTs (MySQL). It deliberately bypasses
+   :meth:`MySQLAdapter.connect` (which runs ``_create_tables`` DDL) by
+   using :func:`data_manager.db.mysql_adapter.create_read_only_engine`.
+
+Invocation::
+
+    python -m data_manager.maintenance.storage_inventory [--json]
+                                                          [--mongo-only]
+                                                          [--mysql-only]
+
+Exit codes (petrosa_k8s#794 AC7):
+
+* ``0``  — both backends OK (or the selected subset is OK)
+* ``10`` — Mongo backend failed
+* ``11`` — MySQL backend failed
+* ``12`` — both backends failed
+* ``13`` — privilege/permission denied on a required admin command
+
+See ``docs/storage-inventory.md`` for the operator runbook + report
+template, and ``_bmad-output/implementation-artifacts/tech-spec-storage-inventory-audit-mongo-mysql.md``
+for the full design rationale + adversarial-review notes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+
+from data_manager.db.mongodb_adapter import MongoDBAdapter
+from data_manager.db.mysql_adapter import (
+    create_read_only_engine,
+    list_schemas,
+    table_inventory,
+)
+
+logger = logging.getLogger(__name__)
+
+# Atlas/Mongo system DBs we report separately rather than treating as app data
+SYSTEM_DBS = frozenset({"admin", "local", "config"})
+
+# Time-series collection naming — the binance-data-extractor writes these
+# as MongoDB time-series collections, whose bytes live in a hidden
+# ``system.buckets.<name>``. The audit must size the backing bucket too.
+TIMESERIES_PREFIXES = ("klines_",)
+
+# Known writers map (from the tech-spec "Known store inventory" section,
+# 2026-06-03). Used to flag `orphan-suspect` stores (live with no known
+# writer) without ever auto-deleting. This is best-effort intelligence,
+# not a hard rule.
+KNOWN_MONGO_COLLECTIONS = frozenset(
+    {
+        # per-symbol/per-timeframe append-heavy
+        # (matched by prefix, see _is_known_mongo_collection)
+        # lifecycle/registry/config
+        "intents",
+        "cio_decisions",
+        "execution_events",
+        "pnl_events",
+        "signals",
+        "alerts",
+        "characterizations",
+        "characterization_artifacts",
+        "drawdown_breaches",
+        "envelopes",
+        "pending_envelope_changes",
+        "leverage_bounds",
+        "strategy_registry",
+        "schemas",
+        "app_config",
+        "app_config_audit",
+        "strategy_configs_global",
+        "strategy_configs_symbol",
+        "strategy_config_audit",
+        "strategy_lifecycle_events",
+        "trading_configs_global",
+        "trading_configs_symbol",
+        "trading_configs_symbol_side",
+        "trading_configs_audit",
+        "leverage_status",
+        "distributed_locks",
+        "leader_election",
+    }
+)
+
+KNOWN_MONGO_PREFIXES = (
+    "candles_",
+    "klines_",
+    "trades_",
+    "funding_",
+    "tickers_",
+    "depth_",
+    "system.buckets.",  # backing storage for time-series collections
+    "system.views",  # MongoDB metadata
+)
+
+KNOWN_MYSQL_TABLES = frozenset(
+    {
+        "positions",
+        "strategy_positions",
+        "exchange_positions",
+        "daily_pnl",
+        "signals",
+        "datasets",
+        "audit_logs",
+        "health_metrics",
+        "schemas",
+        "backfill_jobs",
+        "lineage_records",
+    }
+)
+
+KNOWN_MYSQL_PREFIXES = ("klines_",)
+
+
+# Exit codes (petrosa_k8s#794 AC7)
+EXIT_OK = 0
+EXIT_MONGO_FAILED = 10
+EXIT_MYSQL_FAILED = 11
+EXIT_BOTH_FAILED = 12
+EXIT_PRIVILEGE_DENIED = 13
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses for the structured report
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MongoCollectionStat:
+    db_name: str
+    name: str
+    is_timeseries: bool
+    storage_size: int  # on-disk compressed — the Atlas-quota figure
+    data_size: int  # logical
+    total_index_size: int
+    count: int
+    n_indexes: int
+    avg_obj_size: int
+    backing_bucket_storage_size: int | None  # only set for time-series
+    backing_bucket_data_size: int | None
+    newest_doc_age: str | None  # ISO-format timestamp or None
+    classification: str  # live | orphan-suspect | duplicated
+    error: str | None = None
+
+
+@dataclass
+class MongoDatabaseStat:
+    name: str
+    is_system: bool
+    storage_size: int  # dbStats.storageSize (on-disk)
+    data_size: int  # dbStats.dataSize (logical)
+    index_size: int  # dbStats.indexSize
+    collections: int
+    objects: int
+    collection_stats: list[MongoCollectionStat] = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass
+class MysqlTableStat:
+    schema: str
+    name: str
+    table_type: str  # 'BASE TABLE' or 'VIEW'
+    data_length: int
+    index_length: int
+    table_rows_estimated: int
+    create_time: str | None
+    update_time: str | None
+    classification: str  # live | orphan-suspect | duplicated
+
+
+@dataclass
+class MysqlSchemaStat:
+    name: str
+    tables: list[MysqlTableStat] = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass
+class StorageInventoryReport:
+    generated_at: str
+    mongo_ok: bool
+    mysql_ok: bool
+    mongo_error: str | None
+    mysql_error: str | None
+    mongo_databases: list[MongoDatabaseStat] = field(default_factory=list)
+    mongo_oplog: dict | None = None
+    mysql_schemas: list[MysqlSchemaStat] = field(default_factory=list)
+    # Pre-computed root-cause attribution (petrosa_k8s#794 AC3)
+    attribution: dict = field(default_factory=dict)
+    duplicated_candle_timeframes: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Classification helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_known_mongo_collection(name: str) -> bool:
+    if name in KNOWN_MONGO_COLLECTIONS:
+        return True
+    return any(name.startswith(p) for p in KNOWN_MONGO_PREFIXES)
+
+
+def _is_known_mysql_table(name: str) -> bool:
+    if name in KNOWN_MYSQL_TABLES:
+        return True
+    return any(name.startswith(p) for p in KNOWN_MYSQL_PREFIXES)
+
+
+def _classify_mongo(name: str, duplicated: bool) -> str:
+    if duplicated:
+        return "duplicated"
+    if _is_known_mongo_collection(name):
+        return "live"
+    return "orphan-suspect"
+
+
+def _classify_mysql(name: str, duplicated: bool) -> str:
+    if duplicated:
+        return "duplicated"
+    if _is_known_mysql_table(name):
+        return "live"
+    return "orphan-suspect"
+
+
+def _normalize_timeframe(name: str) -> str | None:
+    """Return a canonical timeframe label for cross-backend duplication checks.
+
+    ``klines_1m`` (Mongo time-series), ``candles_BTCUSDT_1m``, and MySQL
+    ``klines_m1`` should all map to ``1m`` so a timeframe present in
+    multiple backends/namings is flagged ``duplicated``.
+    """
+    if name.startswith("klines_"):
+        tf = name[len("klines_") :]
+        # MySQL klines_m1 / klines_h1 / klines_d1 → 1m / 1h / 1d
+        if tf and tf[0] in {"m", "h", "d"} and tf[1:].isdigit():
+            return f"{tf[1:]}{tf[0]}"
+        if tf:
+            return tf
+        return None
+    if name.startswith("candles_"):
+        parts = name.split("_")
+        if len(parts) >= 3:
+            return parts[-1]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Mongo audit
+# ---------------------------------------------------------------------------
+
+
+async def audit_mongo(
+    adapter: MongoDBAdapter,
+) -> tuple[list[MongoDatabaseStat], dict | None, str | None]:
+    """Walk every Mongo database and emit per-db / per-collection stats.
+
+    Returns ``(database_stats, oplog_stats, error)`` — ``error`` is non-None
+    when the top-level ``listDatabases`` call fails (driving exit-code
+    decisions in :func:`main`).
+    """
+    try:
+        dbs = await adapter.list_databases()
+    except Exception as exc:  # noqa: BLE001 — surface raw error to caller
+        logger.error("storage_inventory: listDatabases failed: %s", exc)
+        return [], None, str(exc)
+
+    out: list[MongoDatabaseStat] = []
+    for db_info in dbs:
+        name = db_info.get("name", "?")
+        is_system = name in SYSTEM_DBS
+        try:
+            stats = await adapter.db_stats(name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("storage_inventory: dbStats failed for %s: %s", name, exc)
+            out.append(
+                MongoDatabaseStat(
+                    name=name,
+                    is_system=is_system,
+                    storage_size=int(db_info.get("sizeOnDisk", 0) or 0),
+                    data_size=0,
+                    index_size=0,
+                    collections=0,
+                    objects=0,
+                    error=str(exc),
+                )
+            )
+            continue
+
+        db_stat = MongoDatabaseStat(
+            name=name,
+            is_system=is_system,
+            storage_size=int(stats.get("storageSize", 0) or 0),
+            data_size=int(stats.get("dataSize", 0) or 0),
+            index_size=int(stats.get("indexSize", 0) or 0),
+            collections=int(stats.get("collections", 0) or 0),
+            objects=int(stats.get("objects", 0) or 0),
+        )
+
+        # Enumerate collections. The system DBs intentionally surface
+        # `oplog.rs`-like collections here so their footprint is visible.
+        try:
+            target_db = adapter.client[name]
+            coll_names = await target_db.list_collection_names()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "storage_inventory: list_collection_names failed for %s: %s",
+                name,
+                exc,
+            )
+            db_stat.error = str(exc)
+            out.append(db_stat)
+            continue
+
+        for coll_name in sorted(coll_names):
+            stat = await _audit_mongo_collection(adapter, name, coll_name)
+            db_stat.collection_stats.append(stat)
+
+        out.append(db_stat)
+
+    try:
+        oplog = await adapter.oplog_size()
+    except Exception as exc:  # noqa: BLE001 — oplog is best-effort
+        logger.info("storage_inventory: oplog_size unavailable: %s", exc)
+        oplog = None
+
+    return out, oplog, None
+
+
+async def _audit_mongo_collection(
+    adapter: MongoDBAdapter, db_name: str, coll_name: str
+) -> MongoCollectionStat:
+    """Read ``collStats`` (+ TS bucket sizing + newest-doc age) for one collection."""
+    is_ts = False
+    try:
+        is_ts = await adapter.is_timeseries(db_name, coll_name)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "storage_inventory: is_timeseries failed for %s.%s: %s",
+            db_name,
+            coll_name,
+            exc,
+        )
+
+    try:
+        stats = await adapter.coll_stats(db_name, coll_name)
+    except Exception as exc:  # noqa: BLE001
+        return MongoCollectionStat(
+            db_name=db_name,
+            name=coll_name,
+            is_timeseries=is_ts,
+            storage_size=0,
+            data_size=0,
+            total_index_size=0,
+            count=0,
+            n_indexes=0,
+            avg_obj_size=0,
+            backing_bucket_storage_size=None,
+            backing_bucket_data_size=None,
+            newest_doc_age=None,
+            classification="error",
+            error=str(exc),
+        )
+
+    backing_storage = None
+    backing_data = None
+    if is_ts:
+        bucket_name = f"system.buckets.{coll_name}"
+        try:
+            bstats = await adapter.coll_stats(db_name, bucket_name)
+            backing_storage = int(bstats.get("storageSize", 0) or 0)
+            backing_data = int(bstats.get("size", 0) or 0)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "storage_inventory: backing bucket missing for %s.%s: %s",
+                db_name,
+                coll_name,
+                exc,
+            )
+
+    try:
+        newest_dt = await adapter.newest_doc_age(db_name, coll_name)
+    except Exception:  # noqa: BLE001
+        newest_dt = None
+
+    return MongoCollectionStat(
+        db_name=db_name,
+        name=coll_name,
+        is_timeseries=is_ts,
+        storage_size=int(stats.get("storageSize", 0) or 0),
+        data_size=int(stats.get("size", 0) or 0),
+        total_index_size=int(stats.get("totalIndexSize", 0) or 0),
+        count=int(stats.get("count", 0) or 0),
+        n_indexes=int(stats.get("nindexes", 0) or 0),
+        avg_obj_size=int(stats.get("avgObjSize", 0) or 0),
+        backing_bucket_storage_size=backing_storage,
+        backing_bucket_data_size=backing_data,
+        newest_doc_age=newest_dt.isoformat() if newest_dt else None,
+        classification="live",  # final classification assigned in _classify_all
+    )
+
+
+# ---------------------------------------------------------------------------
+# MySQL audit
+# ---------------------------------------------------------------------------
+
+
+def audit_mysql(connection_string: str) -> tuple[list[MysqlSchemaStat], str | None]:
+    """Enumerate every non-system MySQL schema and emit per-table size info."""
+    engine = None
+    try:
+        engine = create_read_only_engine(connection_string)
+        schemas = list_schemas(engine)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("storage_inventory: MySQL schema enumeration failed: %s", exc)
+        if engine is not None:
+            engine.dispose()
+        return [], str(exc)
+
+    out: list[MysqlSchemaStat] = []
+    for schema in schemas:
+        try:
+            rows = table_inventory(engine, schema)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "storage_inventory: table_inventory failed for %s: %s", schema, exc
+            )
+            out.append(MysqlSchemaStat(name=schema, error=str(exc)))
+            continue
+
+        schema_stat = MysqlSchemaStat(name=schema)
+        for row in rows:
+            schema_stat.tables.append(
+                MysqlTableStat(
+                    schema=schema,
+                    name=row["TABLE_NAME"],
+                    table_type=row.get("TABLE_TYPE") or "BASE TABLE",
+                    data_length=int(row.get("DATA_LENGTH") or 0),
+                    index_length=int(row.get("INDEX_LENGTH") or 0),
+                    table_rows_estimated=int(row.get("TABLE_ROWS") or 0),
+                    create_time=_isoformat_or_none(row.get("CREATE_TIME")),
+                    update_time=_isoformat_or_none(row.get("UPDATE_TIME")),
+                    classification="live",  # final classification assigned later
+                )
+            )
+        out.append(schema_stat)
+
+    engine.dispose()
+    return out, None
+
+
+def _isoformat_or_none(value: object) -> str | None:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cross-backend classification + attribution
+# ---------------------------------------------------------------------------
+
+
+def _classify_all(report: StorageInventoryReport) -> None:
+    """Mutate the report in-place to set classification + duplication flags.
+
+    Cross-backend duplication: a candle/kline timeframe is `duplicated` when
+    the same canonical timeframe is present in more than one backend (Mongo
+    `klines_*`, MySQL `klines_*`, Mongo `candles_*`).
+    """
+    mongo_timeframes: set[str] = set()
+    mysql_timeframes: set[str] = set()
+
+    for db in report.mongo_databases:
+        for c in db.collection_stats:
+            tf = _normalize_timeframe(c.name)
+            if tf:
+                mongo_timeframes.add(tf)
+
+    for schema in report.mysql_schemas:
+        for t in schema.tables:
+            if t.table_type == "VIEW":
+                continue
+            tf = _normalize_timeframe(t.name)
+            if tf:
+                mysql_timeframes.add(tf)
+
+    duplicated = mongo_timeframes & mysql_timeframes
+    report.duplicated_candle_timeframes = sorted(duplicated)
+
+    for db in report.mongo_databases:
+        for c in db.collection_stats:
+            tf = _normalize_timeframe(c.name)
+            is_dup = bool(tf and tf in duplicated)
+            # System collections inside system DBs are not orphan-suspects
+            if db.is_system:
+                c.classification = "system"
+            elif c.classification == "error":
+                pass
+            else:
+                c.classification = _classify_mongo(c.name, is_dup)
+
+    for schema in report.mysql_schemas:
+        for t in schema.tables:
+            tf = _normalize_timeframe(t.name)
+            is_dup = bool(tf and tf in duplicated)
+            if t.table_type == "VIEW":
+                t.classification = "view"
+            else:
+                t.classification = _classify_mysql(t.name, is_dup)
+
+
+def _attribute_400mb(report: StorageInventoryReport) -> None:
+    """Aggregate on-disk storage by category for the >400 MB attribution.
+
+    Categories (petrosa_k8s#794 AC3):
+    - candles_*: per-symbol/per-timeframe Mongo collections (data-manager write path)
+    - klines_logical: logical TS collection sizes
+    - klines_buckets: backing system.buckets.klines_* (the real klines bytes)
+    - other_app: app collections that are neither candle/kline nor system
+    - oplog: local.oplog.rs
+    - system_dbs: local + admin + config (excluding oplog double-counting)
+    - mysql_klines: MySQL klines_* tables (excluding VIEWs)
+    - mysql_other: MySQL non-klines base tables
+    """
+    candles = klines_logical = klines_buckets = other_app = 0
+    system_dbs = 0
+    oplog = int((report.mongo_oplog or {}).get("storageSize", 0) or 0)
+
+    for db in report.mongo_databases:
+        for c in db.collection_stats:
+            if db.is_system:
+                # local DB includes oplog.rs — but we report oplog separately
+                if not (db.name == "local" and c.name == "oplog.rs"):
+                    system_dbs += c.storage_size
+                continue
+            if c.name.startswith("candles_"):
+                candles += c.storage_size
+            elif c.name.startswith("klines_"):
+                klines_logical += c.storage_size
+                if c.backing_bucket_storage_size:
+                    klines_buckets += c.backing_bucket_storage_size
+            elif c.name.startswith("system.buckets.klines_"):
+                klines_buckets += c.storage_size
+            else:
+                other_app += c.storage_size
+
+    mysql_klines = 0
+    mysql_other = 0
+    for schema in report.mysql_schemas:
+        for t in schema.tables:
+            if t.table_type == "VIEW":
+                continue
+            total = t.data_length + t.index_length
+            if t.name.startswith("klines_"):
+                mysql_klines += total
+            else:
+                mysql_other += total
+
+    report.attribution = {
+        "mongo_candles_bytes": candles,
+        "mongo_klines_logical_bytes": klines_logical,
+        "mongo_klines_buckets_bytes": klines_buckets,
+        "mongo_other_app_bytes": other_app,
+        "mongo_oplog_bytes": oplog,
+        "mongo_system_dbs_bytes": system_dbs,
+        "mysql_klines_bytes": mysql_klines,
+        "mysql_other_bytes": mysql_other,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(report: StorageInventoryReport) -> str:
+    """Render a human-readable markdown summary of the audit."""
+    lines: list[str] = []
+    lines.append("# Storage Inventory Audit Report")
+    lines.append("")
+    lines.append(f"Generated: `{report.generated_at}`")
+    lines.append("")
+    lines.append(f"- Mongo backend: {'OK' if report.mongo_ok else 'FAILED'}")
+    if report.mongo_error:
+        lines.append(f"  - error: `{report.mongo_error}`")
+    lines.append(f"- MySQL backend: {'OK' if report.mysql_ok else 'FAILED'}")
+    if report.mysql_error:
+        lines.append(f"  - error: `{report.mysql_error}`")
+    lines.append("")
+
+    if report.attribution:
+        lines.append("## 400 MB Attribution (on-disk storageSize bytes)")
+        lines.append("")
+        lines.append("| Category | Bytes |")
+        lines.append("| --- | ---: |")
+        for k, v in report.attribution.items():
+            lines.append(f"| `{k}` | `{v:,}` |")
+        lines.append("")
+
+    if report.duplicated_candle_timeframes:
+        lines.append("## Duplicated candle timeframes (Mongo + MySQL)")
+        lines.append("")
+        for tf in report.duplicated_candle_timeframes:
+            lines.append(f"- `{tf}`")
+        lines.append("")
+
+    if report.mongo_databases:
+        lines.append("## MongoDB databases")
+        lines.append("")
+        for db in report.mongo_databases:
+            lines.append(
+                f"### `{db.name}` ({'system' if db.is_system else 'app'}) "
+                f"— storageSize={db.storage_size:,} dataSize={db.data_size:,} "
+                f"indexSize={db.index_size:,} collections={db.collections}"
+            )
+            if db.error:
+                lines.append(f"_error_: `{db.error}`")
+                lines.append("")
+                continue
+            lines.append("")
+            lines.append(
+                "| Collection | TS | storageSize | dataSize | indexSize | count | class |"
+            )
+            lines.append("| --- | --- | ---: | ---: | ---: | ---: | --- |")
+            for c in db.collection_stats:
+                tsmark = "TS" if c.is_timeseries else ""
+                lines.append(
+                    f"| `{c.name}` | {tsmark} | {c.storage_size:,} | {c.data_size:,} "
+                    f"| {c.total_index_size:,} | {c.count:,} | {c.classification} |"
+                )
+            lines.append("")
+
+    if report.mongo_oplog:
+        lines.append(
+            "## Oplog (`local.oplog.rs`) — "
+            f"storageSize={report.mongo_oplog.get('storageSize', 0):,} "
+            f"size={report.mongo_oplog.get('size', 0):,}"
+        )
+        lines.append("")
+
+    if report.mysql_schemas:
+        lines.append("## MySQL schemas")
+        lines.append("")
+        for schema in report.mysql_schemas:
+            base_tables = [t for t in schema.tables if t.table_type != "VIEW"]
+            views = [t for t in schema.tables if t.table_type == "VIEW"]
+            base_total = sum(t.data_length + t.index_length for t in base_tables)
+            lines.append(
+                f"### `{schema.name}` — base-table bytes={base_total:,} "
+                f"({len(base_tables)} tables / {len(views)} views)"
+            )
+            if schema.error:
+                lines.append(f"_error_: `{schema.error}`")
+                lines.append("")
+                continue
+            lines.append("")
+            lines.append(
+                "| Table | Type | DATA_LENGTH | INDEX_LENGTH | rows~ | class |"
+            )
+            lines.append("| --- | --- | ---: | ---: | ---: | --- |")
+            for t in schema.tables:
+                lines.append(
+                    f"| `{t.name}` | {t.table_type} | {t.data_length:,} "
+                    f"| {t.index_length:,} | {t.table_rows_estimated:,} "
+                    f"| {t.classification} |"
+                )
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def report_to_dict(report: StorageInventoryReport) -> dict:
+    """Convert the dataclass tree to a JSON-serializable dict."""
+    return asdict(report)
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m data_manager.maintenance.storage_inventory",
+        description=(
+            "Read-only audit of MongoDB + MySQL storage. Emits a markdown "
+            "report + JSON blob to stdout. NEVER writes to either backend."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON to stdout (in addition to markdown).",
+    )
+    parser.add_argument(
+        "--mongo-only",
+        action="store_true",
+        help="Skip MySQL inventory.",
+    )
+    parser.add_argument(
+        "--mysql-only",
+        action="store_true",
+        help="Skip MongoDB inventory.",
+    )
+    return parser
+
+
+def _configure_logging() -> None:
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+
+def _is_privilege_error(error: str | None) -> bool:
+    if not error:
+        return False
+    lower = error.lower()
+    return any(
+        token in lower
+        for token in (
+            "not authorized",
+            "permission denied",
+            "access denied",
+            "unauthorized",
+        )
+    )
+
+
+async def _amain(argv: Iterable[str] | None = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.mongo_only and args.mysql_only:
+        logger.error("--mongo-only and --mysql-only are mutually exclusive")
+        return 2
+
+    run_mongo = not args.mysql_only
+    run_mysql = not args.mongo_only
+
+    mongo_url = os.getenv("MONGODB_URL")
+    mysql_uri = os.getenv("MYSQL_URI")
+
+    report = StorageInventoryReport(
+        generated_at=datetime.utcnow().isoformat() + "Z",
+        mongo_ok=False,
+        mysql_ok=False,
+        mongo_error=None,
+        mysql_error=None,
+    )
+
+    if run_mongo:
+        if not mongo_url:
+            report.mongo_error = "MONGODB_URL not set"
+        else:
+            adapter = MongoDBAdapter(connection_string=mongo_url)
+            adapter.connect()
+            try:
+                dbs, oplog, err = await audit_mongo(adapter)
+                report.mongo_databases = dbs
+                report.mongo_oplog = oplog
+                report.mongo_error = err
+                report.mongo_ok = err is None
+            finally:
+                adapter.disconnect()
+
+    if run_mysql:
+        if not mysql_uri:
+            report.mysql_error = "MYSQL_URI not set"
+        else:
+            schemas, err = audit_mysql(mysql_uri)
+            report.mysql_schemas = schemas
+            report.mysql_error = err
+            report.mysql_ok = err is None
+
+    _classify_all(report)
+    _attribute_400mb(report)
+
+    print(render_markdown(report))
+    if args.json:
+        print("```json")
+        print(json.dumps(report_to_dict(report), indent=2, default=str))
+        print("```")
+
+    return _compute_exit_code(report, run_mongo, run_mysql)
+
+
+def _compute_exit_code(
+    report: StorageInventoryReport, run_mongo: bool, run_mysql: bool
+) -> int:
+    """Map per-backend errors to the documented exit-code matrix (AC7)."""
+    mongo_failed = run_mongo and not report.mongo_ok
+    mysql_failed = run_mysql and not report.mysql_ok
+
+    if mongo_failed and mysql_failed:
+        if _is_privilege_error(report.mongo_error) or _is_privilege_error(
+            report.mysql_error
+        ):
+            return EXIT_PRIVILEGE_DENIED
+        return EXIT_BOTH_FAILED
+    if mongo_failed:
+        if _is_privilege_error(report.mongo_error):
+            return EXIT_PRIVILEGE_DENIED
+        return EXIT_MONGO_FAILED
+    if mysql_failed:
+        if _is_privilege_error(report.mysql_error):
+            return EXIT_PRIVILEGE_DENIED
+        return EXIT_MYSQL_FAILED
+    return EXIT_OK
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    _configure_logging()
+    return asyncio.run(_amain(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/storage-inventory.md
+++ b/docs/storage-inventory.md
@@ -1,0 +1,205 @@
+# Storage Inventory Audit
+
+A **strictly read-only** audit of every MongoDB database + collection and every
+MySQL schema + table reachable from the cluster. Diagnostic only — it deletes
+nothing. Closes the loop on [`petrosa_k8s#783`](https://github.com/PetroSa2/petrosa_k8s/issues/783)
+(the P0 Atlas-storage incident) by attributing the residual >400 MB across
+backends.
+
+Tracking issue: [`petrosa_k8s#794`](https://github.com/PetroSa2/petrosa_k8s/issues/794)
+(impl_repo `petrosa-data-manager`).
+
+## When to run
+
+- After a major Mongo cleanup, to root-cause whatever footprint is left.
+- When `mongo_atlas_storage_used_bytes` (the alert from
+  [`petrosa_k8s#786`](https://github.com/PetroSa2/petrosa_k8s/issues/786))
+  crosses the 80% warning threshold.
+- Before scoping a retention/migration ticket — so the ticket starts from
+  measurement, not assumption.
+
+It is **not** a recurring CronJob. The companion to this audit is the
+klines-retention CronJob ([`petrosa_k8s#787`](https://github.com/PetroSa2/petrosa_k8s/issues/787)),
+which ships paused; the audit is what tells the operator whether to unpause
+it and what other retention work to file.
+
+## Safety model (two layers — both required)
+
+| Layer | Mechanism | Code reference |
+| --- | --- | --- |
+| 1. Credential | `SELECT`-only MySQL user + Mongo role limited to `read` + `listDatabases` / `clusterMonitor` | provisioned by the operator |
+| 2. Code | Audit calls only `listDatabases` / `dbStats` / `collStats` / `list_collections` / `find_one` (Mongo) and `information_schema` SELECTs (MySQL); bypasses `MySQLAdapter.connect()` (which runs DDL) | `data_manager.maintenance.storage_inventory` + `data_manager.db.mysql_adapter.create_read_only_engine` |
+
+Layer 1 is the **real** safety guarantee. Layer 2 is the second belt — it
+proves the data-manager codebase itself does not emit DDL on the audit path,
+but cannot defend against an over-privileged credential. The unit-test
+suite asserts no write/delete/insert/update/drop method is called on the
+mock adapters during a full audit pass.
+
+## Required DB privileges
+
+### MongoDB Atlas
+
+The audit needs to enumerate every database, including `local`/`admin`/`config`,
+and run `dbStats` + `collStats`. The cleanest Atlas built-in role is one of:
+
+- `clusterMonitor` (project-level) — grants `listDatabases`, `dbStats`,
+  `collStats`, `replSetGetStatus`, etc. without read access to user data.
+- `readAnyDatabase` — broader (allows reading documents); only needed if
+  the audit's best-effort `newest_doc_age` field lookups are also required.
+
+If both roles are unavailable, the audit will exit with code `13`
+(privilege denied) — request the missing privilege rather than working
+around it.
+
+### MySQL
+
+`SELECT` on `information_schema` is sufficient. No DDL is ever issued.
+
+## Required environment
+
+The audit reads only the standard data-manager env vars:
+
+- `MONGODB_URL` — full connection string (the var data-manager actually
+  reads; **not** `MONGODB_URI`).
+- `MYSQL_URI` — full SQLAlchemy connection string (e.g.
+  `mysql+pymysql://user:pass@host:3306/petrosa`).
+- `LOG_LEVEL` (optional; default `INFO`).
+
+When running in-cluster, these come from the `petrosa-sensitive-credentials`
+secret. Inject **both** explicitly in the Job manifest — the existing
+`klines-retention-cronjob.yaml` only injects `MONGODB_URL`, so a naïve copy
+would yield a Mongo-only audit. The `MYSQL_URI` key lives in the same
+secret (see `petrosa_k8s/k8s/shared/database-init/klines-view-mapper.yaml`).
+
+## Invocation
+
+```bash
+# Full audit (both backends)
+opentelemetry-instrument python -m data_manager.maintenance.storage_inventory --json
+
+# Mongo only (e.g. if the MySQL credential is still being provisioned)
+opentelemetry-instrument python -m data_manager.maintenance.storage_inventory --mongo-only --json
+
+# MySQL only
+opentelemetry-instrument python -m data_manager.maintenance.storage_inventory --mysql-only --json
+```
+
+Stdout carries a markdown report. With `--json`, a fenced JSON blob is
+appended so the report can be machine-processed.
+
+### Exit codes (`petrosa_k8s#794` AC7)
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Both backends OK (or the selected subset is OK) |
+| `10` | Mongo backend failed |
+| `11` | MySQL backend failed |
+| `12` | Both backends failed |
+| `13` | Privilege/permission denied on a required admin command |
+
+## In-cluster execution
+
+Local/laptop execution is **expected to fail** on IP allow-listing — Atlas
+and the MySQL backend are not reachable from arbitrary workstations. The
+canonical path is a one-shot `kind: Job` in the `petrosa-apps` namespace:
+
+1. `kubectl apply -f petrosa_k8s/k8s/data-extractor/storage-inventory-job.yaml`
+   (added separately under [`petrosa_k8s#794`](https://github.com/PetroSa2/petrosa_k8s/issues/794)'s
+   sibling PR — the manifest is not in this PR because the
+   `k8s/data-extractor/` directory is GitOps-auto-applied and the Job
+   placement needs explicit operator review per
+   [`project_petrosa_k8s_gitops_auto_apply.md`](../../../petrosa_k8s/docs/)).
+2. Wait for completion: `kubectl wait --for=condition=complete job/storage-inventory -n petrosa-apps --timeout=20m`.
+3. Capture logs **before `ttlSecondsAfterFinished` reaps the pod**:
+   `kubectl logs job/storage-inventory -n petrosa-apps > storage-inventory-$(date -u +%FT%H-%M-%SZ).log`.
+4. Commit the redacted findings to `docs/storage-inventory-report-YYYY-MM-DD.md`.
+
+Run it during a **low-trading window** — `collStats` across hundreds of
+live collections adds latency to a shared Atlas cluster serving live
+trading.
+
+## Findings report template
+
+Use this template for the committed report. Names + sizes only; redact any
+connection strings or credentials that may have leaked into logs.
+
+```markdown
+# Storage Inventory Findings — YYYY-MM-DD
+
+**Run window:** YYYY-MM-DDTHH:MM:SSZ → YYYY-MM-DDTHH:MM:SSZ
+**Run-as credential:** `<readonly-username>` (project `<atlas-project-id>`)
+**Cluster (Mongo):** `<atlas-cluster-id>` (URI redacted)
+**Cluster (MySQL):** `<mysql-host>:3306` (URI redacted)
+**Exit code:** `<0|10|11|12|13>`
+
+## 1. Where the residual ~XXX MB lives (AC3)
+
+Paste the "400 MB Attribution" table from the Job stdout. State the
+dominant consumer and confirm/refute each KEY HYPOTHESIS from the
+tech-spec:
+
+- [ ] `candles_*` left behind by the manual cleanup?
+- [ ] Time-series bucket storage (`system.buckets.klines_*`) dominates the
+      klines logical size?
+- [ ] Per-symbol/per-timeframe collection explosion?
+- [ ] Atlas-only footprint (oplog + system DBs) the app never sees?
+- [ ] Candle duplication across Mongo + MySQL backends?
+- [ ] Multiple Mongo DBs (e.g. `petrosa` + `petrosa_data_manager` + `test_tradeengine`)?
+- [ ] `signals` duplicated across Mongo + MySQL?
+
+## 2. Inventory by backend (AC1)
+
+### MongoDB
+
+Paste the "MongoDB databases" section from the Job stdout.
+
+### MySQL
+
+Paste the "MySQL schemas" section from the Job stdout.
+
+## 3. Duplication + orphan analysis (AC4 + AC5)
+
+- Duplicated candle timeframes: `[...]`
+- Orphan-suspect Mongo collections: `[...]`
+- Orphan-suspect MySQL tables: `[...]`
+
+## 4. Follow-up remediation tickets (AC8)
+
+Filed via `petrosa_k8s/scripts/create-project-item.sh` with the `cross-repo`
+label and linked to `#783`:
+
+- `petrosa_k8s#XXX` — <retention/consolidation/orphan-drop ticket title>
+- ...
+```
+
+## Limitations + caveats
+
+- **Point-in-time snapshot.** Re-run after any large retention/migration
+  pass to refresh.
+- **`TABLE_ROWS` is an InnoDB estimate.** Storage verdict comes from
+  `DATA_LENGTH` + `INDEX_LENGTH`, not the row count.
+- **`storageSize` vs `dataSize`.** The Atlas quota counts on-disk
+  `storageSize` (compressed). The audit reports both; the attribution
+  table sums on-disk `storageSize`. Logical `dataSize` is informational.
+- **Heuristic classification.** `orphan-suspect` and `duplicated` are
+  flags for human review, never auto-action. Remediation is always a
+  follow-up reviewed ticket, not part of this work item.
+- **DB names embedded in URIs are resolved at runtime** by the Job, not
+  knowable from the manifests beforehand. Static literals in this repo
+  (`petrosa`, `petrosa_data_manager`, `test_tradeengine`) are seeds for
+  classification; the live audit is what reveals every effective DB.
+
+## Related
+
+- [`petrosa_k8s#783`](https://github.com/PetroSa2/petrosa_k8s/issues/783)
+  — P0 Atlas-storage incident (parent epic).
+- [`petrosa_k8s#786`](https://github.com/PetroSa2/petrosa_k8s/issues/786)
+  — Atlas storage alerts (the warning that should re-trigger this audit).
+- [`petrosa_k8s#787`](https://github.com/PetroSa2/petrosa_k8s/issues/787)
+  — klines-retention CronJob (ships paused; awaits this audit's verdict).
+- [`docs/klines-retention.md`](klines-retention.md) — sibling maintenance
+  job; same packaging pattern (`python -m`, env-driven, OTel-wrapped).
+- `_bmad-output/implementation-artifacts/tech-spec-storage-inventory-audit-mongo-mysql.md`
+  in the `petrosa_k8s` repo — full design rationale + adversarial-review
+  findings F1–F12 that hardened the spec.

--- a/tests/test_storage_inventory.py
+++ b/tests/test_storage_inventory.py
@@ -562,3 +562,505 @@ def test_render_markdown_includes_attribution_and_duplication_sections():
     assert "`1m`" in text
     assert "## MongoDB databases" in text
     assert "## MySQL schemas" in text
+
+
+def test_render_markdown_handles_empty_report_with_errors():
+    """Markdown renders cleanly when both backends errored before producing data."""
+    report = si.StorageInventoryReport(
+        generated_at="2026-06-03T00:00:00Z",
+        mongo_ok=False,
+        mysql_ok=False,
+        mongo_error="not authorized on admin",
+        mysql_error="connection refused",
+    )
+    text = si.render_markdown(report)
+    assert "Mongo backend: FAILED" in text
+    assert "MySQL backend: FAILED" in text
+    assert "not authorized" in text
+    assert "connection refused" in text
+
+
+def test_render_markdown_includes_oplog_when_present():
+    report = si.StorageInventoryReport(
+        generated_at="t",
+        mongo_ok=True,
+        mysql_ok=True,
+        mongo_error=None,
+        mysql_error=None,
+        mongo_oplog={"storageSize": 5000, "size": 4000},
+    )
+    text = si.render_markdown(report)
+    assert "Oplog" in text
+    assert "5,000" in text
+
+
+def test_render_markdown_marks_error_rows_for_failed_databases():
+    db = si.MongoDatabaseStat(
+        name="petrosa",
+        is_system=False,
+        storage_size=0,
+        data_size=0,
+        index_size=0,
+        collections=0,
+        objects=0,
+        error="dbStats failed",
+    )
+    report = si.StorageInventoryReport(
+        generated_at="t",
+        mongo_ok=True,
+        mysql_ok=True,
+        mongo_error=None,
+        mysql_error=None,
+        mongo_databases=[db],
+    )
+    text = si.render_markdown(report)
+    assert "_error_" in text
+    assert "dbStats failed" in text
+
+
+def test_render_markdown_marks_error_rows_for_failed_schemas():
+    schema = si.MysqlSchemaStat(name="petrosa", error="permission denied")
+    report = si.StorageInventoryReport(
+        generated_at="t",
+        mongo_ok=True,
+        mysql_ok=True,
+        mongo_error=None,
+        mysql_error=None,
+        mysql_schemas=[schema],
+    )
+    text = si.render_markdown(report)
+    assert "_error_" in text
+    assert "permission denied" in text
+
+
+def test_report_to_dict_round_trips_via_json():
+    """The structured report must serialise cleanly via json.dumps(default=str)."""
+    import json as _json
+
+    report = _build_report_for_classification()
+    si._classify_all(report)
+    si._attribute_400mb(report)
+
+    serialised = _json.dumps(si.report_to_dict(report), default=str)
+    parsed = _json.loads(serialised)
+    assert parsed["mongo_ok"] is True
+    assert parsed["attribution"]["mongo_klines_buckets_bytes"] == 2_000_000
+    assert "1m" in parsed["duplicated_candle_timeframes"]
+
+
+def test_isoformat_or_none_handles_datetime_and_none():
+    assert si._isoformat_or_none(None) is None
+    dt = datetime(2026, 6, 3, 12, 0, tzinfo=UTC)
+    assert si._isoformat_or_none(dt) == dt.isoformat()
+    assert si._isoformat_or_none("not-a-datetime") is None
+
+
+def test_is_privilege_error_detects_common_phrasings():
+    assert si._is_privilege_error("not authorized on admin") is True
+    assert si._is_privilege_error("permission denied for user 'audit'") is True
+    assert si._is_privilege_error("Access denied; you need SELECT privilege") is True
+    assert si._is_privilege_error("Unauthorized — listDatabases refused") is True
+    assert si._is_privilege_error("connection refused") is False
+    assert si._is_privilege_error(None) is False
+    assert si._is_privilege_error("") is False
+
+
+# ---------------------------------------------------------------------------
+# _audit_mongo_collection — error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_collection_records_error_when_coll_stats_fails():
+    adapter = AsyncMock()
+    adapter.is_timeseries.return_value = False
+    adapter.coll_stats.side_effect = RuntimeError("namespace not found")
+    adapter.newest_doc_age.return_value = None
+
+    stat = await si._audit_mongo_collection(adapter, "petrosa", "missing_collection")
+
+    assert stat.classification == "error"
+    assert stat.error == "namespace not found"
+    assert stat.storage_size == 0
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_collection_tolerates_missing_backing_bucket():
+    """Time-series collection without a discoverable system.buckets.* still produces a stat."""
+    adapter = AsyncMock()
+    adapter.is_timeseries.return_value = True
+    adapter.coll_stats.side_effect = [
+        _coll_stats(1_000),
+        RuntimeError("system.buckets.klines_1h not found"),
+    ]
+    adapter.newest_doc_age.return_value = None
+
+    stat = await si._audit_mongo_collection(adapter, "petrosa", "klines_1h")
+
+    assert stat.is_timeseries is True
+    assert stat.storage_size == 1_000
+    assert stat.backing_bucket_storage_size is None
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_collection_handles_newest_doc_age_failure():
+    adapter = AsyncMock()
+    adapter.is_timeseries.return_value = False
+    adapter.coll_stats.return_value = _coll_stats(200)
+    adapter.newest_doc_age.side_effect = RuntimeError("read denied")
+
+    stat = await si._audit_mongo_collection(adapter, "petrosa", "signals")
+    assert stat.newest_doc_age is None
+    assert stat.storage_size == 200
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_handles_per_db_stats_failure_gracefully():
+    """A single DB failing dbStats is recorded as an error on that DB; siblings still walk."""
+    adapter = AsyncMock()
+    adapter.list_databases.return_value = [
+        {"name": "petrosa", "sizeOnDisk": 1000, "empty": False},
+        {"name": "denied_db", "sizeOnDisk": 50, "empty": False},
+    ]
+
+    def _db_stats_side_effect(name):
+        if name == "denied_db":
+            raise RuntimeError("not authorized")
+        return _db_stats(1024)
+
+    adapter.db_stats.side_effect = _db_stats_side_effect
+
+    petrosa_db = MagicMock()
+    petrosa_db.list_collection_names = AsyncMock(return_value=["signals"])
+    client = MagicMock()
+    client.__getitem__.return_value = petrosa_db
+    adapter.client = client
+
+    adapter.is_timeseries.return_value = False
+    adapter.coll_stats.return_value = _coll_stats(100)
+    adapter.newest_doc_age.return_value = None
+    adapter.oplog_size.return_value = None
+
+    dbs, _, err = await si.audit_mongo(adapter)
+    assert err is None
+    by_name = {d.name: d for d in dbs}
+    assert by_name["denied_db"].error == "not authorized"
+    assert by_name["petrosa"].error is None
+    # The denied DB carries no per-collection rows because dbStats failed
+    assert by_name["denied_db"].collection_stats == []
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_handles_list_collections_failure_per_db():
+    """If list_collection_names fails for a DB, that DB carries the error and walk continues."""
+    adapter = AsyncMock()
+    adapter.list_databases.return_value = [
+        {"name": "petrosa", "sizeOnDisk": 1, "empty": False},
+    ]
+    adapter.db_stats.return_value = _db_stats(1024)
+    petrosa_db = MagicMock()
+    petrosa_db.list_collection_names = AsyncMock(
+        side_effect=RuntimeError("network blip")
+    )
+    client = MagicMock()
+    client.__getitem__.return_value = petrosa_db
+    adapter.client = client
+    adapter.oplog_size.return_value = None
+
+    dbs, _, err = await si.audit_mongo(adapter)
+    assert err is None
+    assert dbs[0].error == "network blip"
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_continues_when_oplog_unreachable():
+    """oplog_size is best-effort; failure must not propagate to the caller."""
+    adapter = AsyncMock()
+    adapter.list_databases.return_value = []
+    adapter.oplog_size.side_effect = RuntimeError("oplog read denied")
+
+    dbs, oplog, err = await si.audit_mongo(adapter)
+    assert err is None
+    assert oplog is None
+    assert dbs == []
+
+
+# ---------------------------------------------------------------------------
+# MySQL audit — schema-level errors
+# ---------------------------------------------------------------------------
+
+
+def test_audit_mysql_records_per_schema_table_inventory_failure():
+    fake_engine = MagicMock()
+    with (
+        patch.object(si, "create_read_only_engine", return_value=fake_engine),
+        patch.object(si, "list_schemas", return_value=["good", "bad"]),
+        patch.object(
+            si,
+            "table_inventory",
+            side_effect=[
+                [
+                    {
+                        "TABLE_NAME": "positions",
+                        "TABLE_TYPE": "BASE TABLE",
+                        "TABLE_ROWS": 10,
+                        "DATA_LENGTH": 1000,
+                        "INDEX_LENGTH": 200,
+                        "CREATE_TIME": None,
+                        "UPDATE_TIME": None,
+                    },
+                ],
+                RuntimeError("denied"),
+            ],
+        ),
+    ):
+        schemas, err = si.audit_mysql("mysql+pymysql://x")
+
+    assert err is None
+    by_name = {s.name: s for s in schemas}
+    assert by_name["good"].error is None
+    assert by_name["bad"].error == "denied"
+    assert by_name["bad"].tables == []
+    fake_engine.dispose.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Adapter-level read-only helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mongodb_adapter_list_databases_returns_listdatabases_payload():
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+    adapter = MongoDBAdapter.__new__(MongoDBAdapter)
+    adapter._connected = True
+    adapter.client = MagicMock()
+    adapter.client.list_databases = AsyncMock(
+        return_value=[
+            {"name": "petrosa", "sizeOnDisk": 1024, "empty": False},
+            {"name": "admin", "sizeOnDisk": 32, "empty": False},
+        ]
+    )
+
+    result = await adapter.list_databases()
+    assert {db["name"] for db in result} == {"petrosa", "admin"}
+
+
+@pytest.mark.asyncio
+async def test_mongodb_adapter_db_stats_runs_dbstats_command():
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+    adapter = MongoDBAdapter.__new__(MongoDBAdapter)
+    adapter._connected = True
+    fake_db = MagicMock()
+    fake_db.command = AsyncMock(return_value={"storageSize": 1024, "dataSize": 4096})
+    adapter.client = MagicMock()
+    adapter.client.__getitem__.return_value = fake_db
+
+    stats = await adapter.db_stats("petrosa")
+    assert stats["storageSize"] == 1024
+    fake_db.command.assert_awaited_once_with("dbStats")
+
+
+@pytest.mark.asyncio
+async def test_mongodb_adapter_coll_stats_falls_back_to_aggregation_when_command_denied():
+    from pymongo.errors import PyMongoError
+
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+    adapter = MongoDBAdapter.__new__(MongoDBAdapter)
+    adapter._connected = True
+
+    fake_coll = MagicMock()
+    fake_cursor = MagicMock()
+    fake_cursor.to_list = AsyncMock(
+        return_value=[{"storageStats": {"storageSize": 9999}}]
+    )
+    fake_coll.aggregate.return_value = fake_cursor
+
+    fake_db = MagicMock()
+    fake_db.command = AsyncMock(side_effect=PyMongoError("denied"))
+    fake_db.__getitem__.return_value = fake_coll
+    adapter.client = MagicMock()
+    adapter.client.__getitem__.return_value = fake_db
+
+    stats = await adapter.coll_stats("petrosa", "signals")
+    assert stats["storageSize"] == 9999
+    assert stats["_via_aggregation"] is True
+
+
+@pytest.mark.asyncio
+async def test_mongodb_adapter_is_timeseries_reads_collection_spec():
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+    adapter = MongoDBAdapter.__new__(MongoDBAdapter)
+    adapter._connected = True
+
+    fake_db = MagicMock()
+
+    class _FakeCursor:
+        def __init__(self, docs):
+            self._docs = docs
+
+        async def to_list(self, length):
+            return self._docs
+
+    fake_db.list_collections.return_value = _FakeCursor(
+        [
+            {
+                "name": "klines_1h",
+                "type": "timeseries",
+                "options": {"timeseries": {"timeField": "ts"}},
+            }
+        ]
+    )
+    adapter.client = MagicMock()
+    adapter.client.__getitem__.return_value = fake_db
+
+    assert await adapter.is_timeseries("petrosa", "klines_1h") is True
+
+    fake_db.list_collections.return_value = _FakeCursor([])
+    assert await adapter.is_timeseries("petrosa", "missing") is False
+
+
+@pytest.mark.asyncio
+async def test_mongodb_adapter_newest_doc_age_returns_datetime_from_first_hit():
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+    adapter = MongoDBAdapter.__new__(MongoDBAdapter)
+    adapter._connected = True
+
+    fake_coll = MagicMock()
+    target_dt = datetime(2026, 6, 3, 12, 0, tzinfo=UTC)
+    fake_coll.find_one = AsyncMock(return_value={"timestamp": target_dt})
+
+    fake_db = MagicMock()
+    fake_db.__getitem__.return_value = fake_coll
+    adapter.client = MagicMock()
+    adapter.client.__getitem__.return_value = fake_db
+
+    result = await adapter.newest_doc_age("petrosa", "signals")
+    assert result == target_dt
+
+
+@pytest.mark.asyncio
+async def test_mongodb_adapter_newest_doc_age_returns_none_on_empty_collection():
+    from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+    adapter = MongoDBAdapter.__new__(MongoDBAdapter)
+    adapter._connected = True
+
+    fake_coll = MagicMock()
+    fake_coll.find_one = AsyncMock(return_value=None)
+    fake_db = MagicMock()
+    fake_db.__getitem__.return_value = fake_coll
+    adapter.client = MagicMock()
+    adapter.client.__getitem__.return_value = fake_db
+
+    result = await adapter.newest_doc_age("petrosa", "empty_col")
+    assert result is None
+
+
+def test_mysql_create_read_only_engine_does_not_call_create_tables():
+    """AC10: the read-only engine helper must not invoke MetaData.create_all."""
+    from data_manager.db import mysql_adapter as ma
+
+    fake_engine = MagicMock()
+    with patch.object(ma, "create_engine", return_value=fake_engine) as mock_ce:
+        engine = ma.create_read_only_engine("mysql+pymysql://user:pass@host:3306/db")
+
+    assert engine is fake_engine
+    mock_ce.assert_called_once()
+    # The kwargs explicitly disable connection-time pool warming and avoid DDL
+    _, kwargs = mock_ce.call_args
+    assert kwargs["pool_pre_ping"] is True
+    assert kwargs["pool_size"] == 2
+    # Sanity: there is NO call to metadata.create_all anywhere on the engine
+    assert not fake_engine.metadata.create_all.called
+
+
+def test_mysql_list_schemas_excludes_system_schemas():
+    from data_manager.db.mysql_adapter import list_schemas
+
+    fake_conn = MagicMock()
+    fake_conn.__enter__.return_value = fake_conn
+    fake_conn.__exit__.return_value = None
+    fake_conn.execute.return_value.fetchall.return_value = [
+        ("petrosa",),
+        ("information_schema",),
+        ("mysql",),
+        ("performance_schema",),
+        ("sys",),
+        ("staging",),
+    ]
+    fake_engine = MagicMock()
+    fake_engine.connect.return_value = fake_conn
+
+    result = list_schemas(fake_engine)
+    assert sorted(result) == ["petrosa", "staging"]
+
+
+def test_mysql_table_inventory_returns_table_rows_with_table_type():
+    from data_manager.db.mysql_adapter import table_inventory
+
+    fake_conn = MagicMock()
+    fake_conn.__enter__.return_value = fake_conn
+    fake_conn.__exit__.return_value = None
+    fake_rows = [
+        {
+            "TABLE_NAME": "klines_m1",
+            "TABLE_TYPE": "BASE TABLE",
+            "TABLE_ROWS": 1000,
+            "DATA_LENGTH": 1024,
+            "INDEX_LENGTH": 256,
+            "CREATE_TIME": None,
+            "UPDATE_TIME": None,
+        }
+    ]
+    fake_conn.execute.return_value.mappings.return_value.fetchall.return_value = (
+        fake_rows
+    )
+    fake_engine = MagicMock()
+    fake_engine.connect.return_value = fake_conn
+
+    result = table_inventory(fake_engine, "petrosa")
+    assert len(result) == 1
+    assert result[0]["TABLE_NAME"] == "klines_m1"
+    assert result[0]["TABLE_TYPE"] == "BASE TABLE"
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint exit-code paths
+# ---------------------------------------------------------------------------
+
+
+def test_amain_returns_ok_when_both_env_vars_missing_and_only_one_backend_requested(
+    monkeypatch,
+):
+    """--mongo-only with no MONGODB_URL set produces a clear error + exit 10."""
+    monkeypatch.delenv("MONGODB_URL", raising=False)
+    monkeypatch.delenv("MYSQL_URI", raising=False)
+    rc = si.main(["--mongo-only", "--json"])
+    assert rc == si.EXIT_MONGO_FAILED
+
+
+def test_amain_rejects_mutually_exclusive_flags(monkeypatch):
+    monkeypatch.delenv("MONGODB_URL", raising=False)
+    monkeypatch.delenv("MYSQL_URI", raising=False)
+    rc = si.main(["--mongo-only", "--mysql-only"])
+    assert rc == 2
+
+
+def test_amain_returns_mysql_failed_when_mysql_uri_missing(monkeypatch):
+    monkeypatch.delenv("MONGODB_URL", raising=False)
+    monkeypatch.delenv("MYSQL_URI", raising=False)
+    rc = si.main(["--mysql-only"])
+    assert rc == si.EXIT_MYSQL_FAILED
+
+
+def test_amain_returns_both_failed_when_no_env_set(monkeypatch):
+    monkeypatch.delenv("MONGODB_URL", raising=False)
+    monkeypatch.delenv("MYSQL_URI", raising=False)
+    rc = si.main([])
+    assert rc == si.EXIT_BOTH_FAILED

--- a/tests/test_storage_inventory.py
+++ b/tests/test_storage_inventory.py
@@ -1,0 +1,564 @@
+"""Tests for the storage-inventory audit module (petrosa_k8s#794)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from data_manager.maintenance import storage_inventory as si
+
+
+def _coll_stats(
+    storage_size: int, data_size: int = None, count: int = 100, index_size: int = 1024
+) -> dict:
+    return {
+        "storageSize": storage_size,
+        "size": data_size if data_size is not None else storage_size * 2,
+        "count": count,
+        "totalIndexSize": index_size,
+        "nindexes": 2,
+        "avgObjSize": 256,
+    }
+
+
+def _db_stats(storage_size: int, collections: int = 1) -> dict:
+    return {
+        "storageSize": storage_size,
+        "dataSize": storage_size * 2,
+        "indexSize": 1024,
+        "collections": collections,
+        "objects": collections * 100,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Classification helpers
+# ---------------------------------------------------------------------------
+
+
+def test_is_known_mongo_collection_matches_lifecycle_names():
+    assert si._is_known_mongo_collection("intents") is True
+    assert si._is_known_mongo_collection("cio_decisions") is True
+    assert si._is_known_mongo_collection("signals") is True
+
+
+def test_is_known_mongo_collection_matches_known_prefixes():
+    assert si._is_known_mongo_collection("candles_BTCUSDT_1m") is True
+    assert si._is_known_mongo_collection("klines_1h") is True
+    assert si._is_known_mongo_collection("trades_ETHUSDT") is True
+    assert si._is_known_mongo_collection("system.buckets.klines_1h") is True
+
+
+def test_is_known_mongo_collection_returns_false_for_unknown():
+    assert si._is_known_mongo_collection("totally_random") is False
+    assert si._is_known_mongo_collection("legacy_stuff") is False
+
+
+def test_is_known_mysql_table_matches_known_names_and_prefixes():
+    assert si._is_known_mysql_table("positions") is True
+    assert si._is_known_mysql_table("klines_m1") is True
+    assert si._is_known_mysql_table("klines_h4") is True
+    assert si._is_known_mysql_table("random_unknown") is False
+
+
+def test_normalize_timeframe_canonicalises_across_naming_conventions():
+    # Mongo extractor naming
+    assert si._normalize_timeframe("klines_1h") == "1h"
+    # MySQL physical-table naming (m1 → 1m, h4 → 4h, d1 → 1d)
+    assert si._normalize_timeframe("klines_m1") == "1m"
+    assert si._normalize_timeframe("klines_h4") == "4h"
+    assert si._normalize_timeframe("klines_d1") == "1d"
+    # data-manager per-symbol/per-timeframe split
+    assert si._normalize_timeframe("candles_BTCUSDT_15m") == "15m"
+    # Non-candle collections return None
+    assert si._normalize_timeframe("signals") is None
+    assert si._normalize_timeframe("intents") is None
+
+
+# ---------------------------------------------------------------------------
+# Mongo audit aggregation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_aggregates_per_db_and_per_collection():
+    """AC1: full enumeration walks every DB returned by listDatabases."""
+    adapter = AsyncMock()
+    adapter.list_databases.return_value = [
+        {"name": "petrosa", "sizeOnDisk": 1000, "empty": False},
+        {"name": "admin", "sizeOnDisk": 100, "empty": False},
+    ]
+    adapter.db_stats.side_effect = lambda name: _db_stats(
+        1024 * 1024 if name == "petrosa" else 4096,
+        collections=2 if name == "petrosa" else 1,
+    )
+
+    # Mock list_collection_names per-DB via the client[db] indexing
+    petrosa_db = MagicMock()
+    petrosa_db.list_collection_names = AsyncMock(return_value=["signals", "klines_1h"])
+    admin_db = MagicMock()
+    admin_db.list_collection_names = AsyncMock(return_value=["system.users"])
+
+    client = MagicMock()
+    client.__getitem__.side_effect = (
+        lambda n: petrosa_db if n == "petrosa" else admin_db
+    )
+    adapter.client = client
+
+    adapter.is_timeseries.side_effect = lambda db, coll: coll == "klines_1h"
+    adapter.coll_stats.side_effect = lambda db, coll: _coll_stats(
+        50_000 if coll == "klines_1h" else 1_000 if coll == "signals" else 256
+    )
+    adapter.newest_doc_age.return_value = datetime(2026, 6, 3, tzinfo=UTC)
+    adapter.oplog_size.return_value = {"storageSize": 200_000_000, "size": 100_000_000}
+
+    dbs, oplog, err = await si.audit_mongo(adapter)
+
+    assert err is None
+    assert oplog == {"storageSize": 200_000_000, "size": 100_000_000}
+    assert {db.name for db in dbs} == {"petrosa", "admin"}
+    petrosa = next(db for db in dbs if db.name == "petrosa")
+    assert petrosa.is_system is False
+    assert {c.name for c in petrosa.collection_stats} == {"signals", "klines_1h"}
+    klines = next(c for c in petrosa.collection_stats if c.name == "klines_1h")
+    assert klines.is_timeseries is True
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_returns_error_when_list_databases_fails():
+    """AC7: top-level listDatabases failure surfaces an error string."""
+    adapter = AsyncMock()
+    adapter.list_databases.side_effect = RuntimeError("not authorized on admin")
+
+    dbs, oplog, err = await si.audit_mongo(adapter)
+
+    assert dbs == []
+    assert oplog is None
+    assert err is not None
+    assert "not authorized" in err
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_collection_records_backing_bucket_for_timeseries():
+    """AC11: time-series collections also size the backing system.buckets.*."""
+    adapter = AsyncMock()
+    adapter.is_timeseries.return_value = True
+    adapter.coll_stats.side_effect = [
+        _coll_stats(1_000),  # logical klines_1h
+        _coll_stats(500_000),  # backing system.buckets.klines_1h
+    ]
+    adapter.newest_doc_age.return_value = None
+
+    stat = await si._audit_mongo_collection(adapter, "petrosa", "klines_1h")
+
+    assert stat.is_timeseries is True
+    assert stat.storage_size == 1_000
+    assert stat.backing_bucket_storage_size == 500_000
+
+
+# ---------------------------------------------------------------------------
+# MySQL audit aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_audit_mysql_excludes_views_from_byte_totals():
+    """AC6: VIEW rows are surfaced but not summed into storage totals."""
+    fake_engine = MagicMock()
+    fake_engine.dispose = MagicMock()
+
+    with (
+        patch.object(si, "create_read_only_engine", return_value=fake_engine),
+        patch.object(si, "list_schemas", return_value=["petrosa"]),
+        patch.object(
+            si,
+            "table_inventory",
+            return_value=[
+                {
+                    "TABLE_NAME": "klines_m1",
+                    "TABLE_TYPE": "BASE TABLE",
+                    "TABLE_ROWS": 1000,
+                    "DATA_LENGTH": 100_000,
+                    "INDEX_LENGTH": 20_000,
+                    "CREATE_TIME": None,
+                    "UPDATE_TIME": None,
+                },
+                {
+                    "TABLE_NAME": "klines_1m",
+                    "TABLE_TYPE": "VIEW",
+                    "TABLE_ROWS": 0,
+                    "DATA_LENGTH": 0,
+                    "INDEX_LENGTH": 0,
+                    "CREATE_TIME": None,
+                    "UPDATE_TIME": None,
+                },
+            ],
+        ),
+    ):
+        schemas, err = si.audit_mysql("mysql+pymysql://user:pass@host/db")
+
+    assert err is None
+    assert len(schemas) == 1
+    schema = schemas[0]
+    assert {t.name for t in schema.tables} == {"klines_m1", "klines_1m"}
+    base_total = sum(
+        t.data_length + t.index_length for t in schema.tables if t.table_type != "VIEW"
+    )
+    view_total = sum(
+        t.data_length + t.index_length for t in schema.tables if t.table_type == "VIEW"
+    )
+    assert base_total == 120_000
+    assert view_total == 0
+    fake_engine.dispose.assert_called_once()
+
+
+def test_audit_mysql_returns_error_when_schema_enumeration_fails():
+    fake_engine = MagicMock()
+    with (
+        patch.object(si, "create_read_only_engine", return_value=fake_engine),
+        patch.object(
+            si, "list_schemas", side_effect=RuntimeError("access denied for user")
+        ),
+    ):
+        schemas, err = si.audit_mysql("mysql+pymysql://user:pass@host/db")
+    assert schemas == []
+    assert "access denied" in err
+
+
+# ---------------------------------------------------------------------------
+# Classification + attribution
+# ---------------------------------------------------------------------------
+
+
+def _build_report_for_classification() -> si.StorageInventoryReport:
+    return si.StorageInventoryReport(
+        generated_at="2026-06-03T00:00:00Z",
+        mongo_ok=True,
+        mysql_ok=True,
+        mongo_error=None,
+        mysql_error=None,
+        mongo_databases=[
+            si.MongoDatabaseStat(
+                name="petrosa",
+                is_system=False,
+                storage_size=1_000_000,
+                data_size=2_000_000,
+                index_size=10_000,
+                collections=3,
+                objects=300,
+                collection_stats=[
+                    si.MongoCollectionStat(
+                        db_name="petrosa",
+                        name="klines_1m",
+                        is_timeseries=True,
+                        storage_size=100_000,
+                        data_size=400_000,
+                        total_index_size=1024,
+                        count=10_000,
+                        n_indexes=2,
+                        avg_obj_size=64,
+                        backing_bucket_storage_size=2_000_000,
+                        backing_bucket_data_size=4_000_000,
+                        newest_doc_age=None,
+                        classification="live",
+                    ),
+                    si.MongoCollectionStat(
+                        db_name="petrosa",
+                        name="legacy_orphan_collection",
+                        is_timeseries=False,
+                        storage_size=50_000,
+                        data_size=80_000,
+                        total_index_size=512,
+                        count=100,
+                        n_indexes=1,
+                        avg_obj_size=512,
+                        backing_bucket_storage_size=None,
+                        backing_bucket_data_size=None,
+                        newest_doc_age=None,
+                        classification="live",
+                    ),
+                    si.MongoCollectionStat(
+                        db_name="petrosa",
+                        name="signals",
+                        is_timeseries=False,
+                        storage_size=10_000,
+                        data_size=12_000,
+                        total_index_size=256,
+                        count=42,
+                        n_indexes=2,
+                        avg_obj_size=240,
+                        backing_bucket_storage_size=None,
+                        backing_bucket_data_size=None,
+                        newest_doc_age=None,
+                        classification="live",
+                    ),
+                ],
+            ),
+            si.MongoDatabaseStat(
+                name="local",
+                is_system=True,
+                storage_size=300_000_000,
+                data_size=300_000_000,
+                index_size=0,
+                collections=1,
+                objects=0,
+                collection_stats=[
+                    si.MongoCollectionStat(
+                        db_name="local",
+                        name="oplog.rs",
+                        is_timeseries=False,
+                        storage_size=300_000_000,
+                        data_size=300_000_000,
+                        total_index_size=0,
+                        count=0,
+                        n_indexes=0,
+                        avg_obj_size=0,
+                        backing_bucket_storage_size=None,
+                        backing_bucket_data_size=None,
+                        newest_doc_age=None,
+                        classification="live",
+                    ),
+                ],
+            ),
+        ],
+        mongo_oplog={"storageSize": 300_000_000, "size": 280_000_000},
+        mysql_schemas=[
+            si.MysqlSchemaStat(
+                name="petrosa",
+                tables=[
+                    si.MysqlTableStat(
+                        schema="petrosa",
+                        name="klines_m1",
+                        table_type="BASE TABLE",
+                        data_length=200_000,
+                        index_length=40_000,
+                        table_rows_estimated=1234,
+                        create_time=None,
+                        update_time=None,
+                        classification="live",
+                    ),
+                    si.MysqlTableStat(
+                        schema="petrosa",
+                        name="klines_1m",
+                        table_type="VIEW",
+                        data_length=0,
+                        index_length=0,
+                        table_rows_estimated=0,
+                        create_time=None,
+                        update_time=None,
+                        classification="live",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def test_classify_all_flags_duplicated_candle_timeframes():
+    """AC4: a timeframe present in Mongo klines_* AND MySQL klines_* is `duplicated`."""
+    report = _build_report_for_classification()
+    si._classify_all(report)
+
+    assert "1m" in report.duplicated_candle_timeframes
+    petrosa_db = next(db for db in report.mongo_databases if db.name == "petrosa")
+    klines = next(c for c in petrosa_db.collection_stats if c.name == "klines_1m")
+    assert klines.classification == "duplicated"
+    mysql_klines = report.mysql_schemas[0].tables[0]
+    assert mysql_klines.classification == "duplicated"
+
+
+def test_classify_all_flags_orphan_suspect_when_unknown():
+    """AC5: a live collection with no known writer is `orphan-suspect`."""
+    report = _build_report_for_classification()
+    si._classify_all(report)
+    petrosa_db = next(db for db in report.mongo_databases if db.name == "petrosa")
+    orphan = next(
+        c for c in petrosa_db.collection_stats if c.name == "legacy_orphan_collection"
+    )
+    assert orphan.classification == "orphan-suspect"
+
+
+def test_classify_all_labels_system_db_collections_separately():
+    """System DBs (admin/local/config) get `system` classification, never `orphan-suspect`."""
+    report = _build_report_for_classification()
+    si._classify_all(report)
+    local_db = next(db for db in report.mongo_databases if db.name == "local")
+    oplog = local_db.collection_stats[0]
+    assert oplog.classification == "system"
+
+
+def test_classify_all_labels_mysql_view_as_view_not_orphan():
+    """AC6: VIEW rows get explicit `view` classification (not orphan-suspect)."""
+    report = _build_report_for_classification()
+    si._classify_all(report)
+    view = next(t for t in report.mysql_schemas[0].tables if t.table_type == "VIEW")
+    assert view.classification == "view"
+
+
+def test_attribute_400mb_separates_categories_for_root_cause():
+    """AC3: attribution bucket breaks the residual footprint into named categories."""
+    report = _build_report_for_classification()
+    si._classify_all(report)
+    si._attribute_400mb(report)
+
+    attr = report.attribution
+    # klines logical + buckets reported separately
+    assert attr["mongo_klines_logical_bytes"] == 100_000
+    assert attr["mongo_klines_buckets_bytes"] == 2_000_000
+    # legacy_orphan_collection + signals fall into other_app
+    assert attr["mongo_other_app_bytes"] == 60_000
+    # oplog reported separately, not folded into system_dbs
+    assert attr["mongo_oplog_bytes"] == 300_000_000
+    assert attr["mongo_system_dbs_bytes"] == 0  # oplog excluded from this bucket
+    # MySQL klines_m1 only (the VIEW is excluded)
+    assert attr["mysql_klines_bytes"] == 240_000
+    assert attr["mysql_other_bytes"] == 0
+
+
+# ---------------------------------------------------------------------------
+# AC2 — read-only assertion against the audit module
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_mongo_never_invokes_write_methods_on_adapter():
+    """AC2(b): no write/delete/insert/update/drop is ever called by the audit."""
+    adapter = AsyncMock()
+    adapter.list_databases.return_value = [
+        {"name": "petrosa", "sizeOnDisk": 1, "empty": False}
+    ]
+    adapter.db_stats.return_value = _db_stats(1024)
+    petrosa_db = MagicMock()
+    petrosa_db.list_collection_names = AsyncMock(return_value=["signals"])
+    client = MagicMock()
+    client.__getitem__.return_value = petrosa_db
+    adapter.client = client
+    adapter.is_timeseries.return_value = False
+    adapter.coll_stats.return_value = _coll_stats(100)
+    adapter.newest_doc_age.return_value = None
+    adapter.oplog_size.return_value = None
+
+    await si.audit_mongo(adapter)
+
+    forbidden = (
+        "write",
+        "write_batch",
+        "delete_range",
+        "ensure_indexes",
+        "upsert_app_config",
+        "upsert_global_config",
+        "upsert_symbol_config",
+        "delete_global_config",
+        "delete_symbol_config",
+    )
+    for name in forbidden:
+        assert not getattr(adapter, name).called, (
+            f"audit invoked forbidden adapter.{name}"
+        )
+
+
+def test_audit_mysql_does_not_construct_mysqladapter_instance():
+    """AC2/AC10: the audit must use `create_read_only_engine`, never MySQLAdapter.connect()."""
+    fake_engine = MagicMock()
+    with (
+        patch.object(
+            si, "create_read_only_engine", return_value=fake_engine
+        ) as mock_create,
+        patch.object(si, "list_schemas", return_value=[]),
+        patch.object(si, "table_inventory", return_value=[]),
+    ):
+        schemas, err = si.audit_mysql("mysql+pymysql://user:pass@host/db")
+    assert err is None
+    assert mock_create.call_count == 1
+    fake_engine.dispose.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC7 — defined exit codes per failure scenario
+# ---------------------------------------------------------------------------
+
+
+def test_compute_exit_code_both_ok():
+    report = si.StorageInventoryReport(
+        generated_at="t",
+        mongo_ok=True,
+        mysql_ok=True,
+        mongo_error=None,
+        mysql_error=None,
+    )
+    assert si._compute_exit_code(report, True, True) == si.EXIT_OK
+
+
+def test_compute_exit_code_mongo_failed():
+    report = si.StorageInventoryReport(
+        generated_at="t",
+        mongo_ok=False,
+        mysql_ok=True,
+        mongo_error="connection refused",
+        mysql_error=None,
+    )
+    assert si._compute_exit_code(report, True, True) == si.EXIT_MONGO_FAILED
+
+
+def test_compute_exit_code_mysql_failed():
+    report = si.StorageInventoryReport(
+        generated_at="t",
+        mongo_ok=True,
+        mysql_ok=False,
+        mongo_error=None,
+        mysql_error="connection timeout",
+    )
+    assert si._compute_exit_code(report, True, True) == si.EXIT_MYSQL_FAILED
+
+
+def test_compute_exit_code_both_failed():
+    report = si.StorageInventoryReport(
+        generated_at="t",
+        mongo_ok=False,
+        mysql_ok=False,
+        mongo_error="connection refused",
+        mysql_error="connection timeout",
+    )
+    assert si._compute_exit_code(report, True, True) == si.EXIT_BOTH_FAILED
+
+
+def test_compute_exit_code_privilege_denied_distinguished_from_generic():
+    report = si.StorageInventoryReport(
+        generated_at="t",
+        mongo_ok=False,
+        mysql_ok=True,
+        mongo_error="command listDatabases requires authentication: not authorized",
+        mysql_error=None,
+    )
+    assert si._compute_exit_code(report, True, True) == si.EXIT_PRIVILEGE_DENIED
+
+
+def test_compute_exit_code_skips_disabled_backend():
+    """--mongo-only should not penalise the MySQL backend being absent."""
+    report = si.StorageInventoryReport(
+        generated_at="t",
+        mongo_ok=True,
+        mysql_ok=False,
+        mongo_error=None,
+        mysql_error=None,
+    )
+    assert si._compute_exit_code(report, True, False) == si.EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# Output rendering smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_render_markdown_includes_attribution_and_duplication_sections():
+    report = _build_report_for_classification()
+    si._classify_all(report)
+    si._attribute_400mb(report)
+    text = si.render_markdown(report)
+    assert "# Storage Inventory Audit Report" in text
+    assert "## 400 MB Attribution" in text
+    assert "## Duplicated candle timeframes" in text
+    assert "`1m`" in text
+    assert "## MongoDB databases" in text
+    assert "## MySQL schemas" in text


### PR DESCRIPTION
## Summary

Ships the **data-manager half** of [`petrosa_k8s#794`](https://github.com/PetroSa2/petrosa_k8s/issues/794) (leaf of P0 [`#783`](https://github.com/PetroSa2/petrosa_k8s/issues/783)) — a strictly read-only audit of every MongoDB database + collection and every MySQL schema + table reachable from the cluster, attributing on-disk storage so the operator can root-cause the >400 MB residual after the manual klines cleanup.

**No data is read, written, or deleted by this PR.** Application paths are unchanged. The module is additive and inert until manually invoked.

## What's in / out of scope

| Task | Scope | Status |
| --- | --- | --- |
| 1. Mongo read-only introspection helpers | `data_manager/db/mongodb_adapter.py` | ✅ in this PR |
| 2. MySQL read-only introspection helpers | `data_manager/db/mysql_adapter.py` | ✅ in this PR |
| 3. `storage_inventory` module | `data_manager/maintenance/storage_inventory.py` | ✅ in this PR |
| 4. Unit tests | `tests/test_storage_inventory.py` (24 tests) | ✅ in this PR |
| 5. Operator runbook + report template | `docs/storage-inventory.md` | ✅ in this PR |
| 6. One-shot in-cluster Job manifest | `petrosa_k8s/k8s/data-extractor/storage-inventory-job.yaml` | ⏭️ separate `petrosa_k8s` PR (auto-apply concern needs operator review) |
| 7. Live in-cluster run | — | ⏸️ blocked on 5 operator decisions in the issue briefing |
| 8. Findings analysis | `docs/storage-inventory-report-YYYY-MM-DD.md` | ⏸️ after Task 7 |
| 9. Follow-up remediation tickets | via `create-project-item.sh` | ⏸️ after Task 8 |

## Two-layer read-only safety (AC2 / AC10)

1. **Credential — the real guarantee.** The Job must run under a `SELECT`-only MySQL user and a Mongo role limited to `read` + `listDatabases`/`clusterMonitor`. Operator provisions before the live run.
2. **Code-level.** This module issues only:
   - **Mongo:** `listDatabases`, `dbStats`, `collStats` (with `$collStats` aggregation fallback for restricted roles), `list_collections` filter, `find_one`.
   - **MySQL:** `SELECT` against `information_schema.SCHEMATA` and `information_schema.TABLES`.
   - It **deliberately bypasses `MySQLAdapter.connect()`** because that method runs `_create_tables` / `metadata.create_all` DDL — instead it uses the new module-level `create_read_only_engine` helper.
   - System schemas (`mysql`, `information_schema`, `performance_schema`, `sys`) excluded from MySQL enumeration.

Unit test `test_audit_mongo_never_invokes_write_methods_on_adapter` asserts that no `write`/`write_batch`/`delete_range`/`ensure_indexes`/`upsert_*`/`delete_*` method is ever called during a full audit pass. Test `test_audit_mysql_does_not_construct_mysqladapter_instance` asserts the audit goes through `create_read_only_engine`, never instantiating `MySQLAdapter`.

## Acceptance criteria coverage

| AC | Description | Where it's covered in this PR |
| --- | --- | --- |
| AC1 | Full enumeration of every Mongo DB + MySQL schema | `audit_mongo`, `audit_mysql`; tested in `test_audit_mongo_aggregates_per_db_and_per_collection` |
| AC2 | Read-only safety (credential + code, two layers) | `create_read_only_engine`, no-write assertion test |
| AC3 | 400 MB attribution split by category | `_attribute_400mb`; tested in `test_attribute_400mb_separates_categories_for_root_cause` |
| AC4 | Cross-backend candle duplication detection | `_normalize_timeframe` + `_classify_all`; tested in `test_classify_all_flags_duplicated_candle_timeframes` |
| AC5 | Orphan detection (live store with no known writer) | `_classify_mongo`/`_classify_mysql`; tested in `test_classify_all_flags_orphan_suspect_when_unknown` |
| AC6 | MySQL VIEW exclusion from storage totals | `table_inventory` carries `TABLE_TYPE`; tested in `test_audit_mysql_excludes_views_from_byte_totals` + `test_classify_all_labels_mysql_view_as_view_not_orphan` |
| AC7 | Defined exit codes 0/10/11/12/13 | `_compute_exit_code`; tested per-scenario (5 tests) |
| AC8 | Deliverables (committed report + follow-up tickets) | Documented in `docs/storage-inventory.md`; ⏸️ awaits live run |
| AC9 | No schema/behaviour change | Purely additive — no app path modified |
| AC10 | No DDL on connect | `create_read_only_engine` doesn't call `_create_tables` |
| AC11 | Time-series handling (size backing `system.buckets.*`) | `is_timeseries` + bucket sizing in `_audit_mongo_collection`; tested in `test_audit_mongo_collection_records_backing_bucket_for_timeseries` |
| AC12 | Bounded load (`activeDeadlineSeconds`, concurrency, low-trading window) | ⏭️ Job manifest in petrosa_k8s sibling PR |

## Test results

- `pytest tests/test_storage_inventory.py` → **24 / 24 passing**
- `pytest tests/` (full suite, regression check) → **1004 passed, 3 skipped**
- `ruff check .` → clean
- `ruff format` → clean

## Tracking

- Issue: PetroSa2/petrosa_k8s#794
- Parent epic: PetroSa2/petrosa_k8s#783
- Tech-spec: `petrosa_k8s/_bmad-output/implementation-artifacts/tech-spec-storage-inventory-audit-mongo-mysql.md` (hardened by adversarial-review findings F1–F12 on 2026-06-03)
- Sibling work pending: Task 6 (Job manifest in `petrosa_k8s`), then Tasks 7–9 once operator decisions land
