### PR TITLE
docs(799): point storage-inventory runbook at docs/manual-jobs/ path

### DIFF
--- a/docs/storage-inventory.md
+++ b/docs/storage-inventory.md
@@ -104,12 +104,16 @@ Local/laptop execution is **expected to fail** on IP allow-listing — Atlas
 and the MySQL backend are not reachable from arbitrary workstations. The
 canonical path is a one-shot `kind: Job` in the `petrosa-apps` namespace:
 
-1. `kubectl apply -f petrosa_k8s/k8s/data-extractor/storage-inventory-job.yaml`
-   (added separately under [`petrosa_k8s#794`](https://github.com/PetroSa2/petrosa_k8s/issues/794)'s
-   sibling PR — the manifest is not in this PR because the
-   `k8s/data-extractor/` directory is GitOps-auto-applied and the Job
-   placement needs explicit operator review per
-   [`project_petrosa_k8s_gitops_auto_apply.md`](../../../petrosa_k8s/docs/)).
+1. `kubectl apply -f petrosa_k8s/docs/manual-jobs/storage-inventory-job.yaml`
+   — the manifest lives in `docs/manual-jobs/` (NOT under `k8s/**`) so it
+   is invisible to `apply-k8s-changes.yml`'s `k8s/**/*.{yaml,yml}` trigger
+   glob. Placement was deferred from [`petrosa_k8s#794`](https://github.com/PetroSa2/petrosa_k8s/issues/794)
+   Task 6 and shipped under [`petrosa_k8s#799`](https://github.com/PetroSa2/petrosa_k8s/issues/799)
+   precisely because `k8s/data-extractor/` (where the sibling
+   `klines-retention-cronjob.yaml` lives) is GitOps-auto-applied — and
+   `apply-k8s-changes.sh` deletes any matching Job before re-applying on
+   every push to `main`, which would defeat the "one-shot, low-load,
+   operator-triggered" contract.
 2. Wait for completion: `kubectl wait --for=condition=complete job/storage-inventory -n petrosa-apps --timeout=20m`.
 3. Capture logs **before `ttlSecondsAfterFinished` reaps the pod**:
    `kubectl logs job/storage-inventory -n petrosa-apps > storage-inventory-$(date -u +%FT%H-%M-%SZ).log`.


### PR DESCRIPTION
Companion to [`PetroSa2/petrosa_k8s#799`](https://github.com/PetroSa2/petrosa_k8s/issues/799)
(Task 6 carve-out of [`#794`](https://github.com/PetroSa2/petrosa_k8s/issues/794),
leaf of P0 [`#783`](https://github.com/PetroSa2/petrosa_k8s/issues/783)).

## What changes

Updates `docs/storage-inventory.md`'s **In-cluster execution** section to
point at the actual shipped manifest path. The Job manifest landed under
[`PetroSa2/petrosa_k8s#804`](https://github.com/PetroSa2/petrosa_k8s/pull/804)
at `petrosa_k8s/docs/manual-jobs/storage-inventory-job.yaml` (NOT under
`k8s/**`), so the apply command in the runbook needed to follow.

Before:

```
kubectl apply -f petrosa_k8s/k8s/data-extractor/storage-inventory-job.yaml
(... vague deferral note ...)
```

After:

```
kubectl apply -f petrosa_k8s/docs/manual-jobs/storage-inventory-job.yaml
(... why docs/manual-jobs/ — apply-k8s-changes.yml's k8s/**/*.{yaml,yml}
trigger glob would re-run the Job on every push and the apply script
deletes any matching Job before re-applying it, defeating the
"one-shot, low-load, operator-triggered" contract ...)
```

## Closes

Closes AC5 of [`petrosa_k8s#799`](https://github.com/PetroSa2/petrosa_k8s/issues/799):

> AC5 (operator runbook updated): `petrosa-data-manager/docs/storage-inventory.md`
> is updated with the actual apply path + commands.

## Verification

```bash
$ pre-commit run --files docs/storage-inventory.md
# → all applicable hooks Passed
$ git diff main -- docs/storage-inventory.md
# → only the In-cluster execution step 1 paragraph changed
```

No code paths touched — pure runbook update.
