### PR TITLE
feat: add (symbol, timestamp) composite indexes to audit_logs + health_metrics (dm#229)

### DIFF
--- a/data_manager/db/mysql_adapter.py
+++ b/data_manager/db/mysql_adapter.py
@@ -195,6 +195,7 @@ class MySQLAdapter(BaseAdapter):
             Column("timestamp", DateTime, nullable=False),
             Index("idx_audit_logs_dataset_timestamp", "dataset_id", "timestamp"),
             Index("idx_audit_logs_symbol", "symbol"),
+            Index("idx_audit_logs_symbol_timestamp", "symbol", "timestamp"),
         )
 
         # Health metrics table
@@ -212,6 +213,7 @@ class MySQLAdapter(BaseAdapter):
             Column("timestamp", DateTime, nullable=False),
             Index("idx_health_metrics_dataset_timestamp", "dataset_id", "timestamp"),
             Index("idx_health_metrics_symbol", "symbol"),
+            Index("idx_health_metrics_symbol_timestamp", "symbol", "timestamp"),
         )
 
         # Backfill jobs table

--- a/data_manager/scripts/migrations/006_symbol_timestamp_composites.sql
+++ b/data_manager/scripts/migrations/006_symbol_timestamp_composites.sql
@@ -1,0 +1,33 @@
+-- Migration 006: Add (symbol, timestamp) composite covering indexes to audit_logs and health_metrics.
+-- These covering indexes allow WHERE symbol = ? ORDER BY timestamp DESC queries to avoid filesorts.
+-- MySQL 5.x compatible: uses INFORMATION_SCHEMA pre-check instead of IF NOT EXISTS.
+
+SELECT COUNT(*) INTO @audit_idx_exists
+FROM INFORMATION_SCHEMA.STATISTICS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_NAME   = 'audit_logs'
+  AND INDEX_NAME   = 'idx_audit_logs_symbol_timestamp';
+
+SET @audit_sql = IF(
+    @audit_idx_exists = 0,
+    'CREATE INDEX idx_audit_logs_symbol_timestamp ON audit_logs (symbol, timestamp)',
+    'SELECT ''idx_audit_logs_symbol_timestamp already exists'' AS migration_note'
+);
+PREPARE audit_stmt FROM @audit_sql;
+EXECUTE audit_stmt;
+DEALLOCATE PREPARE audit_stmt;
+
+SELECT COUNT(*) INTO @health_idx_exists
+FROM INFORMATION_SCHEMA.STATISTICS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_NAME   = 'health_metrics'
+  AND INDEX_NAME   = 'idx_health_metrics_symbol_timestamp';
+
+SET @health_sql = IF(
+    @health_idx_exists = 0,
+    'CREATE INDEX idx_health_metrics_symbol_timestamp ON health_metrics (symbol, timestamp)',
+    'SELECT ''idx_health_metrics_symbol_timestamp already exists'' AS migration_note'
+);
+PREPARE health_stmt FROM @health_sql;
+EXECUTE health_stmt;
+DEALLOCATE PREPARE health_stmt;

--- a/tests/test_229_symbol_timestamp_indexes.py
+++ b/tests/test_229_symbol_timestamp_indexes.py
@@ -1,0 +1,66 @@
+"""Tests for data-manager#229 — (symbol, timestamp) composite indexes on audit_logs + health_metrics."""
+
+from data_manager.db.mysql_adapter import MySQLAdapter
+
+
+def _index_names(adapter, table_name):
+    table = adapter.tables[table_name]
+    return {idx.name for idx in table.indexes}
+
+
+def test_audit_logs_has_symbol_timestamp_composite_index():
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter._create_tables()
+    names = _index_names(adapter, "audit_logs")
+    assert "idx_audit_logs_symbol_timestamp" in names, (
+        f"Expected idx_audit_logs_symbol_timestamp in audit_logs indexes, got: {names}"
+    )
+
+
+def test_health_metrics_has_symbol_timestamp_composite_index():
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter._create_tables()
+    names = _index_names(adapter, "health_metrics")
+    assert "idx_health_metrics_symbol_timestamp" in names, (
+        f"Expected idx_health_metrics_symbol_timestamp in health_metrics indexes, got: {names}"
+    )
+
+
+def test_audit_logs_composite_index_columns():
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter._create_tables()
+    table = adapter.tables["audit_logs"]
+    idx = next(i for i in table.indexes if i.name == "idx_audit_logs_symbol_timestamp")
+    col_names = [c.name for c in idx.columns]
+    assert col_names == ["symbol", "timestamp"], (
+        f"Expected ['symbol', 'timestamp'], got {col_names}"
+    )
+
+
+def test_health_metrics_composite_index_columns():
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter._create_tables()
+    table = adapter.tables["health_metrics"]
+    idx = next(
+        i for i in table.indexes if i.name == "idx_health_metrics_symbol_timestamp"
+    )
+    col_names = [c.name for c in idx.columns]
+    assert col_names == ["symbol", "timestamp"], (
+        f"Expected ['symbol', 'timestamp'], got {col_names}"
+    )
+
+
+def test_migration_sql_file_exists():
+    import os
+
+    migration_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "data_manager",
+        "scripts",
+        "migrations",
+        "006_symbol_timestamp_composites.sql",
+    )
+    assert os.path.isfile(migration_path), (
+        f"Migration file 006_symbol_timestamp_composites.sql not found at {migration_path}"
+    )


### PR DESCRIPTION
## Summary

Closes #229

Adds covering composite indexes on `(symbol, timestamp)` to `audit_logs` and `health_metrics` tables. The existing single-column `symbol` indexes and `(dataset_id, timestamp)` composites cannot satisfy `WHERE symbol = ? ORDER BY timestamp DESC LIMIT n` queries without a filesort. The new indexes cover the full query pattern.

## Changes

- `data_manager/db/mysql_adapter.py`: Added `idx_audit_logs_symbol_timestamp` and `idx_health_metrics_symbol_timestamp` to the SQLAlchemy table definitions
- `data_manager/scripts/migrations/006_symbol_timestamp_composites.sql`: MySQL 5.x-compatible migration using INFORMATION_SCHEMA pre-check (no `CREATE INDEX IF NOT EXISTS`)
- `tests/test_229_symbol_timestamp_indexes.py`: 5 tests verifying index names, column order, and migration file presence

## Test Results

```
5 passed in 0.17s
1083 passed, 1 pre-existing failure (setuptools not in venv), 3 skipped
```

## Operator Step (post-deploy)

Run migration 006 on production MySQL:
```
mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE < data_manager/scripts/migrations/006_symbol_timestamp_composites.sql
```
Migration is idempotent — INFORMATION_SCHEMA pre-check skips if indexes already exist.