### PR TITLE
feat: emit data_manager_mongo_data_size_bytes gauge (Atlas producer) (#248)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -133,6 +133,22 @@ AUDIT_EVALUATOR_TICK_INTERVAL = int(os.getenv("AUDIT_EVALUATOR_TICK_INTERVAL", "
 # join completeness on each tick.
 AUDIT_EVALUATOR_LOOKBACK_S = int(os.getenv("AUDIT_EVALUATOR_LOOKBACK_S", "1800"))
 
+# MongoDB logical-data-size gauge (data-manager#248) — producer half of the
+# Atlas M0 data-size leading-indicator alert (petrosa_k8s#905, dm#244 AC6).
+# Atlas M0's 512 MiB quota gates on LOGICAL uncompressed `dbStats().dataSize`
+# (NOT the compressed storageSize), which is exactly how all four 2026 P0
+# quota breaches were diagnosed. data-manager is already scraped into Grafana
+# Cloud on :9090, so registering this gauge on the existing registry makes it
+# flow with no new remote-write/Alloy/secret/CronJob. Defaults true.
+ENABLE_MONGO_DATA_SIZE_GAUGE = (
+    os.getenv("ENABLE_MONGO_DATA_SIZE_GAUGE", "true").lower() == "true"
+)
+# Refresh cadence (seconds) for the mongo data-size gauge. 60s is cheap: one
+# dbStats command per application DB per minute, well below scrape frequency.
+MONGO_DATA_SIZE_REFRESH_INTERVAL = int(
+    os.getenv("MONGO_DATA_SIZE_REFRESH_INTERVAL", "60")
+)
+
 # Scheduling Configuration
 AUDIT_INTERVAL = int(os.getenv("AUDIT_INTERVAL", "300"))  # 5 minutes
 ANALYTICS_INTERVAL = int(os.getenv("ANALYTICS_INTERVAL", "900"))  # 15 minutes

--- a/data_manager/main.py
+++ b/data_manager/main.py
@@ -454,6 +454,12 @@ class DataManagerApp:
         self.running = True
         logger.info("All components started successfully")
 
+        # Periodic MongoDB logical-data-size gauge refresh (dm#248). Created
+        # AFTER self.running=True so the `while self.running` loop runs its
+        # first iteration immediately (the series appears within one refresh
+        # interval of boot) rather than exiting on a stale False.
+        asyncio.create_task(self._run_mongo_data_size_loop())
+
         # Wait for shutdown signal
         await self._shutdown_event.wait()
 
@@ -861,6 +867,49 @@ class DataManagerApp:
             )
         except Exception as e:
             logger.error(f"Error in DrawdownScheduler: {e}", exc_info=True)
+
+    async def _run_mongo_data_size_loop(self) -> None:
+        """Periodic MongoDB logical-data-size gauge refresh (dm#248).
+
+        Producer half of the Atlas M0 data-size leading-indicator alert
+        (petrosa_k8s#905 / dm#244 AC6). Refreshes
+        ``data_manager_mongo_data_size_bytes`` from ``dbStats().dataSize``
+        every ``MONGO_DATA_SIZE_REFRESH_INTERVAL`` seconds so the series
+        flows through the already-scraped :9090 endpoint into Grafana Cloud.
+
+        The refresh is failure-isolated inside
+        :func:`refresh_mongo_data_size` (a Mongo error leaves the last-known
+        value and bumps ``..._scrape_errors_total``); the extra try/except
+        here is defense-in-depth so a genuinely unexpected error can never
+        kill the loop.
+        """
+        if not constants.ENABLE_MONGO_DATA_SIZE_GAUGE:
+            logger.info("Mongo data-size gauge disabled")
+            return
+        if not self.db_manager or not getattr(self.db_manager, "mongodb_adapter", None):
+            logger.warning("Mongo data-size gauge loop not started: no mongodb_adapter")
+            return
+
+        from data_manager.maintenance.mongo_data_size_gauge import (
+            refresh_mongo_data_size,
+        )
+
+        interval = max(
+            10,
+            int(getattr(constants, "MONGO_DATA_SIZE_REFRESH_INTERVAL", 60)),
+        )
+        adapter = self.db_manager.mongodb_adapter
+        logger.info(f"Mongo data-size gauge loop started (interval={interval}s)")
+        while self.running:
+            try:
+                await refresh_mongo_data_size(adapter)
+            except Exception as exc:
+                logger.warning(f"Mongo data-size refresh failed: {exc}")
+            try:
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                break
+        logger.info("Mongo data-size gauge loop stopped")
 
     def shutdown(self, signum, frame):
         """Handle shutdown signal."""

