### PR TITLE
fix(observability): emit mongo data-size gauge via OTLP not prometheus :9090 (#252)

### DIFF
--- a/data_manager/main.py
+++ b/data_manager/main.py
@@ -873,9 +873,10 @@ class DataManagerApp:
 
         Producer half of the Atlas M0 data-size leading-indicator alert
         (petrosa_k8s#905 / dm#244 AC6). Refreshes
-        ``data_manager_mongo_data_size_bytes`` from ``dbStats().dataSize``
-        every ``MONGO_DATA_SIZE_REFRESH_INTERVAL`` seconds so the series
-        flows through the already-scraped :9090 endpoint into Grafana Cloud.
+        the ``data_manager_mongo_data_size_bytes`` cache from ``dbStats().dataSize``
+        every ``MONGO_DATA_SIZE_REFRESH_INTERVAL`` seconds; the OTLP
+        ObservableGauge then exports it into Grafana Cloud (dm#252 — the
+        prometheus_client :9090 registry is NOT scraped there).
 
         The refresh is failure-isolated inside
         :func:`refresh_mongo_data_size` (a Mongo error leaves the last-known

--- a/data_manager/maintenance/mongo_data_size_gauge.py
+++ b/data_manager/maintenance/mongo_data_size_gauge.py
@@ -1,7 +1,7 @@
-"""MongoDB logical-data-size Prometheus gauge (data-manager#248).
+"""MongoDB logical-data-size gauge, exported via OTLP (data-manager#248, #252).
 
 Producer half of the MongoDB Atlas M0 data-size leading-indicator alert
-(``petrosa_k8s#905``, itself ``dm#244`` AC6).
+(``petrosa_k8s#905`` / ``petrosa_k8s#920``, itself ``dm#244`` AC6).
 
 Why this exists
 ---------------
@@ -14,16 +14,36 @@ Grafana Cloud and there never will be on M0 — the official Grafana Cloud Atlas
 integration requires M10+. So the only reliable source of the number the quota
 actually gates on is ``db.command("dbStats")["dataSize"]`` from the app itself.
 
-data-manager is already scraped into Grafana Cloud (its Prometheus registry is
-exposed on :9090 — see ``main.py``'s ``start_http_server``). Registering this
-gauge on that **same default registry** makes it flow to Grafana Cloud with no
-new remote-write, Alloy config, secret, or push CronJob. The downstream alert
-(#905) then finalizes as, e.g.::
+Why OTLP, not the prometheus_client :9090 registry (dm#252)
+-----------------------------------------------------------
+dm#248 originally registered this gauge on the ``prometheus_client`` default
+registry exposed on :9090, assuming that endpoint was scraped into Grafana
+Cloud. It is **not**: data-manager reaches Grafana Cloud exclusively through the
+**OTLP pipeline** (``petrosa-otel`` → otelcol → ``grafanacloud-prom``). Nothing
+scrapes :9090, so the gauge was live on the pod but ``0 series`` in Grafana
+Cloud (live-verified 2026-07-04), leaving petrosa_k8s#920/#905 permanently
+``NoData``. This module therefore emits the metric through the **OTEL meter**
+(``get_meter`` → OTLP), exactly like the ``data_manager_decision_*`` counters,
+so it lands in ``grafanacloud-prom`` under the same name and the existing alert
+exprs work unchanged::
 
-    sum(data_manager_mongo_data_size_bytes) / (512 * 1024 * 1024) > 0.70  # WARN
-    sum(data_manager_mongo_data_size_bytes) / (512 * 1024 * 1024) > 0.85  # P1
+    sum(data_manager_mongo_data_size_bytes) / (512 * 1024 * 1024) > 0.80  # WARN
+    sum(data_manager_mongo_data_size_bytes) / (512 * 1024 * 1024) > 0.95  # P1
 
 The denominator is the 512 MiB constant (M0 exposes no ``_limit`` series).
+
+Async scrape vs. sync export (the ObservableGauge idiom)
+--------------------------------------------------------
+An OTEL ``ObservableGauge`` reports via a **synchronous** callback the SDK
+invokes at export time — it cannot ``await`` Motor. So the async refresh loop
+(:func:`refresh_mongo_data_size`, driven from ``main.py`` every
+``MONGO_DATA_SIZE_REFRESH_INTERVAL`` s) writes the latest ``dbStats().dataSize``
+per database into a small module-level cache, and the observable callback reads
+that cache and yields one :class:`Observation` per database at export. The
+cache is guarded by a :class:`threading.Lock` because the callback runs on the
+SDK's exporter thread while the loop writes from the asyncio event-loop thread.
+The scrape-error total is exported the same way (an ``ObservableCounter`` over a
+running integer), so it too reaches Grafana Cloud (AC3).
 
 Why the connected DB, not ``listDatabases``
 -------------------------------------------
@@ -39,43 +59,95 @@ databases can be sampled by explicit name when needed.
 Failure isolation (AC3)
 -----------------------
 :func:`refresh_mongo_data_size` never raises. A missing connected database or a
-per-database ``dbStats`` failure logs a warning, increments
-``data_manager_mongo_data_size_scrape_errors_total``, and leaves the last-known
-gauge value in place (Prometheus gauges retain their prior sample until the
-next successful set). The refresh is fully async (Motor) so it never blocks the
-event loop. Callers should still wrap the ``await`` defensively, but the
-function itself is the primary guard.
+per-database ``dbStats`` failure logs a warning, increments the exported
+``data_manager_mongo_data_size_scrape_errors_total`` counter, and leaves the
+last-known cached value in place (so the exported gauge holds its prior sample
+until the next successful scrape). The refresh is fully async (Motor) so it
+never blocks the event loop.
 """
 
 from __future__ import annotations
 
 import logging
+import threading
+from collections.abc import Iterable
 from typing import Any
 
-from prometheus_client import Counter, Gauge
+from opentelemetry.metrics import CallbackOptions, Observation
+
+try:
+    from petrosa_otel import get_meter
+except ImportError:  # pragma: no cover - petrosa_otel always present in prod
+    from opentelemetry import metrics as _otel_metrics
+
+    def get_meter(name: str) -> Any:
+        return _otel_metrics.get_meter(name)
+
 
 logger = logging.getLogger(__name__)
 
-# Module-level so the gauge is registered exactly once on the default registry
-# (the one ``start_http_server(METRICS_PORT)`` exposes on :9090). A per-``database``
-# label lets the alert ``sum()`` across DBs while still showing which DB
-# dominates (``petrosa_data_manager`` is ~99% of the total).
-mongo_data_size_bytes = Gauge(
+_meter = get_meter(__name__)
+
+# Latest per-database ``dbStats().dataSize`` written by the async refresh loop
+# and read by the ObservableGauge callback at OTLP export time. Guarded by a
+# lock because the two run on different threads (asyncio event loop vs. the
+# SDK's metric-exporter thread). ``_scrape_errors`` is a monotonic running
+# total exported via an ObservableCounter (AC3).
+_state_lock = threading.Lock()
+_last_data_size: dict[str, int] = {}
+_scrape_errors: int = 0
+
+
+def _observe_data_size(_options: CallbackOptions) -> Iterable[Observation]:
+    """ObservableGauge callback: yield the last-known size per database.
+
+    Runs synchronously on the SDK exporter thread; reads only the cache the
+    async refresh loop maintains. Yields nothing until the first successful
+    scrape (so the series simply doesn't appear rather than reporting 0).
+    """
+    with _state_lock:
+        snapshot = dict(_last_data_size)
+    for database, data_size in snapshot.items():
+        yield Observation(data_size, {"database": database})
+
+
+def _observe_scrape_errors(_options: CallbackOptions) -> Iterable[Observation]:
+    """ObservableCounter callback: yield the cumulative scrape-error count."""
+    with _state_lock:
+        yield Observation(_scrape_errors)
+
+
+# Keep module-level references so the instruments (and their callbacks) are not
+# garbage-collected. ``data_manager_mongo_data_size_bytes`` is emitted with no
+# ``unit`` on purpose: the OTLP→Prometheus exporter appends a unit suffix (e.g.
+# ``By`` → ``_bytes``) and the name already ends in ``_bytes`` — mirroring how
+# ``data_manager_decision_messages_received_total`` keeps its exact name.
+mongo_data_size_bytes = _meter.create_observable_gauge(
     "data_manager_mongo_data_size_bytes",
-    "Logical (uncompressed) MongoDB data size in bytes per application database, "
-    "from dbStats().dataSize. This is the figure Atlas M0 gates its 512 MiB quota "
-    "on (NOT the compressed storageSize). Producer for petrosa_k8s#905.",
-    ["database"],
+    callbacks=[_observe_data_size],
+    description=(
+        "Logical (uncompressed) MongoDB data size in bytes per application "
+        "database, from dbStats().dataSize. This is the figure Atlas M0 gates "
+        "its 512 MiB quota on (NOT the compressed storageSize). Producer for "
+        "petrosa_k8s#905 / #920; exported via OTLP (dm#252)."
+    ),
 )
 
-# Companion error counter (AC3): a scrape failure increments this instead of
-# crashing the service or zeroing the gauge, so the alert can be made robust to
-# transient scrape gaps and operators can see scrape health.
-mongo_data_size_scrape_errors = Counter(
+mongo_data_size_scrape_errors = _meter.create_observable_counter(
     "data_manager_mongo_data_size_scrape_errors_total",
-    "Total failed dbStats scrapes while refreshing data_manager_mongo_data_size_bytes "
-    "(listDatabases or per-database dbStats). The gauge retains its last-known value.",
+    callbacks=[_observe_scrape_errors],
+    description=(
+        "Cumulative failed dbStats scrapes while refreshing "
+        "data_manager_mongo_data_size_bytes. The gauge retains its last-known "
+        "value across failures."
+    ),
 )
+
+
+def _record_scrape_error() -> None:
+    global _scrape_errors
+    with _state_lock:
+        _scrape_errors += 1
 
 
 def _resolve_targets(adapter: Any, extra_databases: tuple[str, ...]):
@@ -115,17 +187,19 @@ async def refresh_mongo_data_size(
     *,
     extra_databases: tuple[str, ...] = (),
 ) -> dict[str, int]:
-    """Refresh the ``data_manager_mongo_data_size_bytes`` gauge from ``dbStats``.
+    """Refresh the cached ``data_manager_mongo_data_size_bytes`` values.
 
     Runs ``dbStats`` on the adapter's connected database (and any explicitly
-    named ``extra_databases``) and sets the gauge, labelled by ``database``, to
-    each database's ``dataSize``. Returns a ``{database: data_size_bytes}`` map
-    of the databases successfully sampled (useful for tests and logging).
+    named ``extra_databases``) and stores each database's ``dataSize`` in the
+    module cache the OTLP ObservableGauge exports. Returns a
+    ``{database: data_size_bytes}`` map of the databases successfully sampled
+    (useful for tests and logging).
 
     Never raises (AC3): a missing connected database or any per-database
-    ``dbStats`` error logs a warning, increments
-    :data:`mongo_data_size_scrape_errors`, and leaves the last-known gauge
-    value(s) untouched. Fully async (Motor), so it never blocks the event loop.
+    ``dbStats`` error logs a warning, increments the exported
+    ``data_manager_mongo_data_size_scrape_errors_total`` counter, and leaves the
+    last-known cached value(s) untouched. Fully async (Motor), so it never
+    blocks the event loop.
 
     Args:
         adapter: a connected :class:`~data_manager.db.mongodb_adapter.MongoDBAdapter`
@@ -136,7 +210,7 @@ async def refresh_mongo_data_size(
     """
     targets = list(_resolve_targets(adapter, extra_databases))
     if not targets:
-        mongo_data_size_scrape_errors.inc()
+        _record_scrape_error()
         logger.warning(
             "mongo_data_size: adapter exposes no connected database "
             "(db/db_name unset); leaving last-known gauge value(s) in place",
@@ -148,7 +222,7 @@ async def refresh_mongo_data_size(
         try:
             stats = await db_handle.command("dbStats")
         except Exception as exc:  # noqa: BLE001 — isolate per-DB failures (AC3)
-            mongo_data_size_scrape_errors.inc()
+            _record_scrape_error()
             logger.warning(
                 "mongo_data_size: dbStats failed for %s; keeping last-known "
                 "value for that database: %s",
@@ -157,10 +231,11 @@ async def refresh_mongo_data_size(
             )
             continue
         data_size = int((stats or {}).get("dataSize", 0) or 0)
-        mongo_data_size_bytes.labels(database=name).set(data_size)
         sampled[name] = data_size
 
     if sampled:
+        with _state_lock:
+            _last_data_size.update(sampled)
         total = sum(sampled.values())
         logger.info(
             "mongo_data_size: refreshed %d database(s); total dataSize=%d bytes "

--- a/tests/test_mongo_data_size_gauge.py
+++ b/tests/test_mongo_data_size_gauge.py
@@ -1,14 +1,19 @@
-"""Tests for the MongoDB logical-data-size gauge refresh (data-manager#248).
+"""Tests for the MongoDB logical-data-size gauge refresh (data-manager#248, #252).
 
 Verifies the *producer* half of the Atlas M0 data-size leading-indicator alert
-(petrosa_k8s#905 / dm#244 AC6):
+(petrosa_k8s#905 / #920 / dm#244 AC6):
 
-- AC1/AC2 — the ``data_manager_mongo_data_size_bytes`` gauge is set from a
+- AC1/AC2 — the ``data_manager_mongo_data_size_bytes`` value is cached from a
   mocked ``dbStats().dataSize`` payload on the adapter's connected database
-  (and any explicitly named extra DBs).
-- AC3/AC4 — a ``dbStats`` exception (or an adapter with no connected database)
+  (and any explicitly named extra DBs) and exported per ``database`` via the
+  OTLP ObservableGauge callback.
+- AC3 — a ``dbStats`` exception (or an adapter with no connected database)
   does NOT propagate, bumps ``data_manager_mongo_data_size_scrape_errors_total``,
-  and leaves the last-known gauge value in place.
+  and leaves the last-known cached value in place.
+
+Per dm#252 the metric is exported through the OTEL meter (OTLP), not the
+prometheus_client :9090 registry, so these tests assert on the module cache the
+ObservableGauge reads plus the callbacks themselves — not ``prometheus_client.REGISTRY``.
 
 The refresh runs ``dbStats`` on the connected DB via ``adapter.db.command`` —
 deliberately NOT ``listDatabases`` (a cluster admin command the app credential
@@ -21,6 +26,15 @@ from __future__ import annotations
 import pytest
 
 from data_manager.maintenance import mongo_data_size_gauge as mdsg
+
+
+@pytest.fixture(autouse=True)
+def _reset_gauge_state():
+    """Isolate the module-level OTLP cache/counter between tests."""
+    with mdsg._state_lock:
+        mdsg._last_data_size.clear()
+        mdsg._scrape_errors = 0
+    yield
 
 
 class _FakeDatabase:
@@ -53,16 +67,17 @@ class _FakeAdapter:
 
 
 def _gauge_value(database: str):
-    """Read the current gauge value for a ``database`` label, or None if unset."""
-    from prometheus_client import REGISTRY
+    """Read the cached gauge value for a ``database`` label, or None if unset.
 
-    return REGISTRY.get_sample_value(
-        "data_manager_mongo_data_size_bytes", {"database": database}
-    )
+    Mirrors what the OTLP ObservableGauge callback exports.
+    """
+    with mdsg._state_lock:
+        return mdsg._last_data_size.get(database)
 
 
 def _scrape_errors() -> float:
-    return mdsg.mongo_data_size_scrape_errors._value.get()
+    with mdsg._state_lock:
+        return mdsg._scrape_errors
 
 
 @pytest.mark.asyncio
@@ -167,3 +182,36 @@ async def test_extra_db_duplicate_of_connected_is_skipped():
     )
 
     assert refreshed == {"petrosa_data_manager": 100}
+
+
+@pytest.mark.asyncio
+async def test_observable_gauge_callback_yields_one_observation_per_db():
+    """The OTLP ObservableGauge callback exports the cached value per database."""
+    adapter = _FakeAdapter(
+        "petrosa_data_manager",
+        _FakeDatabase({"dataSize": 400}),
+        client={"petrosa": _FakeDatabase({"dataSize": 25})},
+    )
+    await mdsg.refresh_mongo_data_size(adapter, extra_databases=("petrosa",))
+
+    observed = {
+        obs.attributes["database"]: obs.value for obs in mdsg._observe_data_size(None)
+    }
+
+    assert observed == {"petrosa_data_manager": 400, "petrosa": 25}
+
+
+def test_observable_gauge_callback_yields_nothing_before_first_scrape():
+    """No cached sample → the series simply doesn't appear (not a 0)."""
+    assert list(mdsg._observe_data_size(None)) == []
+
+
+@pytest.mark.asyncio
+async def test_observable_error_counter_callback_reports_cumulative_total():
+    """The OTLP ObservableCounter callback exports the running error total (AC3)."""
+    assert [o.value for o in mdsg._observe_scrape_errors(None)] == [0]
+
+    # No connected DB → one scrape error.
+    await mdsg.refresh_mongo_data_size(_FakeAdapter("", None))
+
+    assert [o.value for o in mdsg._observe_scrape_errors(None)] == [1]


### PR DESCRIPTION
## Summary

`data_manager_mongo_data_size_bytes` (the Atlas M0 storage gauge shipped in dm#248) was registered on the **`prometheus_client` default registry** exposed on `:9090` — but **nothing scrapes `:9090` into Grafana Cloud**. data-manager metrics reach Grafana Cloud exclusively via the **OTLP pipeline** (`petrosa-otel` → otelcol → `grafanacloud-prom`). The gauge was live on the pod (`3.67e8`) but **0 series** in Grafana Cloud (live-verified 2026-07-04), leaving the petrosa_k8s#920 / #905 Atlas-quota alerts permanently `NoData`.

This PR re-instruments the metric through the **OTEL meter (OTLP)**, mirroring the `data_manager_decision_*` counters, so it lands in `grafanacloud-prom` under the same name and the existing alert exprs work unchanged.

## What changed

- **`data_manager_mongo_data_size_bytes`** → OTEL **`ObservableGauge`** (`_meter.create_observable_gauge`). Its **synchronous** export callback reads a lock-guarded module cache that the existing async 60s refresh loop populates from `dbStats().dataSize` per database. This is the standard ObservableGauge idiom for bridging a sync export callback and an async (Motor) scrape. **(AC1)**
- **`data_manager_mongo_data_size_scrape_errors_total`** → OTEL **`ObservableCounter`** over a monotonic running total, so the error signal also reaches Grafana Cloud. **(AC3)**
- **No `unit`** is set on the gauge on purpose: the OTLP→Prometheus exporter appends a unit suffix (`By` → `_bytes`) and the name already ends in `_bytes`; omitting the unit keeps the exact name (matches how `data_manager_decision_messages_received_total` keeps its name).
- Failure isolation preserved: `refresh_mongo_data_size` never raises, bumps the error counter, and retains the last-known cached value across failures.
- `main.py` loop docstring corrected (the `:9090` registry is not scraped into Grafana Cloud).
- Tests updated to assert on the cache + the observable callbacks directly (not `prometheus_client.REGISTRY`), plus new coverage for both callbacks. **Full suite: 1129 passed, 3 skipped.**

## Acceptance criteria status

| AC | Status |
|----|--------|
| **AC1** — gauge via OTEL meter, labelled by `database`, refreshed on 60s loop | ✅ done |
| **AC2** — `grafanacloud-prom` returns ≥1 series post-deploy | ⏳ post-deploy live-verify (operator) |
| **AC3** — `..._scrape_errors_total` reaches Grafana Cloud | ✅ done (ObservableCounter, exported via OTLP) |
| **AC4** — remove `data_manager_mongo_data_size_bytes` from `petrosa_k8s/observability/alert-rules/series-allowlist.txt` | ⏳ **separate petrosa_k8s PR, gated on AC2** — the allowlist comment itself says remove only once the series flows live, else the #920/#922 guard CI fails. Cross-repo + sequencing dependency, so cannot merge with this code. |
| **AC5** — #920 alerts render `Normal` | ⏳ post-deploy live-verify (operator) |

## Why AC4 is deferred

The series-allowlist grandfather entry (added under petrosa_k8s#922) is explicitly documented as *"REMOVE this entry as part of data-manager#252 AC4 (the guard should then validate it live)"*. Removing it **before** the OTLP producer is deployed and the series is confirmed live in `grafanacloud-prom` would break the k8s alert-rules guard, which validates that alert-referenced series exist. AC4 therefore follows AC2 as a post-deploy petrosa_k8s PR.

Closes #252 (AC1/AC3; AC2/AC4/AC5 tracked as post-deploy steps in the issue thread)
