### PR TITLE
fix: mongo data-size gauge uses connected DB, not listDatabases (#248 AC5)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -148,6 +148,16 @@ ENABLE_MONGO_DATA_SIZE_GAUGE = (
 MONGO_DATA_SIZE_REFRESH_INTERVAL = int(
     os.getenv("MONGO_DATA_SIZE_REFRESH_INTERVAL", "60")
 )
+# Optional comma-separated EXTRA database names to sample beyond the connected
+# DB (petrosa_data_manager, which dominates ~99% of logical size). The gauge
+# always samples the connected DB; these are added by explicit name via
+# dbStats. Left empty by default — deliberately NOT using listDatabases, which
+# the app's Mongo credential cannot run (see mongo_data_size_gauge docstring).
+MONGO_DATA_SIZE_DATABASES = tuple(
+    name.strip()
+    for name in os.getenv("MONGO_DATA_SIZE_DATABASES", "").split(",")
+    if name.strip()
+)
 
 # Scheduling Configuration
 AUDIT_INTERVAL = int(os.getenv("AUDIT_INTERVAL", "300"))  # 5 minutes

--- a/data_manager/main.py
+++ b/data_manager/main.py
@@ -899,10 +899,11 @@ class DataManagerApp:
             int(getattr(constants, "MONGO_DATA_SIZE_REFRESH_INTERVAL", 60)),
         )
         adapter = self.db_manager.mongodb_adapter
+        extra_dbs = tuple(getattr(constants, "MONGO_DATA_SIZE_DATABASES", ()))
         logger.info(f"Mongo data-size gauge loop started (interval={interval}s)")
         while self.running:
             try:
-                await refresh_mongo_data_size(adapter)
+                await refresh_mongo_data_size(adapter, extra_databases=extra_dbs)
             except Exception as exc:
                 logger.warning(f"Mongo data-size refresh failed: {exc}")
             try:

--- a/data_manager/maintenance/mongo_data_size_gauge.py
+++ b/data_manager/maintenance/mongo_data_size_gauge.py
@@ -25,9 +25,20 @@ new remote-write, Alloy config, secret, or push CronJob. The downstream alert
 
 The denominator is the 512 MiB constant (M0 exposes no ``_limit`` series).
 
