### PR TITLE
fix: intents TTL index on received_at, self-healing + idempotent job (dm#244)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -63,6 +63,16 @@ MONGODB_URL = os.getenv(
     else f"mongodb://{MONGODB_HOST}:{MONGODB_PORT}/{MONGODB_DB}",
 )
 
+# Intents TTL retention (data-manager#244). The `intents` audit-trail collection
+# grows ~280k docs/day; without a working TTL it exhausts the Atlas M0 512 MB quota
+# and halts all cluster writes (three P0s: 2026-06-10/06-16/06-19). A TTL index on
+# the subscriber-set `received_at` datetime (NOT the publisher-supplied `timestamp`,
+# and NOT the non-existent `createdAt` that k8s#820 mistakenly targeted) caps it.
+# Default 1 day → ~280 MB steady state (~45% headroom). Read by BOTH the app-startup
+# self-heal (MongoDBAdapter.ensure_indexes) and the standalone maintenance job
+# (data_manager.maintenance.intents_ttl_index) so they never disagree.
+INTENTS_TTL_SECONDS = int(os.getenv("MONGODB_INTENTS_TTL_SECONDS", "86400"))
+
 # Feature Flags
 ENABLE_AUDITOR = os.getenv("ENABLE_AUDITOR", "true").lower() == "true"
 ENABLE_BACKFILLER = os.getenv("ENABLE_BACKFILLER", "true").lower() == "true"

--- a/data_manager/db/mongodb_adapter.py
+++ b/data_manager/db/mongodb_adapter.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     MOTOR_AVAILABLE = False
 
+import constants
 from data_manager.db.base_adapter import BaseAdapter, DatabaseError
 
 logger = logging.getLogger(__name__)
@@ -330,6 +331,19 @@ class MongoDBAdapter(BaseAdapter):
                     IndexModel([("strategy_id", ASCENDING)]),
                     IndexModel([("decision_id", ASCENDING)], sparse=True),
                     IndexModel([("timestamp", ASCENDING)]),
+                    # TTL self-heal (data-manager#244). A dedicated index name on the
+                    # subscriber-set `received_at` datetime — NOT `timestamp` (which
+                    # the line above manages as a plain index, so reusing it caused
+                    # the IndexOptionsConflict that silently dropped the TTL in
+                    # k8s#820/#884 and triggered three Atlas M0 quota P0s). Recreating
+                    # it here on every startup means the collection self-heals even if
+                    # an operator drops the index. `received_at` is always a real BSON
+                    # Date (default_factory=datetime.now(UTC)), so TTL purging works.
+                    IndexModel(
+                        [("received_at", ASCENDING)],
+                        expireAfterSeconds=constants.INTENTS_TTL_SECONDS,
+                        name="received_at_ttl_1d",
+                    ),
                 ]
             elif collection == "cio_decisions":
                 # Cross-service identifier contract (P0.2b): `cio_decisions` collection

