### PR TITLE
fix(mongodb): restore await on list_databases() for Motor 2.x compatibility

### DIFF
--- a/data_manager/db/mongodb_adapter.py
+++ b/data_manager/db/mongodb_adapter.py
@@ -439,7 +439,7 @@ class MongoDBAdapter(BaseAdapter):
             raise DatabaseError("Not connected to database")
 
         try:
-            cursor = self.client.list_databases()
+            cursor = await self.client.list_databases()
             return await cursor.to_list(length=None)
         except PyMongoError as e:
             raise DatabaseError(f"Failed to list databases: {e}") from e

--- a/tests/test_storage_inventory.py
+++ b/tests/test_storage_inventory.py
@@ -836,7 +836,7 @@ async def test_mongodb_adapter_list_databases_returns_listdatabases_payload():
     adapter = MongoDBAdapter.__new__(MongoDBAdapter)
     adapter._connected = True
 
-    # list_databases() returns a cursor (not a coroutine); to_list() materialises it
+    # list_databases() is a coroutine in Motor 2.x — must be awaited to get the cursor
     mock_cursor = MagicMock()
     mock_cursor.to_list = AsyncMock(
         return_value=[
@@ -845,7 +845,7 @@ async def test_mongodb_adapter_list_databases_returns_listdatabases_payload():
         ]
     )
     adapter.client = MagicMock()
-    adapter.client.list_databases = MagicMock(return_value=mock_cursor)
+    adapter.client.list_databases = AsyncMock(return_value=mock_cursor)
 
     result = await adapter.list_databases()
     assert {db["name"] for db in result} == {"petrosa", "admin"}


### PR DESCRIPTION
## Summary

Regression introduced in PR #222: removed `await` from `self.client.list_databases()`, breaking Motor 2.x where the call returns a coroutine (not a cursor directly).

### Root cause
- Motor 2.x: `list_databases()` → coroutine → **must be awaited** to get the cursor
- Motor 3.x: same pattern works fine
- PR #222 removed the outer `await`, leaving `cursor.to_list()` to fail with `'coroutine' object has no attribute 'to_list'`

### Fix
```python
# Before (broken in Motor 2.x):
cursor = self.client.list_databases()
return await cursor.to_list(length=None)

# After (Motor 2.x + 3.x compatible):
cursor = await self.client.list_databases()
return await cursor.to_list(length=None)
```

### Tests
- Updated `test_mongodb_adapter_list_databases_returns_listdatabases_payload` mock: `MagicMock → AsyncMock` for `list_databases`
- All 53 storage-inventory tests pass; full suite 1049/1050 (pre-existing `test_setup_py_imports_are_valid` env failure unrelated)

Closes #219 (AC3 cluster re-run unblocked by this fix)