+Why the connected DB, not ``listDatabases``
+-------------------------------------------
+The refresh runs ``dbStats`` on the adapter's **already-connected** database
+(``petrosa_data_manager``, ~99% of the cluster's logical size), not an
+enumeration via ``listDatabases``. ``listDatabases`` is a cluster-level admin
+command the application's Mongo credential is not granted — the read-only
+storage-inventory audit needs a *dedicated* clusterMonitor credential for
+exactly that. Running ``dbStats`` on the connected DB is an ordinary read the
+app can always do, and it is what every P0 diagnosis actually used. Extra
+databases can be sampled by explicit name when needed.
+
 Failure isolation (AC3)
 -----------------------
-:func:`refresh_mongo_data_size` never raises. A ``listDatabases`` failure or a
+:func:`refresh_mongo_data_size` never raises. A missing connected database or a
 per-database ``dbStats`` failure logs a warning, increments
 ``data_manager_mongo_data_size_scrape_errors_total``, and leaves the last-known
 gauge value in place (Prometheus gauges retain their prior sample until the
@@ -44,12 +55,6 @@ from typing import Any
 from prometheus_client import Counter, Gauge
 
 logger = logging.getLogger(__name__)
-
-# Atlas/Mongo system databases — excluded from the app-data total. Their bytes
-# do not count toward what the application is responsible for keeping under the
-# M0 quota, and (e.g. ``local``'s oplog) they are not app-controllable anyway.
-# Mirrors ``storage_inventory.SYSTEM_DBS`` intentionally.
-SYSTEM_DBS = frozenset({"admin", "local", "config"})
 
 # Module-level so the gauge is registered exactly once on the default registry
 # (the one ``start_http_server(METRICS_PORT)`` exposes on :9090). A per-``database``
@@ -73,47 +78,75 @@ mongo_data_size_scrape_errors = Counter(
 )
 
 
+def _resolve_targets(adapter: Any, extra_databases: tuple[str, ...]):
+    """Yield ``(db_name, motor_database_handle)`` pairs to sample.
+
+    Primary target is the adapter's **already-connected** database
+    (``adapter.db`` / ``adapter.db_name``) — ``petrosa_data_manager``, which is
+    ~99% of the cluster's logical size. Additional databases can be named
+    explicitly via ``extra_databases`` and are resolved through
+    ``adapter.client[name]``.
+
+    Deliberately does NOT call ``listDatabases``: that is a cluster-level admin
+    command the application's Mongo credential is not granted (the read-only
+    storage-inventory audit needs a *dedicated* clusterMonitor credential for
+    exactly that reason — see ``storage_inventory``), and enumerating every DB
+    is unnecessary when the app owns the one that dominates the quota. Running
+    ``dbStats`` on the connected DB is an ordinary read the app can always do.
+    """
+    seen: set[str] = set()
+    primary_name = getattr(adapter, "db_name", None)
+    primary_db = getattr(adapter, "db", None)
+    if primary_name and primary_db is not None:
+        seen.add(primary_name)
+        yield primary_name, primary_db
+
+    client = getattr(adapter, "client", None)
+    for name in extra_databases:
+        name = (name or "").strip()
+        if not name or name in seen or client is None:
+            continue
+        seen.add(name)
+        yield name, client[name]
+
+
 async def refresh_mongo_data_size(
     adapter: Any,
     *,
-    system_dbs: frozenset[str] = SYSTEM_DBS,
+    extra_databases: tuple[str, ...] = (),
 ) -> dict[str, int]:
     """Refresh the ``data_manager_mongo_data_size_bytes`` gauge from ``dbStats``.
 
-    Enumerates every non-system database and sets the gauge, labelled by
-    ``database``, to that database's ``dbStats().dataSize``. Returns a
-    ``{database: data_size_bytes}`` map of the databases successfully sampled
-    (useful for tests and structured logging).
+    Runs ``dbStats`` on the adapter's connected database (and any explicitly
+    named ``extra_databases``) and sets the gauge, labelled by ``database``, to
+    each database's ``dataSize``. Returns a ``{database: data_size_bytes}`` map
+    of the databases successfully sampled (useful for tests and logging).
 
-    Never raises (AC3): a ``listDatabases`` error or any per-database
+    Never raises (AC3): a missing connected database or any per-database
     ``dbStats`` error logs a warning, increments
     :data:`mongo_data_size_scrape_errors`, and leaves the last-known gauge
-    value(s) untouched.
+    value(s) untouched. Fully async (Motor), so it never blocks the event loop.
 
     Args:
         adapter: a connected :class:`~data_manager.db.mongodb_adapter.MongoDBAdapter`
-            (or any object exposing async ``list_databases()`` and
-            ``db_stats(name)``).
-        system_dbs: database names to skip (defaults to admin/local/config).
+            exposing ``db`` (connected Motor database), ``db_name``, and
+            ``client``.
+        extra_databases: optional extra database names to also sample by name
+            (best-effort; skipped individually on error).
     """
-    try:
-        databases = await adapter.list_databases()
-    except Exception as exc:  # noqa: BLE001 — must never propagate (AC3)
+    targets = list(_resolve_targets(adapter, extra_databases))
+    if not targets:
         mongo_data_size_scrape_errors.inc()
         logger.warning(
-            "mongo_data_size: listDatabases failed; leaving last-known gauge "
-            "value(s) in place: %s",
-            exc,
+            "mongo_data_size: adapter exposes no connected database "
+            "(db/db_name unset); leaving last-known gauge value(s) in place",
         )
         return {}
 
     sampled: dict[str, int] = {}
-    for db_info in databases:
-        name = (db_info or {}).get("name")
-        if not name or name in system_dbs:
-            continue
+    for name, db_handle in targets:
         try:
-            stats = await adapter.db_stats(name)
+            stats = await db_handle.command("dbStats")
         except Exception as exc:  # noqa: BLE001 — isolate per-DB failures (AC3)
             mongo_data_size_scrape_errors.inc()
             logger.warning(

--- a/tests/test_mongo_data_size_gauge.py
+++ b/tests/test_mongo_data_size_gauge.py
@@ -3,15 +3,17 @@
 Verifies the *producer* half of the Atlas M0 data-size leading-indicator alert
 (petrosa_k8s#905 / dm#244 AC6):
 
-- AC1/AC2 — the ``data_manager_mongo_data_size_bytes`` gauge is set per
-  application database from a mocked ``dbStats().dataSize`` payload, and system
-  databases (admin/local/config) are excluded.
-- AC3/AC4 — a ``dbStats`` exception (or a top-level ``listDatabases`` failure)
+- AC1/AC2 — the ``data_manager_mongo_data_size_bytes`` gauge is set from a
+  mocked ``dbStats().dataSize`` payload on the adapter's connected database
+  (and any explicitly named extra DBs).
+- AC3/AC4 — a ``dbStats`` exception (or an adapter with no connected database)
   does NOT propagate, bumps ``data_manager_mongo_data_size_scrape_errors_total``,
   and leaves the last-known gauge value in place.
 
-The tests drive a fake Motor-style adapter exposing the exact async surface
-``refresh_mongo_data_size`` relies on (``list_databases`` / ``db_stats``).
+The refresh runs ``dbStats`` on the connected DB via ``adapter.db.command`` —
+deliberately NOT ``listDatabases`` (a cluster admin command the app credential
+cannot run, and which is absent from the deployed adapter). The fakes below
+mirror that exact surface (``db`` / ``db_name`` / ``client``).
 """
 
 from __future__ import annotations
@@ -21,30 +23,33 @@ import pytest
 from data_manager.maintenance import mongo_data_size_gauge as mdsg
 
 
-class _FakeAdapter:
-    """Minimal async stand-in for MongoDBAdapter's introspection surface.
+class _FakeDatabase:
+    """Async stand-in for a Motor database exposing ``command('dbStats')``.
 
-    ``databases`` is the ``listDatabases`` payload shape (list of dicts with a
-    ``name``); ``stats`` maps db-name → the ``dbStats`` dict to return, or an
-    ``Exception`` instance to raise for that database. ``list_raises`` forces
-    the top-level ``list_databases`` call to raise.
+    ``stats`` is the dict to return, or an ``Exception`` instance to raise.
     """
 
-    def __init__(self, databases, stats, *, list_raises: Exception | None = None):
-        self._databases = databases
+    def __init__(self, stats):
         self._stats = stats
-        self._list_raises = list_raises
 
-    async def list_databases(self):
-        if self._list_raises is not None:
-            raise self._list_raises
-        return self._databases
+    async def command(self, name):
+        assert name == "dbStats"
+        if isinstance(self._stats, Exception):
+            raise self._stats
+        return self._stats
 
-    async def db_stats(self, name):
-        value = self._stats[name]
-        if isinstance(value, Exception):
-            raise value
-        return value
+
+class _FakeAdapter:
+    """Minimal stand-in for MongoDBAdapter's connected surface.
+
+    ``db_name`` + ``db`` model the connected database; ``client`` maps extra
+    database names to :class:`_FakeDatabase` handles (as ``client[name]``).
+    """
+
+    def __init__(self, db_name, db, *, client=None):
+        self.db_name = db_name
+        self.db = db
+        self.client = client or {}
 
 
 def _gauge_value(database: str):
@@ -61,44 +66,37 @@ def _scrape_errors() -> float:
 
 
 @pytest.mark.asyncio
-async def test_refresh_sets_gauge_per_app_db_and_skips_system_dbs():
+async def test_refresh_sets_gauge_for_connected_db():
     adapter = _FakeAdapter(
-        databases=[
-            {"name": "petrosa_data_manager"},
-            {"name": "petrosa"},
-            {"name": "admin"},
-            {"name": "local"},
-            {"name": "config"},
-        ],
-        stats={
-            "petrosa_data_manager": {"dataSize": 345_000_000},
-            "petrosa": {"dataSize": 12_000_000},
-            # System DBs must never be queried; give them raising values to
-            # prove they are skipped before db_stats is called.
-            "admin": RuntimeError("should not be queried"),
-            "local": RuntimeError("should not be queried"),
-            "config": RuntimeError("should not be queried"),
-        },
+        "petrosa_data_manager", _FakeDatabase({"dataSize": 345_000_000})
     )
 
     refreshed = await mdsg.refresh_mongo_data_size(adapter)
 
-    assert refreshed == {
-        "petrosa_data_manager": 345_000_000,
-        "petrosa": 12_000_000,
-    }
+    assert refreshed == {"petrosa_data_manager": 345_000_000}
     assert _gauge_value("petrosa_data_manager") == 345_000_000
-    assert _gauge_value("petrosa") == 12_000_000
-    # System DBs never set a series.
-    assert _gauge_value("admin") is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_samples_extra_databases_by_name():
+    adapter = _FakeAdapter(
+        "petrosa_data_manager",
+        _FakeDatabase({"dataSize": 300}),
+        client={"petrosa": _FakeDatabase({"dataSize": 25})},
+    )
+
+    refreshed = await mdsg.refresh_mongo_data_size(
+        adapter, extra_databases=("petrosa",)
+    )
+
+    assert refreshed == {"petrosa_data_manager": 300, "petrosa": 25}
+    assert _gauge_value("petrosa_data_manager") == 300
+    assert _gauge_value("petrosa") == 25
 
 
 @pytest.mark.asyncio
 async def test_missing_datasize_defaults_to_zero():
-    adapter = _FakeAdapter(
-        databases=[{"name": "empty_db"}],
-        stats={"empty_db": {"storageSize": 100}},  # no dataSize key
-    )
+    adapter = _FakeAdapter("empty_db", _FakeDatabase({"storageSize": 100}))
 
     refreshed = await mdsg.refresh_mongo_data_size(adapter)
 
@@ -107,42 +105,36 @@ async def test_missing_datasize_defaults_to_zero():
 
 
 @pytest.mark.asyncio
-async def test_dbstats_exception_is_isolated_and_does_not_propagate():
-    # First, a clean refresh establishes a known value.
-    good = _FakeAdapter(
-        databases=[{"name": "iso_db"}],
-        stats={"iso_db": {"dataSize": 500}},
-    )
+async def test_dbstats_exception_is_isolated_and_retains_last_value():
+    # A clean refresh establishes a known value.
+    good = _FakeAdapter("iso_db", _FakeDatabase({"dataSize": 500}))
     await mdsg.refresh_mongo_data_size(good)
     assert _gauge_value("iso_db") == 500
 
     errors_before = _scrape_errors()
 
-    # Now dbStats raises for that DB. The call must not raise, the error
-    # counter must advance, and the last-known gauge value must be retained.
+    # Now dbStats raises. The call must not raise, the error counter must
+    # advance, and the last-known gauge value must be retained (AC3).
     broken = _FakeAdapter(
-        databases=[{"name": "iso_db"}],
-        stats={"iso_db": PermissionError("not authorized on iso_db")},
+        "iso_db", _FakeDatabase(PermissionError("not authorized on iso_db"))
     )
     refreshed = await mdsg.refresh_mongo_data_size(broken)
 
-    assert refreshed == {}  # nothing refreshed this pass
+    assert refreshed == {}
     assert _scrape_errors() == errors_before + 1
-    assert _gauge_value("iso_db") == 500  # last-known value retained (AC3)
+    assert _gauge_value("iso_db") == 500
 
 
 @pytest.mark.asyncio
-async def test_one_failing_db_does_not_block_the_others():
+async def test_one_failing_extra_db_does_not_block_connected_db():
     adapter = _FakeAdapter(
-        databases=[{"name": "good_db"}, {"name": "bad_db"}],
-        stats={
-            "good_db": {"dataSize": 777},
-            "bad_db": RuntimeError("transient"),
-        },
+        "good_db",
+        _FakeDatabase({"dataSize": 777}),
+        client={"bad_db": _FakeDatabase(RuntimeError("transient"))},
     )
 
     errors_before = _scrape_errors()
-    refreshed = await mdsg.refresh_mongo_data_size(adapter)
+    refreshed = await mdsg.refresh_mongo_data_size(adapter, extra_databases=("bad_db",))
 
     assert refreshed == {"good_db": 777}
     assert _gauge_value("good_db") == 777
@@ -150,15 +142,28 @@ async def test_one_failing_db_does_not_block_the_others():
 
 
 @pytest.mark.asyncio
-async def test_list_databases_failure_is_isolated():
+async def test_no_connected_database_is_isolated():
     errors_before = _scrape_errors()
-    adapter = _FakeAdapter(
-        databases=[],
-        stats={},
-        list_raises=ConnectionError("mongo unreachable"),
-    )
+    # Adapter never connected: db is None, db_name empty.
+    adapter = _FakeAdapter("", None)
 
     refreshed = await mdsg.refresh_mongo_data_size(adapter)
 
     assert refreshed == {}
     assert _scrape_errors() == errors_before + 1
+
+
+@pytest.mark.asyncio
+async def test_extra_db_duplicate_of_connected_is_skipped():
+    # Passing the connected DB name again must not double-count it.
+    adapter = _FakeAdapter(
+        "petrosa_data_manager",
+        _FakeDatabase({"dataSize": 100}),
+        client={"petrosa_data_manager": _FakeDatabase({"dataSize": 999})},
+    )
+
+    refreshed = await mdsg.refresh_mongo_data_size(
+        adapter, extra_databases=("petrosa_data_manager",)
+    )
+
+    assert refreshed == {"petrosa_data_manager": 100}

--- a/tests/unit/test_main_mongo_data_size_loop.py
+++ b/tests/unit/test_main_mongo_data_size_loop.py
@@ -63,7 +63,7 @@ async def test_loop_runs_one_iteration_then_exits(monkeypatch):
 
     # refresh stops the loop after the first pass so `while self.running`
     # exits deterministically.
-    async def _refresh(adapter):
+    async def _refresh(adapter, **kwargs):
         app.running = False
         return {"petrosa_data_manager": 1}
 
@@ -87,7 +87,7 @@ async def test_loop_isolates_unexpected_refresh_error(monkeypatch):
 
     # refresh raises (defense-in-depth branch); loop must not propagate and
     # must still terminate — we flip running off before raising.
-    async def _boom(adapter):
+    async def _boom(adapter, **kwargs):
         app.running = False
         raise RuntimeError("unexpected")
 


### PR DESCRIPTION
## Summary — corrective fix for #248 (AC5 failed live)

Live AC5 verification of #248 (merged as `d4f8460`) found the gauge **was never populated in production**: the 60s refresh failed on every cycle with `'MongoDBAdapter' object has no attribute 'list_databases'` — 399 consecutive scrape errors, `data_manager_mongo_data_size_bytes` absent from `/metrics`.

## Root cause (two real problems)

1. **Wrong command / privilege.** #248 enumerated databases via `adapter.list_databases()` → `listDatabases`, a **cluster-level admin command the app's Mongo credential is not granted** (the read-only storage-inventory audit needs a *dedicated* clusterMonitor credential for exactly this). `dbStats` on the connected DB is an ordinary read the app can always do — and is how all four 2026 quota P0s were diagnosed.
2. **Stale deployed adapter.** The running image (`r190-d4f8460`) ships an `mongodb_adapter.py` missing `list_databases`/`db_stats`/`find_filtered` despite those being on `main` — a separate image-staleness anomaly (filed separately). The call `AttributeError`'d regardless of privilege.

## Fix

Sample the adapter's **already-connected** database via `adapter.db.command("dbStats")` (label `petrosa_data_manager`, ~99% of logical size), plus any explicitly named `MONGO_DATA_SIZE_DATABASES`. No `listDatabases`, no privileged admin command, no dependency on adapter helper methods — works with the app credential and any adapter version.

**Verified live with the app credential:** `db.command("dbStats")["dataSize"]` = **337.5 MiB** (consistent with ~330 MiB at #248 filing).

## Changes
- `data_manager/maintenance/mongo_data_size_gauge.py` — `_resolve_targets()` (connected DB + explicit extras) + `dbStats` on each; dropped `list_databases()`/`SYSTEM_DBS` enumeration.
- `constants.py` — `MONGO_DATA_SIZE_DATABASES` (optional comma-sep extras; default just the connected DB).
- `data_manager/main.py` — loop passes `extra_databases`.
- Tests rewritten for the connected-DB surface (7 gauge + 4 loop; full suite 1126 passed).

## AC status
AC1–AC4 ✅. **AC5 will be re-verified live** once this deploys (query `data_manager_mongo_data_size_bytes` in Grafana Cloud ≈ `dbStats().dataSize`).

Re: #248