--- a/data_manager/maintenance/intents_ttl_index.py
+++ b/data_manager/maintenance/intents_ttl_index.py
@@ -1,0 +1,416 @@
+"""Idempotent TTL-index maintenance job for the ``intents`` collection.
+
+Targets `PetroSa2/petrosa-data-manager#244` — the root-cause fix for three
+MongoDB Atlas M0 quota P0 incidents (2026-06-10, 2026-06-16, 2026-06-19).
+
+Why the previous attempts failed
+--------------------------------
+``petrosa_k8s#820`` shipped a TTL index on the ``intents`` collection keyed on
+``timestamp`` (the ticket body says ``createdAt``; the manifest actually used
+``timestamp`` — both are wrong for different reasons). That index reused the
+name ``timestamp_1``, which the application itself creates as a *plain* index on
+every consumer startup (``MongoDBAdapter.ensure_indexes``). The two definitions
+collide (``IndexOptionsConflict``), so the TTL was silently lost on the next
+deploy and documents accumulated until the 512 MB Atlas quota halted all writes.
+
+The fix
+-------
+Maintain a TTL index under a **dedicated name** (``received_at_ttl_1d``) on the
+**subscriber-set** ``received_at`` field:
+
+* ``received_at`` is always written by data-manager as a real BSON ``Date``
+  (``IntentEvent.received_at`` ``default_factory=datetime.now(UTC)``), so the TTL
+  monitor actually purges — unlike a publisher-supplied ``timestamp`` that could
+  arrive as a string, and unlike the non-existent ``createdAt``.
+* The dedicated name never collides with the app-managed ``timestamp_1`` index.
+
+This job is the operator-runnable, auditable companion to the app-startup
+self-heal added in ``MongoDBAdapter.ensure_indexes``. It is **idempotent**
+(AC2), logs the database + collection + index spec at INFO on every run (AC3),
+runs against an **explicit** database name (AC4), and audits sibling collections
+for the same class of defect (AC5).
+
+Invocation::
+
+    # Dry-run — report what would change, mutate nothing.
+    opentelemetry-instrument python -m \\
+        data_manager.maintenance.intents_ttl_index --dry-run
+
+    # Apply — create/repair the TTL index and drop legacy broken ones.
+    opentelemetry-instrument python -m \\
+        data_manager.maintenance.intents_ttl_index --apply
+
+Environment contract::
+
+    MONGODB_URL                  (required) full connection string
+    MONGODB_DATABASE             explicit DB name; falls back to MONGODB_DB,
+                                 then to "petrosa_data_manager" (AC4)
+    MONGODB_INTENTS_TTL_SECONDS  TTL window in seconds (default 86400 = 1 day)
+
+Exit codes::
+
+    0  success (apply completed, or dry-run completed cleanly)
+    2  MONGODB_URL not set
+    4  MongoDB error
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+
+try:
+    from pymongo import ASCENDING
+    from pymongo.errors import PyMongoError
+except ImportError:  # pragma: no cover - pymongo is a runtime dependency
+    ASCENDING = 1  # type: ignore[assignment]
+
+    class PyMongoError(Exception):  # type: ignore[no-redef]
+        """Fallback when pymongo is unavailable (keeps import-time safe)."""
+
+
+from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+logger = logging.getLogger(__name__)
+
+INTENTS_COLLECTION = "intents"
+TTL_FIELD = "received_at"
+TTL_INDEX_NAME = "received_at_ttl_1d"
+LEGACY_BROKEN_FIELD = "createdAt"
+DEFAULT_DATABASE = "petrosa_data_manager"
+DEFAULT_TTL_SECONDS = 86400  # 1 day
+
+# AC5 — sibling collections that could share the same unbounded-growth defect.
+# Documented decision: these are audit/financial-event trails. They are NOT
+# auto-expired by this job pending per-collection volume evidence; instead they
+# are audited (their current index state is logged) on every run, and the Atlas
+# data-size leading-indicator alert (AC6, in petrosa_k8s) is the safety net that
+# tells us if any of them starts to threaten the quota. Flip a collection to a
+# managed TTL here (with its documented timestamp field) once evidence warrants.
+SIBLING_COLLECTIONS: tuple[str, ...] = (
+    "alerts",
+    "cio_decisions",
+    "execution_events",
+    "pnl_events",
+    "trades",
+)
+SIBLING_RETENTION_DECISION = (
+    "retain — audit/financial trail; not auto-expired pending volume evidence; "
+    "covered by the Atlas data-size leading-indicator alert (data-manager#244 AC6)"
+)
+
+
+@dataclass
+class TtlIndexConfig:
+    """Resolved configuration for one TTL-index maintenance run."""
+
+    database: str = DEFAULT_DATABASE
+    ttl_seconds: int = DEFAULT_TTL_SECONDS
+    dry_run: bool = False
+
+
+@dataclass
+class TtlIndexResult:
+    """Outcome of ensuring the intents TTL index."""
+
+    database: str
+    collection: str
+    index_name: str
+    field: str
+    ttl_seconds: int
+    action: str  # one of: noop | created | collmod | recreated
+    dropped_legacy: list[str] = field(default_factory=list)
+    dry_run: bool = False
+
+
+@dataclass
+class SiblingAuditResult:
+    """Per-sibling-collection audit outcome (AC5)."""
+
+    collection: str
+    present: bool
+    ttl_indexes: dict[str, int]  # index name -> expireAfterSeconds
+    decision: str
+
+
+def resolve_database_name(environ: dict[str, str] | None = None) -> str:
+    """Resolve the EXPLICIT target database name (AC4).
+
+    Precedence: ``MONGODB_DATABASE`` (the name suggested by the ticket) →
+    ``MONGODB_DB`` (the existing repo convention) → ``petrosa_data_manager``.
+    Never derived from the connection-string path, because that is exactly how
+    k8s#820 ended up targeting the wrong database.
+    """
+    env = environ if environ is not None else os.environ
+    return env.get("MONGODB_DATABASE") or env.get("MONGODB_DB") or DEFAULT_DATABASE
+
+
+def load_config_from_env(environ: dict[str, str] | None = None) -> TtlIndexConfig:
+    """Build a :class:`TtlIndexConfig` from environment variables."""
+    env = environ if environ is not None else os.environ
+    ttl_seconds = _parse_int_env(
+        env, "MONGODB_INTENTS_TTL_SECONDS", DEFAULT_TTL_SECONDS, minimum=60
+    )
+    return TtlIndexConfig(
+        database=resolve_database_name(env),
+        ttl_seconds=ttl_seconds,
+        dry_run=False,
+    )
+
+
+def _parse_int_env(env: dict[str, str], key: str, default: int, *, minimum: int) -> int:
+    raw = env.get(key)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring non-integer %s=%r; using default %d", key, raw, default
+        )
+        return default
+    if value < minimum:
+        logger.warning("Clamping %s=%d to minimum %d", key, value, minimum)
+        return minimum
+    return value
+
+
+def _index_key_fields(meta: dict) -> list[str]:
+    """Return the ordered key field names for an index_information() entry."""
+    return [field_name for field_name, _direction in meta.get("key", [])]
+
+
+def _is_legacy_createdat_ttl(meta: dict) -> bool:
+    """True if this index is a TTL index keyed solely on the broken ``createdAt``."""
+    return "expireAfterSeconds" in meta and _index_key_fields(meta) == [
+        LEGACY_BROKEN_FIELD
+    ]
+
+
+async def ensure_intents_ttl_index(
+    db,
+    db_name: str,
+    *,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    dry_run: bool = False,
+) -> TtlIndexResult:
+    """Idempotently ensure the canonical ``received_at`` TTL index on ``intents``.
+
+    * Drops any legacy ``createdAt``-keyed TTL index (AC2).
+    * No-ops if ``received_at_ttl_1d`` already matches the desired spec (AC2).
+    * Repairs the TTL window via ``collMod`` if the index exists with the right
+      field but a different ``expireAfterSeconds`` (AC2).
+    * Creates the index if absent (AC1).
+    * Logs database + collection + index spec at INFO on every run (AC3).
+    """
+    coll = db[INTENTS_COLLECTION]
+    info = await coll.index_information()
+
+    # AC2 — drop legacy createdAt-based TTL indexes.
+    dropped_legacy: list[str] = []
+    for name, meta in info.items():
+        if _is_legacy_createdat_ttl(meta):
+            dropped_legacy.append(name)
+            if not dry_run:
+                await coll.drop_index(name)
+
+    existing = info.get(TTL_INDEX_NAME)
+    if existing is not None and _index_key_fields(existing) == [TTL_FIELD]:
+        current_ttl = existing.get("expireAfterSeconds")
+        if current_ttl == ttl_seconds:
+            action = "noop"
+        else:
+            action = "collmod"
+            if not dry_run:
+                await db.command(
+                    "collMod",
+                    INTENTS_COLLECTION,
+                    index={"name": TTL_INDEX_NAME, "expireAfterSeconds": ttl_seconds},
+                )
+    elif existing is not None:
+        # Name squatting on the wrong field — drop and recreate cleanly.
+        action = "recreated"
+        if not dry_run:
+            await coll.drop_index(TTL_INDEX_NAME)
+            await coll.create_index(
+                [(TTL_FIELD, ASCENDING)],
+                name=TTL_INDEX_NAME,
+                expireAfterSeconds=ttl_seconds,
+            )
+    else:
+        action = "created"
+        if not dry_run:
+            await coll.create_index(
+                [(TTL_FIELD, ASCENDING)],
+                name=TTL_INDEX_NAME,
+                expireAfterSeconds=ttl_seconds,
+            )
+
+    result = TtlIndexResult(
+        database=db_name,
+        collection=INTENTS_COLLECTION,
+        index_name=TTL_INDEX_NAME,
+        field=TTL_FIELD,
+        ttl_seconds=ttl_seconds,
+        action=action,
+        dropped_legacy=dropped_legacy,
+        dry_run=dry_run,
+    )
+
+    # AC3 — auditable single-line record of exactly what this run touched.
+    logger.info(
+        "intents_ttl_index: db=%s collection=%s index=%s key={%s: 1} "
+        "expireAfterSeconds=%d action=%s dropped_legacy=%s%s",
+        result.database,
+        result.collection,
+        result.index_name,
+        result.field,
+        result.ttl_seconds,
+        result.action,
+        result.dropped_legacy or "[]",
+        " (dry-run)" if dry_run else "",
+    )
+    return result
+
+
+async def audit_sibling_collections(
+    db,
+    db_name: str,
+) -> list[SiblingAuditResult]:
+    """Audit sibling collections for the same unbounded-growth defect (AC5).
+
+    Read-only: logs each sibling's current TTL-index state and the documented
+    retention decision so the audit trail is grep-able and the per-collection
+    decision is explicit.
+    """
+    present_collections = set(await db.list_collection_names())
+    results: list[SiblingAuditResult] = []
+
+    for name in SIBLING_COLLECTIONS:
+        if name not in present_collections:
+            logger.info(
+                "intents_ttl_index[audit]: db=%s collection=%s present=False "
+                "decision=%s",
+                db_name,
+                name,
+                SIBLING_RETENTION_DECISION,
+            )
+            results.append(
+                SiblingAuditResult(
+                    collection=name,
+                    present=False,
+                    ttl_indexes={},
+                    decision=SIBLING_RETENTION_DECISION,
+                )
+            )
+            continue
+
+        info = await db[name].index_information()
+        ttl_indexes = {
+            idx_name: meta["expireAfterSeconds"]
+            for idx_name, meta in info.items()
+            if "expireAfterSeconds" in meta
+        }
+        logger.info(
+            "intents_ttl_index[audit]: db=%s collection=%s present=True "
+            "ttl_indexes=%s decision=%s",
+            db_name,
+            name,
+            ttl_indexes or "{}",
+            SIBLING_RETENTION_DECISION,
+        )
+        results.append(
+            SiblingAuditResult(
+                collection=name,
+                present=True,
+                ttl_indexes=ttl_indexes,
+                decision=SIBLING_RETENTION_DECISION,
+            )
+        )
+
+    return results
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m data_manager.maintenance.intents_ttl_index",
+        description=(
+            "Idempotently ensure the received_at TTL index on the intents "
+            "collection and audit sibling collections (data-manager#244)."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report planned index changes without mutating the database.",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Create/repair the TTL index and drop legacy broken indexes.",
+    )
+    parser.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=None,
+        help="Override MONGODB_INTENTS_TTL_SECONDS for this run.",
+    )
+    return parser
+
+
+def _configure_logging() -> None:
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+
+async def _amain(argv: list[str] | None = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(argv)
+
+    config = load_config_from_env()
+    config.dry_run = bool(args.dry_run)
+    if args.ttl_seconds is not None:
+        config.ttl_seconds = max(60, args.ttl_seconds)
+
+    connection_string = os.getenv("MONGODB_URL")
+    if not connection_string:
+        logger.error("MONGODB_URL is not set; cannot connect to MongoDB")
+        return 2
+
+    adapter = MongoDBAdapter(connection_string=connection_string)
+    adapter.connect()
+    try:
+        # AC4 — select the database by EXPLICIT name, never the adapter's
+        # connection-string-derived default.
+        db = adapter.client[config.database]
+        await ensure_intents_ttl_index(
+            db,
+            config.database,
+            ttl_seconds=config.ttl_seconds,
+            dry_run=config.dry_run,
+        )
+        await audit_sibling_collections(db, config.database)
+    except PyMongoError as exc:
+        logger.error("MongoDB error during intents TTL maintenance: %s", exc)
+        return 4
+    finally:
+        adapter.disconnect()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    _configure_logging()
+    return asyncio.run(_amain(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/intents-ttl-retention.md
+++ b/docs/intents-ttl-retention.md
@@ -1,0 +1,120 @@
+# Intents TTL Retention (data-manager#244)
+
+Root-cause fix for three MongoDB Atlas M0 quota P0 incidents
+(2026-06-10, 2026-06-16, 2026-06-19) caused by the `intents` audit-trail
+collection growing without a working TTL index until it exhausted the 512 MB
+Atlas quota and halted **all** cluster writes.
+
+## What was broken
+
+`petrosa_k8s#820` (and the `#884` collMod follow-up) tried to put a TTL index on
+the `intents` collection keyed on `timestamp`. Two compounding defects:
+
+1. **Name collision.** The application creates a *plain* `timestamp_1` index on
+   the `intents` collection on every consumer startup
+   (`MongoDBAdapter.ensure_indexes`). A TTL index reusing the name `timestamp_1`
+   collides (`IndexOptionsConflict`), so the TTL was silently lost on the next
+   deploy.
+2. **Wrong field.** `timestamp` is publisher-supplied and the ticket body even
+   referred to a non-existent `createdAt` field. Neither is a reliable,
+   data-manager-controlled BSON `Date`.
+
+Live evidence (2026-06-19): 411,413 intents, 100% older than 1 day, and
+`timestamp_1` present **without** `expireAfterSeconds`.
+
+## The fix
+
+A TTL index under a **dedicated name** on the **subscriber-set** field:
+
+| Property              | Value                                            |
+| --------------------- | ------------------------------------------------ |
+| Index name            | `received_at_ttl_1d`                              |
+| Key                   | `{ received_at: 1 }`                              |
+| `expireAfterSeconds`  | `86400` (1 day; `MONGODB_INTENTS_TTL_SECONDS`)   |
+| Database              | `petrosa_data_manager` (explicit)                |
+
+`received_at` is always written by data-manager as a real `datetime`
+(`IntentEvent.received_at`, `default_factory=datetime.now(UTC)`), so the TTL
+monitor actually purges. The dedicated name never collides with the app-managed
+`timestamp_1` index.
+
+At ~280k docs/day a 1-day window holds the collection at ~280 MB (~45% headroom
+under the 512 MB Atlas M0 quota).
+
+### Two layers of defense
+
+1. **Self-heal (primary).** `MongoDBAdapter.ensure_indexes("intents")` now
+   declares `received_at_ttl_1d`, so the index is recreated on every consumer
+   startup even if an operator drops it. No manual step required after a deploy.
+2. **Standalone job (operator-runnable, auditable).**
+   `data_manager.maintenance.intents_ttl_index` creates/repairs the index on
+   demand and audits sibling collections.
+
+## Environment contract (AC4)
+
+| Variable                      | Default                | Meaning                                                        |
+| ----------------------------- | ---------------------- | -------------------------------------------------------------- |
+| `MONGODB_URL`                 | — (required)           | Full connection string.                                        |
+| `MONGODB_DATABASE`            | falls back ↓           | **Explicit** target DB name (AC4).                             |
+| `MONGODB_DB`                  | `petrosa_data_manager` | Repo-convention fallback when `MONGODB_DATABASE` is unset.     |
+| `MONGODB_INTENTS_TTL_SECONDS` | `86400`                | TTL window in seconds (min 60).                                |
+
+The job resolves the database name as
+`MONGODB_DATABASE → MONGODB_DB → "petrosa_data_manager"` and selects it
+**explicitly** — it never derives the DB from the connection-string path, which
+is exactly how `#820` ended up writing to the wrong database.
+
+## Running the job
+
+```bash
+# Dry-run — report planned changes, mutate nothing.
+opentelemetry-instrument python -m \
+    data_manager.maintenance.intents_ttl_index --dry-run
+
+# Apply — create/repair the TTL index and drop legacy broken indexes.
+opentelemetry-instrument python -m \
+    data_manager.maintenance.intents_ttl_index --apply
+```
+
+Exit codes: `0` success · `2` `MONGODB_URL` not set · `4` MongoDB error.
+
+The job logs a single auditable INFO line per run with the database, collection,
+index spec, action taken (`created` / `noop` / `collmod` / `recreated`), and any
+legacy `createdAt`-keyed TTL indexes it dropped (AC2/AC3). Confirm purging is
+actually happening — do **not** assume from index presence alone (this is the
+verification step `#820` skipped):
+
+```bash
+mongosh "$MONGODB_URL" --eval \
+  'db.getSiblingDB("petrosa_data_manager").intents.countDocuments({})'
+# Re-check after >1 day; the count must stop growing without bound.
+```
+
+## Sibling-collection retention decisions (AC5)
+
+The job audits these sibling collections every run and logs their current
+TTL-index state:
+
+| Collection         | Decision                                                    |
+| ------------------ | ----------------------------------------------------------- |
+| `alerts`           | Retain — not auto-expired pending volume evidence.          |
+| `cio_decisions`    | Retain — financial/audit trail; not auto-expired.           |
+| `execution_events` | Retain — financial/audit trail; not auto-expired.           |
+| `pnl_events`       | Retain — audit trail (watch: repeated mark-to-market rows). |
+| `trades`           | Retain — financial/audit trail; not auto-expired.           |
+
+**Rationale.** Only `intents` has demonstrated unbounded growth that breaches
+the quota (~280k docs/day, dominated by pre-CIO and multi-intent-per-decision
+volume). The siblings are audit/financial-event trails with material value and
+no current evidence of runaway growth, so auto-expiry is **deliberately not**
+applied to them yet. The leading-indicator Grafana alert (AC6, in
+`petrosa_k8s`) — WARN at `data_size / quota > 0.7`, P1 at `> 0.85` — is the
+safety net that surfaces any sibling that starts to threaten the quota, at which
+point its row in this table is flipped to a managed TTL (add it to the job's
+managed set with its documented timestamp field).
+
+## Related
+
+- `petrosa_k8s#820` — original TTL job (shipped, broken: name collision + wrong field).
+- `petrosa_k8s#884` / `#887` — collMod 7d→1d follow-up (also broken; superseded).
+- `docs/klines-retention.md` — sibling retention job (MySQL klines).

--- a/tests/test_intents_ttl_index.py
+++ b/tests/test_intents_ttl_index.py
@@ -1,0 +1,242 @@
+"""Tests for the intents TTL-index maintenance job (data-manager#244)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from data_manager.maintenance import intents_ttl_index as itx
+
+
+def _make_db(index_info_by_collection=None, collection_names=None):
+    """Build a fake motor database with AsyncMock collection methods."""
+    index_info_by_collection = index_info_by_collection or {}
+    db = MagicMock()
+    collections: dict = {}
+
+    def getitem(name):
+        if name not in collections:
+            coll = MagicMock()
+            coll.index_information = AsyncMock(
+                return_value=index_info_by_collection.get(name, {})
+            )
+            coll.create_index = AsyncMock(return_value=itx.TTL_INDEX_NAME)
+            coll.drop_index = AsyncMock()
+            collections[name] = coll
+        return collections[name]
+
+    db.__getitem__.side_effect = getitem
+    db.command = AsyncMock(return_value={"ok": 1})
+    db.list_collection_names = AsyncMock(return_value=collection_names or [])
+    db._collections = collections
+    return db
+
+
+def _ttl_meta(field: str, seconds: int) -> dict:
+    return {"key": [(field, 1)], "expireAfterSeconds": seconds}
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_database_name_prefers_mongodb_database():
+    env = {"MONGODB_DATABASE": "explicit_db", "MONGODB_DB": "legacy_db"}
+    assert itx.resolve_database_name(env) == "explicit_db"
+
+
+def test_resolve_database_name_falls_back_to_mongodb_db():
+    env = {"MONGODB_DB": "legacy_db"}
+    assert itx.resolve_database_name(env) == "legacy_db"
+
+
+def test_resolve_database_name_defaults_when_unset():
+    assert itx.resolve_database_name({}) == "petrosa_data_manager"
+    assert itx.resolve_database_name({}) == itx.DEFAULT_DATABASE
+
+
+def test_load_config_from_env_parses_ttl_seconds():
+    config = itx.load_config_from_env({"MONGODB_INTENTS_TTL_SECONDS": "3600"})
+    assert config.ttl_seconds == 3600
+
+
+def test_load_config_from_env_defaults_and_clamps():
+    assert itx.load_config_from_env({}).ttl_seconds == itx.DEFAULT_TTL_SECONDS
+    # Below the 60s minimum is clamped up.
+    assert (
+        itx.load_config_from_env({"MONGODB_INTENTS_TTL_SECONDS": "5"}).ttl_seconds == 60
+    )
+    # Non-integer falls back to default.
+    assert (
+        itx.load_config_from_env({"MONGODB_INTENTS_TTL_SECONDS": "nope"}).ttl_seconds
+        == itx.DEFAULT_TTL_SECONDS
+    )
+
+
+def test_is_legacy_createdat_ttl_detects_only_createdat_ttl():
+    assert itx._is_legacy_createdat_ttl(_ttl_meta("createdAt", 604800)) is True
+    # A TTL on received_at is not legacy.
+    assert itx._is_legacy_createdat_ttl(_ttl_meta("received_at", 86400)) is False
+    # A plain createdAt index (no TTL) is not a legacy TTL index.
+    assert itx._is_legacy_createdat_ttl({"key": [("createdAt", 1)]}) is False
+
+
+def test_index_key_fields_extracts_field_names():
+    assert itx._index_key_fields({"key": [("received_at", 1)]}) == ["received_at"]
+    assert itx._index_key_fields({"key": [("symbol", 1), ("timestamp", 1)]}) == [
+        "symbol",
+        "timestamp",
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# ensure_intents_ttl_index
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_ensure_creates_index_when_absent():
+    db = _make_db(index_info_by_collection={"intents": {"_id_": {"key": [("_id", 1)]}}})
+    result = await itx.ensure_intents_ttl_index(db, "petrosa_data_manager")
+
+    assert result.action == "created"
+    assert result.database == "petrosa_data_manager"
+    assert result.field == "received_at"
+    coll = db["intents"]
+    coll.create_index.assert_awaited_once()
+    _args, kwargs = coll.create_index.call_args
+    assert kwargs["name"] == itx.TTL_INDEX_NAME
+    assert kwargs["expireAfterSeconds"] == itx.DEFAULT_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_ensure_noop_when_index_matches_spec():
+    db = _make_db(
+        index_info_by_collection={
+            "intents": {itx.TTL_INDEX_NAME: _ttl_meta("received_at", 86400)}
+        }
+    )
+    result = await itx.ensure_intents_ttl_index(
+        db, "petrosa_data_manager", ttl_seconds=86400
+    )
+
+    assert result.action == "noop"
+    coll = db["intents"]
+    coll.create_index.assert_not_awaited()
+    coll.drop_index.assert_not_awaited()
+    db.command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_collmod_when_ttl_window_differs():
+    db = _make_db(
+        index_info_by_collection={
+            "intents": {itx.TTL_INDEX_NAME: _ttl_meta("received_at", 604800)}
+        }
+    )
+    result = await itx.ensure_intents_ttl_index(
+        db, "petrosa_data_manager", ttl_seconds=86400
+    )
+
+    assert result.action == "collmod"
+    db.command.assert_awaited_once()
+    args, kwargs = db.command.call_args
+    assert args[0] == "collMod"
+    assert args[1] == "intents"
+    assert kwargs["index"]["expireAfterSeconds"] == 86400
+
+
+@pytest.mark.asyncio
+async def test_ensure_drops_legacy_createdat_ttl():
+    db = _make_db(
+        index_info_by_collection={
+            "intents": {
+                "createdAt_1": _ttl_meta("createdAt", 604800),
+                itx.TTL_INDEX_NAME: _ttl_meta("received_at", 86400),
+            }
+        }
+    )
+    result = await itx.ensure_intents_ttl_index(
+        db, "petrosa_data_manager", ttl_seconds=86400
+    )
+
+    assert "createdAt_1" in result.dropped_legacy
+    assert result.action == "noop"  # received_at index already correct
+    db["intents"].drop_index.assert_awaited_once_with("createdAt_1")
+
+
+@pytest.mark.asyncio
+async def test_ensure_recreates_when_name_on_wrong_field():
+    db = _make_db(
+        index_info_by_collection={
+            "intents": {itx.TTL_INDEX_NAME: _ttl_meta("timestamp", 86400)}
+        }
+    )
+    result = await itx.ensure_intents_ttl_index(
+        db, "petrosa_data_manager", ttl_seconds=86400
+    )
+
+    assert result.action == "recreated"
+    coll = db["intents"]
+    coll.drop_index.assert_awaited_once_with(itx.TTL_INDEX_NAME)
+    coll.create_index.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_mutates_nothing_but_reports_action():
+    db = _make_db(index_info_by_collection={"intents": {"_id_": {"key": [("_id", 1)]}}})
+    result = await itx.ensure_intents_ttl_index(
+        db, "petrosa_data_manager", dry_run=True
+    )
+
+    assert result.action == "created"
+    assert result.dry_run is True
+    coll = db["intents"]
+    coll.create_index.assert_not_awaited()
+    coll.drop_index.assert_not_awaited()
+    db.command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_reports_legacy_drop_without_dropping():
+    db = _make_db(
+        index_info_by_collection={
+            "intents": {"createdAt_1": _ttl_meta("createdAt", 604800)}
+        }
+    )
+    result = await itx.ensure_intents_ttl_index(
+        db, "petrosa_data_manager", dry_run=True
+    )
+
+    assert result.dropped_legacy == ["createdAt_1"]
+    db["intents"].drop_index.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# audit_sibling_collections (AC5)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_audit_reports_present_and_absent_siblings():
+    db = _make_db(
+        index_info_by_collection={
+            "pnl_events": {"ttl_x": _ttl_meta("received_at", 86400)},
+            "alerts": {"_id_": {"key": [("_id", 1)]}},
+        },
+        collection_names=["intents", "pnl_events", "alerts"],
+    )
+    results = await itx.audit_sibling_collections(db, "petrosa_data_manager")
+
+    by_name = {r.collection: r for r in results}
+    # Every documented sibling is reported.
+    assert set(by_name) == set(itx.SIBLING_COLLECTIONS)
+    assert by_name["pnl_events"].present is True
+    assert by_name["pnl_events"].ttl_indexes == {"ttl_x": 86400}
+    assert by_name["alerts"].present is True
+    assert by_name["alerts"].ttl_indexes == {}
+    # cio_decisions / execution_events / trades are absent in this fixture.
+    assert by_name["trades"].present is False
+    assert all(r.decision == itx.SIBLING_RETENTION_DECISION for r in results)

--- a/tests/test_mongodb_adapter_methods.py
+++ b/tests/test_mongodb_adapter_methods.py
@@ -322,8 +322,17 @@ class TestEnsureIndexes:
         adapter.db.__getitem__ = MagicMock(return_value=coll)
         await adapter.ensure_indexes("intents")
         indexes = coll.create_indexes.call_args[0][0]
-        # intent_id (unique), strategy_id, decision_id (sparse), timestamp = 4
-        assert len(indexes) == 4
+        # intent_id (unique), strategy_id, decision_id (sparse), timestamp,
+        # received_at TTL (data-manager#244) = 5
+        assert len(indexes) == 5
+        # The received_at TTL index self-heals the Atlas-quota fix (dm#244):
+        # a dedicated name on the subscriber-set received_at datetime.
+        import constants
+
+        ttl = [ix for ix in indexes if "expireAfterSeconds" in ix.document]
+        assert len(ttl) == 1
+        assert ttl[0].document["name"] == "received_at_ttl_1d"
+        assert ttl[0].document["expireAfterSeconds"] == constants.INTENTS_TTL_SECONDS
 
     @pytest.mark.asyncio
     async def test_swallows_pymongo_error(self, adapter):


### PR DESCRIPTION
## Summary

Root-cause fix for the three MongoDB Atlas M0 quota P0 incidents (2026-06-10, 2026-06-16, 2026-06-19) caused by the `intents` collection growing without a working TTL index until it exhausted the 512 MB quota and halted all cluster writes.

### Why the prior attempts failed
`petrosa_k8s#820` / `#884` keyed the TTL on `timestamp` and reused the name `timestamp_1` — which the app itself creates as a *plain* index on every consumer startup (`MongoDBAdapter.ensure_indexes`). The two definitions collide (`IndexOptionsConflict`), so the TTL was silently dropped on the next deploy. (The ticket body's `createdAt` field never existed.)

### The fix
A TTL index under a **dedicated name** `received_at_ttl_1d` on the **subscriber-set** `received_at` datetime — always a real BSON `Date` (`IntentEvent.received_at`), so it actually purges, and the dedicated name never collides with the app-managed `timestamp_1` index.

**Two layers of defense:**
1. **Self-heal (primary):** `MongoDBAdapter.ensure_indexes("intents")` now declares the TTL index, so it's recreated on every consumer startup — survives deploys with no manual step.
2. **Standalone job (operator-runnable, auditable):** `data_manager.maintenance.intents_ttl_index`.

## Acceptance criteria

- **AC1** ✅ TTL index on `received_at`, `expireAfterSeconds=86400`.
- **AC2** ✅ Idempotent: no-ops when correct; `collMod` repairs a wrong window; drops legacy `createdAt`-keyed TTL indexes.
- **AC3** ✅ Single auditable INFO line per run (db + collection + index spec + action).
- **AC4** ✅ Explicit DB name `MONGODB_DATABASE → MONGODB_DB → petrosa_data_manager`; never derived from the connection-string path (that's how #820 hit the wrong DB).
- **AC5** ✅ Audits sibling collections (`alerts`, `cio_decisions`, `execution_events`, `pnl_events`, `trades`) with documented retention decisions (see `docs/intents-ttl-retention.md`).
- **AC6** ⏭️ Grafana Atlas data-size leading-indicator alert — requires `petrosa_k8s` (Grafana provisioning lives there); filed as a follow-up. Cross-repo, out of scope for this data-manager PR.

## Testing
- 15 new unit tests in `tests/test_intents_ttl_index.py` (create / no-op / collMod / legacy-drop / recreate / dry-run / sibling audit / env resolution).
- Updated `test_mongodb_adapter_methods.py` for the self-heal index.
- Full suite green locally: **1104 passed**, coverage **85%** (`--cov-fail-under=40`).

## Operator usage
```bash
# Dry-run
opentelemetry-instrument python -m data_manager.maintenance.intents_ttl_index --dry-run
# Apply
opentelemetry-instrument python -m data_manager.maintenance.intents_ttl_index --apply
```

Closes #244
