### PR TITLE
fix: regime endpoint returns 200+null when no data computed (dm#242)

### DIFF
--- a/data_manager/api/routes/analysis.py
+++ b/data_manager/api/routes/analysis.py
@@ -570,7 +570,21 @@ async def get_regime(
     """
     Get market regime classification for a trading pair.
 
-    Returns current market regime and confidence level.
+    Query params:
+      - pair: trading pair symbol (e.g. "BTCUSDT")
+      - period: data period hint (e.g. "1h", "1d") — stored in the analytics collection name
+
+    Response shape (200 OK):
+      {pair, metric="regime", data: {regime, volatility_level, volume_level,
+       trend_direction, confidence} | null, metadata: {timestamp, collection}}
+
+    When no regime has been computed yet for the pair, `data` is null and the
+    status is still 200. Callers must treat null `data` as "regime unknown" —
+    NOT as a wiring error. A 404 from this endpoint always means the route
+    itself is missing, never that data is absent.
+
+    503 → MongoDB adapter unavailable.
+    500 → Unexpected server error.
     """
     if not api_module.db_manager or not api_module.db_manager.mongodb_adapter:
         raise HTTPException(status_code=503, detail="Database not available")
@@ -582,9 +596,15 @@ async def get_regime(
         )
 
         if not results:
-            raise HTTPException(
-                status_code=404, detail=f"No regime data available for {pair}"
-            )
+            return {
+                "pair": pair,
+                "metric": "regime",
+                "data": None,
+                "metadata": {
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "collection": collection,
+                },
+            }
 
         r = results[0]
 

--- a/tests/test_analysis_masking.py
+++ b/tests/test_analysis_masking.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,24 +8,54 @@ from data_manager.api.routes.analysis import get_deviation, get_regime, get_seas
 
 
 @pytest.mark.asyncio
-async def test_get_regime_404_not_masked():
-    """Verify that 404 is not masked as 500 in get_regime."""
-    # Mock db_manager and mongodb_adapter
+async def test_get_regime_no_data_returns_200_with_null_data():
+    """When no regime is computed, endpoint returns 200 with data=None (not 404).
+
+    A 404 means 'route not found'. Missing computed data is a valid empty-state,
+    not a routing error. CIO's from_api_response handles data=None gracefully.
+    """
     mock_db = MagicMock()
     mock_adapter = AsyncMock()
     mock_db.mongodb_adapter = mock_adapter
-
-    # query_latest returns empty list -> triggers 404
     mock_adapter.query_latest.return_value = []
 
     with patch("data_manager.api.routes.analysis.api_module") as mock_api:
         mock_api.db_manager = mock_db
 
-        with pytest.raises(HTTPException) as exc_info:
-            await get_regime(pair="UNKNOWN", period="1h")
+        result = await get_regime(pair="UNKNOWNPAIR", period="1h")
 
-        assert exc_info.value.status_code == 404
-        assert "No regime data available" in exc_info.value.detail
+    assert isinstance(result, dict)
+    assert result["pair"] == "UNKNOWNPAIR"
+    assert result["metric"] == "regime"
+    assert result["data"] is None
+    assert "collection" in result["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_get_regime_with_data_returns_200():
+    """When regime data exists, endpoint returns 200 with populated data block."""
+    mock_db = MagicMock()
+    mock_adapter = AsyncMock()
+    mock_db.mongodb_adapter = mock_adapter
+    mock_adapter.query_latest.return_value = [
+        {
+            "regime": "CONSOLIDATION",
+            "volatility_level": "low",
+            "volume_level": "low",
+            "trend_direction": "neutral",
+            "confidence": "0.85",
+            "metadata": {"computed_at": datetime(2026, 6, 18, 12, 0, 0)},
+        }
+    ]
+
+    with patch("data_manager.api.routes.analysis.api_module") as mock_api:
+        mock_api.db_manager = mock_db
+
+        result = await get_regime(pair="BTCUSDT", period="1h")
+
+    assert result["pair"] == "BTCUSDT"
+    assert result["data"]["regime"] == "CONSOLIDATION"
+    assert result["data"]["confidence"] == "0.85"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes **[BUG] /analysis/regime returns 404 on every CIO call** (closes #242).

### Root cause (AC2)

`data_manager/api/routes/analysis.py:586` raised `HTTPException(404)` whenever the
`analytics_{pair}_regime` MongoDB collection had no entries for the requested pair.
HTTP 404 means **route not found** — not **data absent**. CIO's `context_builder`
treated this as a wiring error, logged an ERROR, and proceeded without regime context,
biasing the LLM toward conservative `pause_strategy` decisions (see cio#169).

### Fix (AC3)

Return **200 OK with `data: null`** when the collection is empty. The CIO
`RegimeAPIResponse` model already declares `data: RegimeAPIData | None = None`,
and `RegimeResult.from_api_response()` handles the null case by defaulting to
`CHOPPY/LOW` — no CIO changes needed.

| Before | After |
|--------|-------|
| `HTTP 404 No regime data available for BTCUSDT` | `HTTP 200 {"pair":"BTCUSDT", "data": null, ...}` |
| CIO logs ERROR, loses regime context | CIO decodes response, defaults to CHOPPY/LOW cleanly |

### Tests (AC4)

Updated `tests/test_analysis_masking.py`:
- `test_get_regime_no_data_returns_200_with_null_data` — verifies empty collection → 200 + data=None
- `test_get_regime_with_data_returns_200` — verifies data present → 200 + populated data block

### Docstring (AC5)

Added contract documentation to `get_regime` covering query params, response shape,
null-data semantics, and error codes.

### Test results
```
1069 passed, 3 skipped (integration + env-broken test_setup excluded, both pre-existing)
```

## Checklist
- [x] AC2: Root cause identified and documented
- [x] AC3: Fix on data-manager side (200+null); CIO contract unchanged
- [x] AC4: 2 new unit tests covering no-data and data-present paths
- [x] AC5: Docstring added to `get_regime`
- [ ] AC1: Cluster-side repro (post-deploy operator step — verify with kubectl exec)