### PR TITLE
fix: add trades collection retention job (#246)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -73,6 +73,16 @@ MONGODB_URL = os.getenv(
 # (data_manager.maintenance.intents_ttl_index) so they never disagree.
 INTENTS_TTL_SECONDS = int(os.getenv("MONGODB_INTENTS_TTL_SECONDS", "86400"))
 
+# Trades retention (data-manager#246). The `trades` collection (raw public-trade
+# ticks written directly by the binance-futures extractor) grows unbounded at
+# ~22 MB/day and drove the 4th Atlas M0 quota P0 (2026-07-01: 870k docs / ~349 MB,
+# writes blocked). Its `timestamp`/`trade_time`/`extracted_at` fields are stored as
+# ISO-8601 STRINGS, not BSON Dates, so a native TTL index is impossible (same root
+# pattern as #244). Instead a scheduled job deletes docs older than this window via
+# lexicographic string comparison on the ISO-8601 `timestamp` field. Default 7 days;
+# revisit toward 3 days if raw ticks still trend toward the quota.
+TRADES_RETENTION_DAYS = int(os.getenv("TRADES_RETENTION_DAYS", "7"))
+
 # Feature Flags
 ENABLE_AUDITOR = os.getenv("ENABLE_AUDITOR", "true").lower() == "true"
 ENABLE_BACKFILLER = os.getenv("ENABLE_BACKFILLER", "true").lower() == "true"

--- a/data_manager/maintenance/intents_ttl_index.py
+++ b/data_manager/maintenance/intents_ttl_index.py
@@ -103,6 +103,23 @@ SIBLING_RETENTION_DECISION = (
     "covered by the Atlas data-size leading-indicator alert (data-manager#244 AC6)"
 )
 
+# Per-collection overrides to the default decision above. A sibling graduates
+# here once volume evidence warrants active retention. `trades` graduated on
+# 2026-07-01 (4th Atlas M0 P0, 870k docs / ~349 MB) — it is now actively pruned
+# by data_manager.maintenance.trades_retention via lexicographic ISO-8601 string
+# comparison (its timestamps are strings, so a native TTL index is impossible).
+SIBLING_DECISION_OVERRIDES: dict[str, str] = {
+    "trades": (
+        "actively pruned by data_manager.maintenance.trades_retention "
+        "(data-manager#246) — string timestamps preclude a native TTL index"
+    ),
+}
+
+
+def _sibling_decision(collection: str) -> str:
+    """Return the retention decision for a sibling collection."""
+    return SIBLING_DECISION_OVERRIDES.get(collection, SIBLING_RETENTION_DECISION)
+
 
 @dataclass
 class TtlIndexConfig:
@@ -291,20 +308,21 @@ async def audit_sibling_collections(
     results: list[SiblingAuditResult] = []
 
     for name in SIBLING_COLLECTIONS:
+        decision = _sibling_decision(name)
         if name not in present_collections:
             logger.info(
                 "intents_ttl_index[audit]: db=%s collection=%s present=False "
                 "decision=%s",
                 db_name,
                 name,
-                SIBLING_RETENTION_DECISION,
+                decision,
             )
             results.append(
                 SiblingAuditResult(
                     collection=name,
                     present=False,
                     ttl_indexes={},
-                    decision=SIBLING_RETENTION_DECISION,
+                    decision=decision,
                 )
             )
             continue
@@ -321,14 +339,14 @@ async def audit_sibling_collections(
             db_name,
             name,
             ttl_indexes or "{}",
-            SIBLING_RETENTION_DECISION,
+            decision,
         )
         results.append(
             SiblingAuditResult(
                 collection=name,
                 present=True,
                 ttl_indexes=ttl_indexes,
-                decision=SIBLING_RETENTION_DECISION,
+                decision=decision,
             )
         )
 

--- a/data_manager/maintenance/trades_retention.py
+++ b/data_manager/maintenance/trades_retention.py
@@ -1,0 +1,383 @@
+"""Scheduled retention job for the ``trades`` collection (data-manager#246).
+
+Targets ``PetroSa2/petrosa-data-manager#246`` — the root-cause fix for the 4th
+MongoDB Atlas M0 quota P0 (2026-07-01), the first one driven by ``trades``
+rather than ``intents`` (#244).
+
+Why a scheduled job and not a TTL index
+---------------------------------------
+The ``trades`` collection holds raw public-trade ticks written **directly by the
+binance-futures extractor** (data-manager does not persist individual trades —
+see ``consumer/message_handler.py``). Its ``timestamp`` / ``trade_time`` /
+``extracted_at`` fields are stored as **ISO-8601 strings**, not BSON ``Date``
+values. A native MongoDB TTL index requires a ``Date`` field, so TTL is
+impossible on the current schema — exactly the same root pattern as #244.
+
+Instead this job deletes documents older than a configurable window via
+**lexicographic string comparison** on the ISO-8601 ``timestamp`` field. ISO-8601
+timestamps sort lexicographically the same way they sort chronologically (that is
+the whole point of the format), so ``{"timestamp": {"$lt": cutoff_iso}}`` selects
+exactly the stale rows — mirroring the manual 2026-07-01 remediation that freed
+~184 MB. Deletion walks oldest-first in bounded batches so one run's blast radius
+is capped and a large backlog is reclaimed over successive runs.
+
+Invocation::
+
+    # Dry-run — report how many docs would be deleted, mutate nothing.
+    opentelemetry-instrument python -m \\
+        data_manager.maintenance.trades_retention --dry-run
+
+    # Apply — delete stale trades in bounded batches.
+    opentelemetry-instrument python -m \\
+        data_manager.maintenance.trades_retention --apply
+
+Environment contract::
+
+    MONGODB_URL                 (required) full connection string
+    MONGODB_DATABASE            explicit DB name; falls back to MONGODB_DB, then
+                                to "petrosa_data_manager" (never derived from the
+                                connection-string path — that is how k8s#820
+                                targeted the wrong DB)
+    TRADES_RETENTION_DAYS       retention window in days (default 7; see constants)
+    TRADES_RETENTION_COLLECTION target collection (default "trades")
+    TRADES_RETENTION_TS_FIELD   ISO-8601 string field to compare (default "timestamp")
+    TRADES_RETENTION_BATCH_SIZE docs deleted per batch (default 5000)
+    TRADES_RETENTION_MAX_BATCHES max batches per run (default 400; bounds blast radius)
+
+Exit codes::
+
+    0  success (apply completed, or dry-run completed cleanly)
+    2  MONGODB_URL not set
+    4  MongoDB error
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+try:
+    from pymongo.errors import PyMongoError
+except ImportError:  # pragma: no cover - pymongo is a runtime dependency
+
+    class PyMongoError(Exception):  # type: ignore[no-redef]
+        """Fallback when pymongo is unavailable (keeps import-time safe)."""
+
+
+import constants
+from data_manager.db.mongodb_adapter import MongoDBAdapter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATABASE = "petrosa_data_manager"
+DEFAULT_COLLECTION = "trades"
+DEFAULT_TS_FIELD = "timestamp"
+DEFAULT_BATCH_SIZE = 5000
+DEFAULT_MAX_BATCHES = 400
+
+
+@dataclass
+class TradesRetentionConfig:
+    """Resolved configuration for one trades-retention run."""
+
+    database: str = DEFAULT_DATABASE
+    collection: str = DEFAULT_COLLECTION
+    ts_field: str = DEFAULT_TS_FIELD
+    retention_days: int = constants.TRADES_RETENTION_DAYS
+    batch_size: int = DEFAULT_BATCH_SIZE
+    max_batches: int = DEFAULT_MAX_BATCHES
+    dry_run: bool = False
+
+
+@dataclass
+class TradesRetentionResult:
+    """Outcome of a trades-retention run."""
+
+    database: str
+    collection: str
+    ts_field: str
+    cutoff_iso: str
+    eligible: int
+    batches_processed: int
+    docs_deleted: int
+    capped: bool
+    dry_run: bool
+
+
+def resolve_database_name(environ: dict[str, str] | None = None) -> str:
+    """Resolve the EXPLICIT target database name.
+
+    Precedence: ``MONGODB_DATABASE`` → ``MONGODB_DB`` → ``petrosa_data_manager``.
+    Never derived from the connection-string path, because that is exactly how
+    k8s#820 ended up targeting the wrong database.
+    """
+    env = environ if environ is not None else os.environ
+    return env.get("MONGODB_DATABASE") or env.get("MONGODB_DB") or DEFAULT_DATABASE
+
+
+def compute_cutoff_iso(now: datetime, retention_days: int) -> str:
+    """Return the ISO-8601 cutoff string; docs with ``ts_field`` < this are stale.
+
+    The cutoff is rendered WITHOUT a timezone suffix (``%Y-%m-%dT%H:%M:%S``) so it
+    is a clean lexicographic lower bound: a stored value such as
+    ``2026-06-24T12:00:00Z`` or ``2026-06-24T12:00:00.123+00:00`` sharing the same
+    second-prefix is longer than the cutoff and therefore compares GREATER — i.e.
+    boundary docs are conservatively **kept**, never deleted early.
+    """
+    cutoff_dt = now - timedelta(days=retention_days)
+    return cutoff_dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def load_config_from_env(
+    environ: dict[str, str] | None = None,
+) -> TradesRetentionConfig:
+    """Build a :class:`TradesRetentionConfig` from environment variables."""
+    env = environ if environ is not None else os.environ
+    return TradesRetentionConfig(
+        database=resolve_database_name(env),
+        collection=env.get("TRADES_RETENTION_COLLECTION", DEFAULT_COLLECTION),
+        ts_field=env.get("TRADES_RETENTION_TS_FIELD", DEFAULT_TS_FIELD),
+        retention_days=_parse_int_env(
+            env, "TRADES_RETENTION_DAYS", constants.TRADES_RETENTION_DAYS, minimum=1
+        ),
+        batch_size=_parse_int_env(
+            env, "TRADES_RETENTION_BATCH_SIZE", DEFAULT_BATCH_SIZE, minimum=1
+        ),
+        max_batches=_parse_int_env(
+            env, "TRADES_RETENTION_MAX_BATCHES", DEFAULT_MAX_BATCHES, minimum=1
+        ),
+        dry_run=False,
+    )
+
+
+def _parse_int_env(env: dict[str, str], key: str, default: int, *, minimum: int) -> int:
+    raw = env.get(key)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring non-integer %s=%r; using default %d", key, raw, default
+        )
+        return default
+    if value < minimum:
+        logger.warning("Clamping %s=%d to minimum %d", key, value, minimum)
+        return minimum
+    return value
+
+
+async def prune_trades(
+    db,
+    config: TradesRetentionConfig,
+    *,
+    now: datetime | None = None,
+) -> TradesRetentionResult:
+    """Delete trades older than the retention window in bounded, oldest-first batches.
+
+    Idempotent (AC3): each run recomputes the cutoff and deletes only what is
+    currently stale; a run with nothing to delete is a clean no-op. Emits an
+    auditable single-line INFO summary with the deleted count (AC3).
+    """
+    effective_now = now if now is not None else datetime.now(UTC)
+    cutoff_iso = compute_cutoff_iso(effective_now, config.retention_days)
+    coll = db[config.collection]
+    stale_filter = {config.ts_field: {"$lt": cutoff_iso}}
+
+    eligible = await coll.count_documents(stale_filter)
+    if eligible == 0:
+        logger.info(
+            "trades_retention: db=%s collection=%s ts_field=%s cutoff=%s "
+            "eligible=0 deleted=0 action=noop%s",
+            config.database,
+            config.collection,
+            config.ts_field,
+            cutoff_iso,
+            " (dry-run)" if config.dry_run else "",
+        )
+        return TradesRetentionResult(
+            database=config.database,
+            collection=config.collection,
+            ts_field=config.ts_field,
+            cutoff_iso=cutoff_iso,
+            eligible=0,
+            batches_processed=0,
+            docs_deleted=0,
+            capped=False,
+            dry_run=config.dry_run,
+        )
+
+    if config.dry_run:
+        logger.info(
+            "trades_retention: db=%s collection=%s ts_field=%s cutoff=%s "
+            "eligible=%d deleted=0 action=dry-run",
+            config.database,
+            config.collection,
+            config.ts_field,
+            cutoff_iso,
+            eligible,
+        )
+        return TradesRetentionResult(
+            database=config.database,
+            collection=config.collection,
+            ts_field=config.ts_field,
+            cutoff_iso=cutoff_iso,
+            eligible=eligible,
+            batches_processed=0,
+            docs_deleted=0,
+            capped=eligible > 0,
+            dry_run=True,
+        )
+
+    batches_processed = 0
+    docs_deleted = 0
+    while batches_processed < config.max_batches:
+        # Select the oldest batch of stale _ids, then delete by _id. delete_many
+        # has no native limit, so this two-step keeps each batch bounded and
+        # deterministic (oldest-first).
+        cursor = (
+            coll.find(stale_filter, {"_id": 1})
+            .sort(config.ts_field, 1)
+            .limit(config.batch_size)
+        )
+        ids = [doc["_id"] async for doc in cursor]
+        if not ids:
+            break
+        result = await coll.delete_many({"_id": {"$in": ids}})
+        deleted = result.deleted_count
+        docs_deleted += deleted
+        batches_processed += 1
+        logger.info(
+            "trades_retention: %s batch %d — deleted %d (cutoff=%s)",
+            config.collection,
+            batches_processed,
+            deleted,
+            cutoff_iso,
+        )
+        if deleted == 0:
+            break
+
+    remaining = await coll.count_documents(stale_filter)
+    capped = remaining > 0
+
+    logger.info(
+        "trades_retention: db=%s collection=%s ts_field=%s cutoff=%s "
+        "eligible=%d deleted=%d batches=%d remaining=%d capped=%s action=applied",
+        config.database,
+        config.collection,
+        config.ts_field,
+        cutoff_iso,
+        eligible,
+        docs_deleted,
+        batches_processed,
+        remaining,
+        capped,
+    )
+    if capped:
+        logger.warning(
+            "trades_retention: %s hit max_batches=%d before draining backlog "
+            "(%d docs still older than cutoff); next scheduled run resumes",
+            config.collection,
+            config.max_batches,
+            remaining,
+        )
+
+    return TradesRetentionResult(
+        database=config.database,
+        collection=config.collection,
+        ts_field=config.ts_field,
+        cutoff_iso=cutoff_iso,
+        eligible=eligible,
+        batches_processed=batches_processed,
+        docs_deleted=docs_deleted,
+        capped=capped,
+        dry_run=False,
+    )
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m data_manager.maintenance.trades_retention",
+        description=(
+            "Delete trades older than the configured retention window from the "
+            "trades collection via lexicographic ISO-8601 string comparison "
+            "(data-manager#246)."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report how many docs would be deleted without mutating the database.",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Delete stale trades in bounded, oldest-first batches.",
+    )
+    parser.add_argument(
+        "--retention-days",
+        type=int,
+        default=None,
+        help="Override TRADES_RETENTION_DAYS for this run.",
+    )
+    parser.add_argument(
+        "--collection",
+        default=None,
+        help="Override TRADES_RETENTION_COLLECTION for this run.",
+    )
+    return parser
+
+
+def _configure_logging() -> None:
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+
+async def _amain(argv: list[str] | None = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(argv)
+
+    config = load_config_from_env()
+    config.dry_run = bool(args.dry_run)
+    if args.retention_days is not None:
+        config.retention_days = max(1, args.retention_days)
+    if args.collection:
+        config.collection = args.collection
+
+    connection_string = os.getenv("MONGODB_URL")
+    if not connection_string:
+        logger.error("MONGODB_URL is not set; cannot connect to MongoDB")
+        return 2
+
+    adapter = MongoDBAdapter(connection_string=connection_string)
+    adapter.connect()
+    try:
+        # Select the database by EXPLICIT name, never the adapter's
+        # connection-string-derived default (k8s#820 lesson).
+        db = adapter.client[config.database]
+        await prune_trades(db, config)
+    except PyMongoError as exc:
+        logger.error("MongoDB error during trades retention: %s", exc)
+        return 4
+    finally:
+        adapter.disconnect()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    _configure_logging()
+    return asyncio.run(_amain(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/trades-retention.md
+++ b/docs/trades-retention.md
@@ -1,0 +1,90 @@
+# Trades Retention (data-manager#246)
+
+Root-cause fix for the **4th** MongoDB Atlas M0 quota P0 (2026-07-01) — the first
+one driven by the `trades` collection rather than `intents` (#244).
+
+## What was broken
+
+The `trades` collection holds raw public-trade ticks written **directly by the
+binance-futures extractor** (data-manager itself does not persist individual
+trades — see `consumer/message_handler.py`). It had **no retention mechanism** and
+grew unbounded at ~54k docs / ~22 MB per day. On 2026-07-01 it reached
+**870,146 docs / ~349 MB dataSize**, pushing `petrosa_data_manager` logical size
+over the **512 MB Atlas M0 cap** and blocking **all** cluster writes:
+
+- distributed-lock Mongo init failing
+- data-manager returning 500 on writes
+- tradeengine boot probe failing → pod cycling (trading effectively halted;
+  this is what had blocked petrosa-tradeengine#490 AC5)
+
+The manual stopgap deleted `trades` older than 7 days (460,300 docs, ~184 MB
+freed). At ~22 MB/day the collection would re-breach the cap in ~1.5 weeks
+without a retention job.
+
+## Why not a TTL index
+
+`trades.timestamp` (and `trade_time`, `extracted_at`) are stored as **ISO-8601
+strings**, not BSON `Date` values. A native MongoDB TTL index requires a `Date`
+field, so TTL is impossible on the current schema — the same root pattern as the
+`intents` bug (#244).
+
+## The fix
+
+A scheduled maintenance job — `data_manager.maintenance.trades_retention` —
+deletes documents older than a configurable window via **lexicographic string
+comparison** on the ISO-8601 `timestamp` field. ISO-8601 timestamps sort
+lexicographically exactly as they sort chronologically, so
+`{"timestamp": {"$lt": cutoff_iso}}` selects precisely the stale rows (mirroring
+the manual remediation). Deletion walks **oldest-first in bounded batches** so a
+single run's blast radius is capped and a large backlog is reclaimed over
+successive runs.
+
+| Property              | Value                                              |
+| --------------------- | -------------------------------------------------- |
+| Collection            | `trades` (`TRADES_RETENTION_COLLECTION`)           |
+| Comparison field      | `timestamp` string (`TRADES_RETENTION_TS_FIELD`)   |
+| Retention window      | 7 days (`TRADES_RETENTION_DAYS`)                   |
+| Batch size            | 5000 docs (`TRADES_RETENTION_BATCH_SIZE`)          |
+| Max batches per run   | 400 (`TRADES_RETENTION_MAX_BATCHES`)               |
+| Database              | `petrosa_data_manager` (explicit; `MONGODB_DATABASE`) |
+
+The cutoff string is rendered without a timezone suffix (`%Y-%m-%dT%H:%M:%S`) so
+it is a clean lexicographic lower bound: a stored value like
+`2026-07-01T00:00:00Z` sharing the same second-prefix is *longer* and therefore
+compares greater, so boundary docs are conservatively **kept**, never deleted
+early.
+
+## Running it
+
+```bash
+# Dry-run — report how many docs would be deleted, mutate nothing.
+opentelemetry-instrument python -m data_manager.maintenance.trades_retention --dry-run
+
+# Apply — delete stale trades in bounded, oldest-first batches.
+opentelemetry-instrument python -m data_manager.maintenance.trades_retention --apply
+```
+
+Exit codes: `0` success, `2` `MONGODB_URL` not set, `4` MongoDB error.
+
+## Deployment
+
+This module is the **logic** half of the retention path. The scheduled
+**CronJob** manifest lives in `petrosa_k8s` (mirroring the klines-retention and
+health-metrics-retention CronJobs) and is tracked as a companion infra ticket.
+Recommended schedule: hourly, so the collection never drifts far above steady
+state between runs.
+
+## Long-term option (AC4)
+
+A better long-term fix is to store a real BSON `Date` field on `trades` at ingest
+(in the extractor) so a native TTL index can replace this scheduled job. That is
+a cross-repo change requiring extractor coordination and is deliberately left as
+a follow-up; the scheduled job is the safe, self-contained fix that stops the
+recurring P0 now.
+
+## Related
+
+- data-manager#244 — intents TTL fix (prior culprit; same string-timestamp root pattern)
+- petrosa_k8s#905 — Grafana leading-indicator alert for Atlas data-size (would warn before write-blocking)
+- petrosa-tradeengine#490 / #493 — the AC5 this P0 had blocked
+- Prior Atlas P0s: 2026-06-10 / 06-16 / 06-19 (all `intents`); 2026-07-01 (`trades`, this ticket)

--- a/tests/test_intents_ttl_index.py
+++ b/tests/test_intents_ttl_index.py
@@ -239,4 +239,11 @@ async def test_audit_reports_present_and_absent_siblings():
     assert by_name["alerts"].ttl_indexes == {}
     # cio_decisions / execution_events / trades are absent in this fixture.
     assert by_name["trades"].present is False
-    assert all(r.decision == itx.SIBLING_RETENTION_DECISION for r in results)
+    # `trades` graduated to active retention (data-manager#246); the rest keep
+    # the default "retain pending evidence" decision.
+    assert by_name["trades"].decision == itx.SIBLING_DECISION_OVERRIDES["trades"]
+    assert all(
+        r.decision == itx.SIBLING_RETENTION_DECISION
+        for r in results
+        if r.collection != "trades"
+    )

--- a/tests/test_trades_retention.py
+++ b/tests/test_trades_retention.py
@@ -1,0 +1,263 @@
+"""Tests for the trades-retention maintenance job (data-manager#246).
+
+The ``trades`` collection stores its ``timestamp`` as an ISO-8601 **string**, so
+retention is enforced by lexicographic ``$lt`` comparison rather than a BSON-Date
+TTL index. These tests use an in-memory fake collection that implements the exact
+Mongo semantics the job relies on (``count_documents`` with ``$lt`` on a string
+field, ``find().sort().limit()`` with an ``_id`` projection, and ``delete_many``
+with ``_id $in``) so the retention *behaviour* — not just the call shape — is
+verified.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from data_manager.maintenance import trades_retention as tr
+
+
+class _FakeCursor:
+    """Async-iterable cursor supporting sort/limit/projection over dict docs."""
+
+    def __init__(self, docs: list[dict], ts_field: str):
+        self._docs = docs
+        self._ts_field = ts_field
+        self._sort_field: str | None = None
+        self._sort_dir = 1
+        self._limit: int | None = None
+
+    def sort(self, field: str, direction: int) -> _FakeCursor:
+        self._sort_field = field
+        self._sort_dir = direction
+        return self
+
+    def limit(self, n: int) -> _FakeCursor:
+        self._limit = n
+        return self
+
+    def __aiter__(self):
+        docs = self._docs
+        if self._sort_field is not None:
+            docs = sorted(
+                docs,
+                key=lambda d: d[self._sort_field],
+                reverse=self._sort_dir < 0,
+            )
+        if self._limit is not None:
+            docs = docs[: self._limit]
+        # Only the projected _id is needed by the job.
+        self._iter = iter([{"_id": d["_id"]} for d in docs])
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:  # pragma: no cover - loop terminator
+            raise StopAsyncIteration
+
+
+class _FakeCollection:
+    """Minimal in-memory Mongo collection implementing the job's query surface."""
+
+    def __init__(self, docs: list[dict], ts_field: str = "timestamp"):
+        self._docs = {d["_id"]: dict(d) for d in docs}
+        self._ts_field = ts_field
+
+    @staticmethod
+    def _matches(doc: dict, query: dict) -> bool:
+        for field, cond in query.items():
+            value = doc.get(field)
+            if isinstance(cond, dict):
+                for op, operand in cond.items():
+                    if op == "$lt" and not (value < operand):
+                        return False
+                    if op == "$in" and value not in operand:
+                        return False
+            elif value != cond:
+                return False
+        return True
+
+    async def count_documents(self, query: dict) -> int:
+        return sum(1 for d in self._docs.values() if self._matches(d, query))
+
+    def find(self, query: dict, projection: dict | None = None) -> _FakeCursor:
+        matched = [d for d in self._docs.values() if self._matches(d, query)]
+        return _FakeCursor(matched, self._ts_field)
+
+    async def delete_many(self, query: dict):
+        to_delete = [_id for _id, d in self._docs.items() if self._matches(d, query)]
+        for _id in to_delete:
+            del self._docs[_id]
+
+        class _Result:
+            deleted_count = len(to_delete)
+
+        return _Result()
+
+
+class _FakeDB:
+    def __init__(self, collections: dict[str, _FakeCollection]):
+        self._collections = collections
+
+    def __getitem__(self, name: str) -> _FakeCollection:
+        return self._collections[name]
+
+
+def _iso(day: int, hour: int = 0) -> str:
+    return f"2026-07-{day:02d}T{hour:02d}:00:00Z"
+
+
+def _make_trades() -> list[dict]:
+    # 3 old (June), 2 recent (July 1) relative to a NOW of 2026-07-08.
+    return [
+        {"_id": 1, "symbol": "BTCUSDT", "timestamp": "2026-06-20T00:00:00Z"},
+        {"_id": 2, "symbol": "BTCUSDT", "timestamp": "2026-06-25T12:00:00Z"},
+        {"_id": 3, "symbol": "ETHUSDT", "timestamp": "2026-06-30T23:59:59Z"},
+        {"_id": 4, "symbol": "BTCUSDT", "timestamp": "2026-07-01T00:00:00Z"},
+        {"_id": 5, "symbol": "ETHUSDT", "timestamp": "2026-07-07T08:00:00Z"},
+    ]
+
+
+NOW = datetime(2026, 7, 8, 0, 0, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_database_name_precedence():
+    assert tr.resolve_database_name({"MONGODB_DATABASE": "explicit"}) == "explicit"
+    assert tr.resolve_database_name({"MONGODB_DB": "legacy"}) == "legacy"
+    assert tr.resolve_database_name({}) == tr.DEFAULT_DATABASE
+
+
+def test_compute_cutoff_iso_has_no_tz_suffix_and_is_lexicographic_lower_bound():
+    cutoff = tr.compute_cutoff_iso(NOW, 7)
+    assert cutoff == "2026-07-01T00:00:00"
+    # A stored value sharing the second-prefix but carrying a 'Z' is LONGER and
+    # therefore compares greater → boundary docs are kept, never deleted early.
+    assert "2026-07-01T00:00:00Z" > cutoff
+
+
+def test_load_config_from_env_clamps_and_parses():
+    cfg = tr.load_config_from_env(
+        {
+            "MONGODB_DATABASE": "db1",
+            "TRADES_RETENTION_DAYS": "3",
+            "TRADES_RETENTION_BATCH_SIZE": "0",  # clamped to 1
+            "TRADES_RETENTION_COLLECTION": "trades",
+        }
+    )
+    assert cfg.database == "db1"
+    assert cfg.retention_days == 3
+    assert cfg.batch_size == 1
+    assert cfg.collection == "trades"
+
+
+def test_load_config_from_env_ignores_non_integer():
+    cfg = tr.load_config_from_env({"TRADES_RETENTION_DAYS": "notanint"})
+    # Falls back to the constants default.
+    assert cfg.retention_days == tr.constants.TRADES_RETENTION_DAYS
+
+
+# --------------------------------------------------------------------------- #
+# prune_trades behaviour
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_prune_trades_deletes_only_docs_older_than_window():
+    coll = _FakeCollection(_make_trades())
+    db = _FakeDB({"trades": coll})
+    cfg = tr.TradesRetentionConfig(retention_days=7)
+
+    result = await tr.prune_trades(db, cfg, now=NOW)
+
+    # cutoff = 2026-07-01T00:00:00 → ids 1,2,3 (June) deleted; 4,5 kept (AC5).
+    assert result.docs_deleted == 3
+    assert result.eligible == 3
+    assert set(coll._docs.keys()) == {4, 5}
+    assert result.capped is False
+    assert result.cutoff_iso == "2026-07-01T00:00:00"
+
+
+@pytest.mark.asyncio
+async def test_prune_trades_dry_run_mutates_nothing():
+    coll = _FakeCollection(_make_trades())
+    db = _FakeDB({"trades": coll})
+    cfg = tr.TradesRetentionConfig(retention_days=7, dry_run=True)
+
+    result = await tr.prune_trades(db, cfg, now=NOW)
+
+    assert result.dry_run is True
+    assert result.eligible == 3
+    assert result.docs_deleted == 0
+    # Nothing deleted.
+    assert set(coll._docs.keys()) == {1, 2, 3, 4, 5}
+
+
+@pytest.mark.asyncio
+async def test_prune_trades_noop_when_nothing_stale():
+    coll = _FakeCollection(_make_trades())
+    db = _FakeDB({"trades": coll})
+    # 365-day window → nothing is old enough.
+    cfg = tr.TradesRetentionConfig(retention_days=365)
+
+    result = await tr.prune_trades(db, cfg, now=NOW)
+
+    assert result.docs_deleted == 0
+    assert result.eligible == 0
+    assert result.batches_processed == 0
+    assert set(coll._docs.keys()) == {1, 2, 3, 4, 5}
+
+
+@pytest.mark.asyncio
+async def test_prune_trades_batches_and_caps_blast_radius():
+    coll = _FakeCollection(_make_trades())
+    db = _FakeDB({"trades": coll})
+    # batch_size 1, max_batches 2 → only the 2 oldest of the 3 stale docs removed.
+    cfg = tr.TradesRetentionConfig(retention_days=7, batch_size=1, max_batches=2)
+
+    result = await tr.prune_trades(db, cfg, now=NOW)
+
+    assert result.docs_deleted == 2
+    assert result.batches_processed == 2
+    assert result.capped is True
+    # The two OLDEST (ids 1 and 2) go first; id 3 remains for the next run.
+    assert set(coll._docs.keys()) == {3, 4, 5}
+
+
+@pytest.mark.asyncio
+async def test_prune_trades_is_idempotent():
+    coll = _FakeCollection(_make_trades())
+    db = _FakeDB({"trades": coll})
+    cfg = tr.TradesRetentionConfig(retention_days=7)
+
+    first = await tr.prune_trades(db, cfg, now=NOW)
+    second = await tr.prune_trades(db, cfg, now=NOW)
+
+    assert first.docs_deleted == 3
+    assert second.docs_deleted == 0
+    assert second.eligible == 0
+    assert set(coll._docs.keys()) == {4, 5}
+
+
+@pytest.mark.asyncio
+async def test_prune_trades_respects_custom_collection_and_field():
+    docs = [
+        {"_id": 1, "trade_time": "2026-06-01T00:00:00Z"},
+        {"_id": 2, "trade_time": "2026-07-07T00:00:00Z"},
+    ]
+    coll = _FakeCollection(docs, ts_field="trade_time")
+    db = _FakeDB({"agg_trades": coll})
+    cfg = tr.TradesRetentionConfig(
+        collection="agg_trades", ts_field="trade_time", retention_days=7
+    )
+
+    result = await tr.prune_trades(db, cfg, now=NOW)
+
+    assert result.docs_deleted == 1
+    assert set(coll._docs.keys()) == {2}


### PR DESCRIPTION
Closes #246

## Problem
The `trades` collection (raw public-trade ticks written directly by the binance-futures extractor) had **no retention** and grew unbounded (~54k docs / ~22 MB/day). On 2026-07-01 it reached 870,146 docs / ~349 MB, pushing `petrosa_data_manager` over the 512 MB Atlas M0 cap and **blocking all cluster writes** (4th recurrence; first driven by `trades` rather than `intents`).

Its `timestamp`/`trade_time`/`extracted_at` fields are stored as **ISO-8601 strings**, not BSON `Date`, so a native TTL index is impossible — same root pattern as #244.

## Fix
New scheduled maintenance job `data_manager.maintenance.trades_retention`:
- Deletes docs older than a configurable window (default **7d**, `TRADES_RETENTION_DAYS`) via **lexicographic `$lt` string comparison** on the ISO-8601 `timestamp` field — mirroring the manual 2026-07-01 remediation. **(AC1, AC2)**
- **Oldest-first, bounded batches** (`TRADES_RETENTION_BATCH_SIZE`/`MAX_BATCHES`) so one run's blast radius is capped and a backlog drains over successive runs.
- **Idempotent**; emits an auditable single-line INFO summary with the deleted count each run. **(AC3)**
- `--dry-run` counts only, mutates nothing; `--apply` deletes. Exit codes 0/2/4. **(AC5)**
- Explicit DB selection (`MONGODB_DATABASE`→`MONGODB_DB`→`petrosa_data_manager`), never connection-string-derived (k8s#820 lesson).
- `intents_ttl_index` sibling-audit updated: `trades` graduated from "retain pending evidence" to "actively pruned by trades_retention".

## AC4 (long-term)
Storing a real BSON `Date` at ingest (extractor) to enable a native TTL is left as a cross-repo follow-up; this scheduled job is the safe self-contained fix that stops the recurring P0 now.

## Deployment
This is the retention **logic**. The scheduled **CronJob** manifest lives in `petrosa_k8s` (mirroring klines/health-metrics retention CronJobs) and is filed as a companion infra ticket.

## Tests
10 new tests using an in-memory fake collection that implements real `$lt` string / batch / `_id`-projection semantics — validates only-older-than-window deletion, dry-run no-op, idempotency, batch capping, custom collection/field. Full suite: **1115 passed, 3 skipped**.