### PR TITLE
[TECH-DEBT] Convert backfill_jobs.status from VARCHAR(20) to ENUM

### DIFF
--- a/data_manager/db/mysql_adapter.py
+++ b/data_manager/db/mysql_adapter.py
@@ -16,6 +16,7 @@ try:
     from sqlalchemy import (
         Column,
         DateTime,
+        Enum,
         Index,
         Integer,
         MetaData,
@@ -223,7 +224,11 @@ class MySQLAdapter(BaseAdapter):
             Column("timeframe", String(10)),
             Column("start_time", DateTime, nullable=False),
             Column("end_time", DateTime, nullable=False),
-            Column("status", String(20), nullable=False),
+            Column(
+                "status",
+                Enum("pending", "running", "completed", "failed"),
+                nullable=False,
+            ),
             Column("progress", Numeric(5, 2), default=0),
             Column("records_fetched", Integer, default=0),
             Column("records_inserted", Integer, default=0),

--- a/data_manager/scripts/migrations/004_backfill_status_enum.sql
+++ b/data_manager/scripts/migrations/004_backfill_status_enum.sql
@@ -1,0 +1,7 @@
+-- Migration 004: convert backfill_jobs.status from VARCHAR(20) to ENUM
+-- Pre-check (MANDATORY before running ALTER):
+--   SELECT DISTINCT status, COUNT(*) FROM backfill_jobs GROUP BY status;
+-- Expected values: subset of 'pending', 'running', 'completed', 'failed'.
+-- If unexpected values exist, normalize them before running this migration.
+ALTER TABLE backfill_jobs
+  MODIFY COLUMN status ENUM('pending', 'running', 'completed', 'failed') NOT NULL;


### PR DESCRIPTION
## Summary

Converts `backfill_jobs.status` column from `VARCHAR(20)` to `ENUM('pending', 'running', 'completed', 'failed')`, shrinking the index from 20-byte string keys to 1-2-byte ordinals.

## Changes

- `data_manager/db/mysql_adapter.py`: Add `Enum` to SQLAlchemy imports; change `status` column definition in `backfill_jobs` table.
- `data_manager/scripts/migrations/004_backfill_status_enum.sql`: `ALTER TABLE` migration with mandatory pre-check comment.

## Acceptance Criteria

- AC9: `SHOW CREATE TABLE backfill_jobs` shows `status ENUM('pending','running','completed','failed') NOT NULL` after migration.
- `_create_tables()` uses `Column('status', Enum(...))` matching the migration.

## Notes

- Migration includes a mandatory pre-flight `SELECT DISTINCT status` comment — operator must verify no unexpected values before running `ALTER TABLE`.
- Tested: 1066 passed, 3 skipped locally (pre-existing `test_setup.py` anaconda env failure unrelated to this change).

Closes #232

> **Parent EPIC:** PetroSa2/petrosa_k8s#821
> **Mini-EPIC parent:** PetroSa2/petrosa-data-manager#227