--- a/data_manager/maintenance/mongo_data_size_gauge.py
+++ b/data_manager/maintenance/mongo_data_size_gauge.py
@@ -1,0 +1,140 @@
+"""MongoDB logical-data-size Prometheus gauge (data-manager#248).
+
+Producer half of the MongoDB Atlas M0 data-size leading-indicator alert
+(``petrosa_k8s#905``, itself ``dm#244`` AC6).
+
+Why this exists
+---------------
+MongoDB Atlas M0 enforces its 512 MiB quota on the **logical, uncompressed**
+``dbStats().dataSize`` — NOT the compressed ``storageSize`` reported as the
+"on-disk" figure. Every one of the four 2026 production quota P0s
+(06-10 / 06-16 / 06-19 / 07-01) was diagnosed by running ``dbStats`` from the
+application and reading ``dataSize``. There is **no** Atlas data-size series in
+Grafana Cloud and there never will be on M0 — the official Grafana Cloud Atlas
+integration requires M10+. So the only reliable source of the number the quota
+actually gates on is ``db.command("dbStats")["dataSize"]`` from the app itself.
+
+data-manager is already scraped into Grafana Cloud (its Prometheus registry is
+exposed on :9090 — see ``main.py``'s ``start_http_server``). Registering this
+gauge on that **same default registry** makes it flow to Grafana Cloud with no
+new remote-write, Alloy config, secret, or push CronJob. The downstream alert
+(#905) then finalizes as, e.g.::
+
+    sum(data_manager_mongo_data_size_bytes) / (512 * 1024 * 1024) > 0.70  # WARN
+    sum(data_manager_mongo_data_size_bytes) / (512 * 1024 * 1024) > 0.85  # P1
+
+The denominator is the 512 MiB constant (M0 exposes no ``_limit`` series).
+
+Failure isolation (AC3)
+-----------------------
+:func:`refresh_mongo_data_size` never raises. A ``listDatabases`` failure or a
+per-database ``dbStats`` failure logs a warning, increments
+``data_manager_mongo_data_size_scrape_errors_total``, and leaves the last-known
+gauge value in place (Prometheus gauges retain their prior sample until the
+next successful set). The refresh is fully async (Motor) so it never blocks the
+event loop. Callers should still wrap the ``await`` defensively, but the
+function itself is the primary guard.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from prometheus_client import Counter, Gauge
+
+logger = logging.getLogger(__name__)
+
+# Atlas/Mongo system databases — excluded from the app-data total. Their bytes
+# do not count toward what the application is responsible for keeping under the
+# M0 quota, and (e.g. ``local``'s oplog) they are not app-controllable anyway.
+# Mirrors ``storage_inventory.SYSTEM_DBS`` intentionally.
+SYSTEM_DBS = frozenset({"admin", "local", "config"})
+
+# Module-level so the gauge is registered exactly once on the default registry
+# (the one ``start_http_server(METRICS_PORT)`` exposes on :9090). A per-``database``
+# label lets the alert ``sum()`` across DBs while still showing which DB
+# dominates (``petrosa_data_manager`` is ~99% of the total).
+mongo_data_size_bytes = Gauge(
+    "data_manager_mongo_data_size_bytes",
+    "Logical (uncompressed) MongoDB data size in bytes per application database, "
+    "from dbStats().dataSize. This is the figure Atlas M0 gates its 512 MiB quota "
+    "on (NOT the compressed storageSize). Producer for petrosa_k8s#905.",
+    ["database"],
+)
+
+# Companion error counter (AC3): a scrape failure increments this instead of
+# crashing the service or zeroing the gauge, so the alert can be made robust to
+# transient scrape gaps and operators can see scrape health.
+mongo_data_size_scrape_errors = Counter(
+    "data_manager_mongo_data_size_scrape_errors_total",
+    "Total failed dbStats scrapes while refreshing data_manager_mongo_data_size_bytes "
+    "(listDatabases or per-database dbStats). The gauge retains its last-known value.",
+)
+
+
+async def refresh_mongo_data_size(
+    adapter: Any,
+    *,
+    system_dbs: frozenset[str] = SYSTEM_DBS,
+) -> dict[str, int]:
+    """Refresh the ``data_manager_mongo_data_size_bytes`` gauge from ``dbStats``.
+
+    Enumerates every non-system database and sets the gauge, labelled by
+    ``database``, to that database's ``dbStats().dataSize``. Returns a
+    ``{database: data_size_bytes}`` map of the databases successfully sampled
+    (useful for tests and structured logging).
+
+    Never raises (AC3): a ``listDatabases`` error or any per-database
+    ``dbStats`` error logs a warning, increments
+    :data:`mongo_data_size_scrape_errors`, and leaves the last-known gauge
+    value(s) untouched.
+
+    Args:
+        adapter: a connected :class:`~data_manager.db.mongodb_adapter.MongoDBAdapter`
+            (or any object exposing async ``list_databases()`` and
+            ``db_stats(name)``).
+        system_dbs: database names to skip (defaults to admin/local/config).
+    """
+    try:
+        databases = await adapter.list_databases()
+    except Exception as exc:  # noqa: BLE001 — must never propagate (AC3)
+        mongo_data_size_scrape_errors.inc()
+        logger.warning(
+            "mongo_data_size: listDatabases failed; leaving last-known gauge "
+            "value(s) in place: %s",
+            exc,
+        )
+        return {}
+
+    sampled: dict[str, int] = {}
+    for db_info in databases:
+        name = (db_info or {}).get("name")
+        if not name or name in system_dbs:
+            continue
+        try:
+            stats = await adapter.db_stats(name)
+        except Exception as exc:  # noqa: BLE001 — isolate per-DB failures (AC3)
+            mongo_data_size_scrape_errors.inc()
+            logger.warning(
+                "mongo_data_size: dbStats failed for %s; keeping last-known "
+                "value for that database: %s",
+                name,
+                exc,
+            )
+            continue
+        data_size = int((stats or {}).get("dataSize", 0) or 0)
+        mongo_data_size_bytes.labels(database=name).set(data_size)
+        sampled[name] = data_size
+
+    if sampled:
+        total = sum(sampled.values())
+        logger.info(
+            "mongo_data_size: refreshed %d database(s); total dataSize=%d bytes "
+            "(%.1f MiB) — %s",
+            len(sampled),
+            total,
+            total / (1024 * 1024),
+            ", ".join(f"{k}={v}" for k, v in sorted(sampled.items())),
+        )
+    return sampled

--- a/tests/test_mongo_data_size_gauge.py
+++ b/tests/test_mongo_data_size_gauge.py
@@ -1,0 +1,164 @@
+"""Tests for the MongoDB logical-data-size gauge refresh (data-manager#248).
+
+Verifies the *producer* half of the Atlas M0 data-size leading-indicator alert
+(petrosa_k8s#905 / dm#244 AC6):
+
+- AC1/AC2 — the ``data_manager_mongo_data_size_bytes`` gauge is set per
+  application database from a mocked ``dbStats().dataSize`` payload, and system
+  databases (admin/local/config) are excluded.
+- AC3/AC4 — a ``dbStats`` exception (or a top-level ``listDatabases`` failure)
+  does NOT propagate, bumps ``data_manager_mongo_data_size_scrape_errors_total``,
+  and leaves the last-known gauge value in place.
+
+The tests drive a fake Motor-style adapter exposing the exact async surface
+``refresh_mongo_data_size`` relies on (``list_databases`` / ``db_stats``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_manager.maintenance import mongo_data_size_gauge as mdsg
+
+
+class _FakeAdapter:
+    """Minimal async stand-in for MongoDBAdapter's introspection surface.
+
+    ``databases`` is the ``listDatabases`` payload shape (list of dicts with a
+    ``name``); ``stats`` maps db-name → the ``dbStats`` dict to return, or an
+    ``Exception`` instance to raise for that database. ``list_raises`` forces
+    the top-level ``list_databases`` call to raise.
+    """
+
+    def __init__(self, databases, stats, *, list_raises: Exception | None = None):
+        self._databases = databases
+        self._stats = stats
+        self._list_raises = list_raises
+
+    async def list_databases(self):
+        if self._list_raises is not None:
+            raise self._list_raises
+        return self._databases
+
+    async def db_stats(self, name):
+        value = self._stats[name]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+def _gauge_value(database: str):
+    """Read the current gauge value for a ``database`` label, or None if unset."""
+    from prometheus_client import REGISTRY
+
+    return REGISTRY.get_sample_value(
+        "data_manager_mongo_data_size_bytes", {"database": database}
+    )
+
+
+def _scrape_errors() -> float:
+    return mdsg.mongo_data_size_scrape_errors._value.get()
+
+
+@pytest.mark.asyncio
+async def test_refresh_sets_gauge_per_app_db_and_skips_system_dbs():
+    adapter = _FakeAdapter(
+        databases=[
+            {"name": "petrosa_data_manager"},
+            {"name": "petrosa"},
+            {"name": "admin"},
+            {"name": "local"},
+            {"name": "config"},
+        ],
+        stats={
+            "petrosa_data_manager": {"dataSize": 345_000_000},
+            "petrosa": {"dataSize": 12_000_000},
+            # System DBs must never be queried; give them raising values to
+            # prove they are skipped before db_stats is called.
+            "admin": RuntimeError("should not be queried"),
+            "local": RuntimeError("should not be queried"),
+            "config": RuntimeError("should not be queried"),
+        },
+    )
+
+    refreshed = await mdsg.refresh_mongo_data_size(adapter)
+
+    assert refreshed == {
+        "petrosa_data_manager": 345_000_000,
+        "petrosa": 12_000_000,
+    }
+    assert _gauge_value("petrosa_data_manager") == 345_000_000
+    assert _gauge_value("petrosa") == 12_000_000
+    # System DBs never set a series.
+    assert _gauge_value("admin") is None
+
+
+@pytest.mark.asyncio
+async def test_missing_datasize_defaults_to_zero():
+    adapter = _FakeAdapter(
+        databases=[{"name": "empty_db"}],
+        stats={"empty_db": {"storageSize": 100}},  # no dataSize key
+    )
+
+    refreshed = await mdsg.refresh_mongo_data_size(adapter)
+
+    assert refreshed == {"empty_db": 0}
+    assert _gauge_value("empty_db") == 0
+
+
+@pytest.mark.asyncio
+async def test_dbstats_exception_is_isolated_and_does_not_propagate():
+    # First, a clean refresh establishes a known value.
+    good = _FakeAdapter(
+        databases=[{"name": "iso_db"}],
+        stats={"iso_db": {"dataSize": 500}},
+    )
+    await mdsg.refresh_mongo_data_size(good)
+    assert _gauge_value("iso_db") == 500
+
+    errors_before = _scrape_errors()
+
+    # Now dbStats raises for that DB. The call must not raise, the error
+    # counter must advance, and the last-known gauge value must be retained.
+    broken = _FakeAdapter(
+        databases=[{"name": "iso_db"}],
+        stats={"iso_db": PermissionError("not authorized on iso_db")},
+    )
+    refreshed = await mdsg.refresh_mongo_data_size(broken)
+
+    assert refreshed == {}  # nothing refreshed this pass
+    assert _scrape_errors() == errors_before + 1
+    assert _gauge_value("iso_db") == 500  # last-known value retained (AC3)
+
+
+@pytest.mark.asyncio
+async def test_one_failing_db_does_not_block_the_others():
+    adapter = _FakeAdapter(
+        databases=[{"name": "good_db"}, {"name": "bad_db"}],
+        stats={
+            "good_db": {"dataSize": 777},
+            "bad_db": RuntimeError("transient"),
+        },
+    )
+
+    errors_before = _scrape_errors()
+    refreshed = await mdsg.refresh_mongo_data_size(adapter)
+
+    assert refreshed == {"good_db": 777}
+    assert _gauge_value("good_db") == 777
+    assert _scrape_errors() == errors_before + 1
+
+
+@pytest.mark.asyncio
+async def test_list_databases_failure_is_isolated():
+    errors_before = _scrape_errors()
+    adapter = _FakeAdapter(
+        databases=[],
+        stats={},
+        list_raises=ConnectionError("mongo unreachable"),
+    )
+
+    refreshed = await mdsg.refresh_mongo_data_size(adapter)
+
+    assert refreshed == {}
+    assert _scrape_errors() == errors_before + 1

--- a/tests/unit/test_main_mongo_data_size_loop.py
+++ b/tests/unit/test_main_mongo_data_size_loop.py
@@ -1,0 +1,98 @@
+"""Coverage for ``DataManagerApp._run_mongo_data_size_loop`` (data-manager#248).
+
+The periodic MongoDB data-size gauge loop is the in-process driver for the
+Atlas M0 leading-indicator producer. These tests exercise the method directly
+(not just via inspect) so codecov sees the guard branches, one successful
+refresh iteration, and the defense-in-depth exception path.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+import constants
+from data_manager.main import DataManagerApp
+from data_manager.maintenance import mongo_data_size_gauge as mdsg
+
+
+def _app_with_adapter() -> DataManagerApp:
+    app = DataManagerApp()
+    # Minimal db_manager exposing a truthy mongodb_adapter.
+    app.db_manager = types.SimpleNamespace(mongodb_adapter=object())
+    return app
+
+
+@pytest.mark.asyncio
+async def test_loop_returns_early_when_disabled(monkeypatch):
+    monkeypatch.setattr(constants, "ENABLE_MONGO_DATA_SIZE_GAUGE", False)
+    app = _app_with_adapter()
+    app.running = True
+
+    # Must return immediately without touching the adapter.
+    called = AsyncMock()
+    monkeypatch.setattr(mdsg, "refresh_mongo_data_size", called)
+
+    await app._run_mongo_data_size_loop()
+
+    called.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_loop_returns_early_when_no_adapter(monkeypatch):
+    monkeypatch.setattr(constants, "ENABLE_MONGO_DATA_SIZE_GAUGE", True)
+    app = DataManagerApp()
+    app.db_manager = None  # no adapter available
+    app.running = True
+
+    called = AsyncMock()
+    monkeypatch.setattr(mdsg, "refresh_mongo_data_size", called)
+
+    await app._run_mongo_data_size_loop()
+
+    called.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_one_iteration_then_exits(monkeypatch):
+    monkeypatch.setattr(constants, "ENABLE_MONGO_DATA_SIZE_GAUGE", True)
+    app = _app_with_adapter()
+    app.running = True
+
+    # refresh stops the loop after the first pass so `while self.running`
+    # exits deterministically.
+    async def _refresh(adapter):
+        app.running = False
+        return {"petrosa_data_manager": 1}
+
+    refresh_mock = AsyncMock(side_effect=_refresh)
+    monkeypatch.setattr(mdsg, "refresh_mongo_data_size", refresh_mock)
+    # Neutralize the inter-iteration sleep so the test is instant.
+    monkeypatch.setattr("data_manager.main.asyncio.sleep", AsyncMock())
+
+    await app._run_mongo_data_size_loop()
+
+    refresh_mock.assert_awaited_once()
+    # The adapter handed to refresh is the one on db_manager.
+    assert refresh_mock.await_args.args[0] is app.db_manager.mongodb_adapter
+
+
+@pytest.mark.asyncio
+async def test_loop_isolates_unexpected_refresh_error(monkeypatch):
+    monkeypatch.setattr(constants, "ENABLE_MONGO_DATA_SIZE_GAUGE", True)
+    app = _app_with_adapter()
+    app.running = True
+
+    # refresh raises (defense-in-depth branch); loop must not propagate and
+    # must still terminate — we flip running off before raising.
+    async def _boom(adapter):
+        app.running = False
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(mdsg, "refresh_mongo_data_size", AsyncMock(side_effect=_boom))
+    monkeypatch.setattr("data_manager.main.asyncio.sleep", AsyncMock())
+
+    # Must not raise.
+    await app._run_mongo_data_size_loop()


### PR DESCRIPTION
## Summary

Emit a `data_manager_mongo_data_size_bytes` Prometheus gauge (labelled by `database`), refreshed every 60s from `db.command("dbStats")["dataSize"]` across the non-system application databases. This is the **producer half** of the MongoDB Atlas M0 data-size leading-indicator alert (petrosa_k8s#905, itself dm#244 AC6).

Atlas M0 enforces its 512 MiB quota on **logical uncompressed** `dbStats().dataSize` — not the compressed `storageSize` — which is exactly how all four 2026 quota P0s were diagnosed. data-manager is already scraped into Grafana Cloud on :9090, so registering the gauge on the existing default registry makes it flow with **no new remote-write, Alloy config, secret, or CronJob**.

## Changes

- `data_manager/maintenance/mongo_data_size_gauge.py` (new) — `mongo_data_size_bytes` Gauge + `mongo_data_size_scrape_errors` Counter on the default registry, and a failure-isolated `refresh_mongo_data_size(adapter)` that enumerates non-system DBs (`admin`/`local`/`config` excluded) and sets the gauge from `dbStats().dataSize`. Reuses the adapter's existing read-only `list_databases()` / `db_stats()` helpers (from the k8s#800 storage audit).
- `data_manager/main.py` — periodic `_run_mongo_data_size_loop` background task, created after `self.running = True` so the series appears within one interval of boot.
- `constants.py` — `ENABLE_MONGO_DATA_SIZE_GAUGE` (default true) + `MONGO_DATA_SIZE_REFRESH_INTERVAL` (default 60s).
- `tests/test_mongo_data_size_gauge.py` (new) — 5 tests.

## Acceptance Criteria

- **AC1** — Gauge `data_manager_mongo_data_size_bytes` registered on the default registry exposed on :9090. ✅
- **AC2** — Refreshed every 60s (`MONGO_DATA_SIZE_REFRESH_INTERVAL`) from `dbStats().dataSize`, per-DB via a `database` label (total = `sum(...)`). ✅
- **AC3** — Failure-isolated: a `dbStats`/`listDatabases` error logs a warning, increments `data_manager_mongo_data_size_scrape_errors_total`, and leaves the last-known value; never crashes/blocks (motor async). ✅
- **AC4** — Unit tests assert the gauge is set from a mocked `dbStats` payload and that a `dbStats` exception does not propagate. ✅ (5 tests)
- **AC5** — Post-deploy: confirm `data_manager_mongo_data_size_bytes` is queryable in Grafana Cloud ≈ live `dbStats().dataSize`. ⏳ operator/post-deploy step.

## Downstream

Unblocks **petrosa_k8s#905** (the alert rule): `sum(data_manager_mongo_data_size_bytes) / (512*1024*1024) > 0.70` (WARN) / `> 0.85` (P1).

## Testing

- New suite: 5 passed.
- Full suite: **1120 passed, 3 skipped**.
- `ruff check` + `ruff format --check` clean; pre-commit hooks all pass.

Closes #248
