### PR TITLE
fix(#233): add migration 005 — ANALYZE TABLE optimizer stats refresh

### DIFF
--- a/data_manager/scripts/migrations/005_analyze_tables.sql
+++ b/data_manager/scripts/migrations/005_analyze_tables.sql
@@ -1,0 +1,10 @@
+-- Migration 005: refresh InnoDB cardinality stats after migrations 002-004
+-- Ticket: PetroSa2/petrosa-data-manager#233
+-- Reason: After dropping and adding indexes (migrations 002-004) and
+--         tradeengine#466, InnoDB statistics are stale. ANALYZE TABLE
+--         refreshes optimizer stats so the correct indexes are chosen.
+-- NOTE: ANALYZE TABLE is fast (seconds–minutes) and non-blocking for reads.
+-- Pre-condition: All migrations 002-004 AND petrosa-tradeengine#466 deployed.
+
+ANALYZE TABLE audit_logs, health_metrics, backfill_jobs;
+ANALYZE TABLE klines_m5, klines_m15, klines_m30, klines_h1, klines_d1;


### PR DESCRIPTION
## Summary

Adds migration 005 to refresh InnoDB cardinality statistics after all prior index migrations (002-004) and petrosa-tradeengine#466 are applied.

## AC10 Verification

Job ran in cluster 2026-06-13, all 8 tables returned `status='OK'`:
```
INFO ANALYZE TABLE audit_logs ... OK
INFO ANALYZE TABLE health_metrics ... OK
INFO ANALYZE TABLE backfill_jobs ... OK
INFO ANALYZE TABLE klines_m5/m15/m30/h1/d1 ... OK
INFO Migration 005 complete
```
Runtime: 19 seconds. UPDATE_TIME verified within 1 minute of run timestamp.

## Changes

- `data_manager/scripts/migrations/005_analyze_tables.sql` — documents the migration SQL

k8s Job manifest is in a companion PR on petrosa_k8s (docs/manual-jobs/).

Closes #233