### PR TITLE
fix(#231): switch klines INSERT IGNORE to ON DUPLICATE KEY UPDATE

### DIFF
--- a/data_manager/db/mysql_adapter.py
+++ b/data_manager/db/mysql_adapter.py
@@ -418,13 +418,26 @@ class MySQLAdapter(BaseAdapter):
             records.append(record)
         total = len(records)
 
+        # klines tables carry `extracted_at`; use ON DUPLICATE KEY UPDATE to
+        # avoid MySQL 5.x gap-lock contention that INSERT IGNORE causes on
+        # unique-index conflicts (petrosa-data-manager#231).
+        uses_on_dup_key = "extracted_at" in table.c
+
         def _write_attempt() -> int:
             """Single write attempt — returns rowcount or raises."""
+            from sqlalchemy.dialects.mysql import insert as mysql_insert
+
             engine = self._ensure_connected()
             with engine.connect() as conn:
                 trans = conn.begin()
                 try:
-                    stmt = table.insert().prefix_with("IGNORE")
+                    if uses_on_dup_key:
+                        ins = mysql_insert(table)
+                        stmt = ins.on_duplicate_key_update(
+                            extracted_at=ins.inserted.extracted_at
+                        )
+                    else:
+                        stmt = table.insert().prefix_with("IGNORE")
                     result = conn.execute(stmt, records)
                     trans.commit()
                     return int(result.rowcount or 0)
@@ -437,9 +450,10 @@ class MySQLAdapter(BaseAdapter):
                 return retry_transient(_write_attempt)
             except IntegrityError:
                 # Non-transient: FK violation / NOT NULL / similar.
-                # Note: duplicate-key with INSERT IGNORE does NOT land here.
+                # ON DUPLICATE KEY UPDATE and INSERT IGNORE both absorb
+                # duplicate-key collisions without raising here.
                 logger.warning(
-                    "Integrity error writing to %s — not a duplicate (INSERT IGNORE absorbs those)",
+                    "Integrity error writing to %s — not a duplicate (absorbed by upsert/ignore)",
                     collection,
                 )
                 raise
@@ -462,8 +476,15 @@ class MySQLAdapter(BaseAdapter):
             self._record_write_failure(collection, "circuit_or_unknown")
             raise
 
-        duplicates = max(0, total - rowcount)
-        return WriteResult(inserted=rowcount, duplicates=duplicates, failed=0)
+        if uses_on_dup_key:
+            # ON DUPLICATE KEY UPDATE: MySQL reports 1 per insert, 2 per update.
+            # duplicates = rowcount - total; inserts = total - duplicates.
+            duplicates = max(0, rowcount - total)
+        else:
+            # INSERT IGNORE: MySQL reports 1 per insert, 0 per ignored duplicate.
+            duplicates = max(0, total - rowcount)
+        inserts = total - duplicates
+        return WriteResult(inserted=inserts, duplicates=duplicates, failed=0)
 
     def _record_write_failure(self, collection: str, reason: str) -> None:
         """Increment the write-failure counter — fire-and-forget; never raise."""

--- a/tests/test_mysql_write_retriable_accountable.py
+++ b/tests/test_mysql_write_retriable_accountable.py
@@ -331,3 +331,122 @@ def test_adapter_increments_failure_counter_on_circuit_open():
             counter.labels.return_value.inc.assert_called_once()
     finally:
         adapter.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# AC8 — klines write path uses ON DUPLICATE KEY UPDATE, not INSERT IGNORE
+# ---------------------------------------------------------------------------
+
+
+class _KlinesRec(BaseModel):
+    """Minimal Pydantic model matching the klines_* table schema."""
+
+    symbol: str
+    timestamp: str
+    open_time: str
+    close_time: str
+    interval: str
+    open_price: float
+    high_price: float
+    low_price: float
+    close_price: float
+    volume: float
+    quote_asset_volume: float
+    number_of_trades: int
+    taker_buy_base_asset_volume: float
+    taker_buy_quote_asset_volume: float
+    price_change: float | None = None
+    price_change_percent: float | None = None
+    extracted_at: str
+    extractor_version: str
+    source: str
+
+
+def _klines_rec(symbol: str = "BTCUSDT") -> _KlinesRec:
+    return _KlinesRec(
+        symbol=symbol,
+        timestamp="2024-01-01T00:00:00",
+        open_time="2024-01-01T00:00:00",
+        close_time="2024-01-01T00:04:59",
+        interval="5m",
+        open_price=50000.0,
+        high_price=50100.0,
+        low_price=49900.0,
+        close_price=50050.0,
+        volume=100.0,
+        quote_asset_volume=5000000.0,
+        number_of_trades=500,
+        taker_buy_base_asset_volume=60.0,
+        taker_buy_quote_asset_volume=3000000.0,
+        extracted_at="2024-01-01T00:05:00",
+        extractor_version="1.0.0",
+        source="binance",
+    )
+
+
+def test_klines_write_uses_on_duplicate_key_not_insert_ignore():
+    """AC8: klines write path emits ON DUPLICATE KEY UPDATE, not INSERT IGNORE."""
+    from sqlalchemy.dialects import mysql as mysql_dialect
+
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter.engine_options = {}
+    adapter.connect()
+    try:
+        records = [_klines_rec()]
+        captured_stmts: list = []
+
+        fake_result = MagicMock()
+        fake_result.rowcount = 1
+        fake_conn = MagicMock()
+
+        def _capture(stmt, *args, **kwargs):
+            captured_stmts.append(stmt)
+            return fake_result
+
+        fake_conn.execute.side_effect = _capture
+        fake_conn.begin.return_value = MagicMock()
+        fake_engine = MagicMock()
+        fake_engine.connect.return_value.__enter__.return_value = fake_conn
+
+        with patch.object(adapter, "_ensure_connected", return_value=fake_engine):
+            adapter.write(records, "klines_m5")
+
+        assert len(captured_stmts) == 1
+        sql = str(captured_stmts[0].compile(dialect=mysql_dialect.dialect()))
+        assert "ON DUPLICATE KEY UPDATE" in sql
+        assert "INSERT IGNORE" not in sql
+        assert "extracted_at" in sql
+    finally:
+        adapter.disconnect()
+
+
+def test_klines_write_duplicate_does_not_raise_and_counts_correctly():
+    """AC8: duplicate klines rows do not raise; WriteResult reflects ON DUPLICATE KEY arithmetic.
+
+    MySQL returns rowcount=1 for a new insert and rowcount=2 for an updated
+    duplicate.  For a batch of 2 rows where 1 is new and 1 is a duplicate:
+      rowcount = 1*1 + 1*2 = 3; duplicates = rowcount - total = 3 - 2 = 1.
+    """
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter.engine_options = {}
+    adapter.connect()
+    try:
+        records = [_klines_rec("BTCUSDT"), _klines_rec("ETHUSDT")]
+
+        fake_result = MagicMock()
+        fake_result.rowcount = 3  # 1 insert (1) + 1 duplicate update (2)
+        fake_conn = MagicMock()
+        fake_conn.execute.return_value = fake_result
+        fake_conn.begin.return_value = MagicMock()
+        fake_engine = MagicMock()
+        fake_engine.connect.return_value.__enter__.return_value = fake_conn
+
+        with patch.object(adapter, "_ensure_connected", return_value=fake_engine):
+            result = adapter.write(records, "klines_m5")
+
+        assert isinstance(result, WriteResult)
+        assert result.inserted == 1
+        assert result.duplicates == 1
+        assert result.failed == 0
+    finally:
+        adapter.disconnect()


### PR DESCRIPTION
## Summary

Switches the klines write path from `INSERT IGNORE` to `ON DUPLICATE KEY UPDATE extracted_at = VALUES(extracted_at)` to eliminate gap-lock contention under MySQL 5.x REPEATABLE READ isolation.

## What changed

- `mysql_adapter.py` `write()`: detects klines tables via `"extracted_at" in table.c`; routes to MySQL-dialect `on_duplicate_key_update` instead of `prefix_with("IGNORE")`
- WriteResult arithmetic corrected: MySQL returns rowcount=1 per insert, rowcount=2 per duplicate-update with ON DUPLICATE KEY UPDATE, so `duplicates = rowcount - total` (vs `total - rowcount` for INSERT IGNORE)
- 2 new tests covering AC8: SQL assertion (ON DUPLICATE KEY UPDATE present, INSERT IGNORE absent) + WriteResult count verification

## Risk

Single-file change to the highest-volume write path. Functionally equivalent: duplicates still silently absorbed; only `extracted_at` is refreshed. Can be reverted independently.

Closes #231