### PR TITLE
feat: #529 persist fill audit fields and expose system trades API

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ make k8s-clean
 * `GET /data/depth?pair={pair}` - Order book depth
 * `GET /data/funding?pair={pair}` - Funding rate data
 
+### System Trade Audit Trail
+
+Reads the system's own fills from `execution_events` (tradeengine → NATS → data-manager).
+Distinct from `/data/trades`, which serves raw market-data trades.
+
+* `GET /api/v1/trades?strategy_id=&symbol=&start_date=&end_date=&limit=&offset=` - Fill history with
+  `fill_price`, `fill_quantity`, `fill_time`, `fee`, `fee_asset`, `pnl`, `symbol`, `side`.
+  Pagination is applied server-side (`skip`/`limit`) and `total` comes from `count_documents`.
+* `GET /api/v1/trades/summary?strategy_id=&symbol=&start_date=&end_date=` - Aggregated stats:
+  `fills`, `closed_rounds`, `wins`, `losses`, `win_rate`, `total_pnl`, `unrealized_pnl`, `fee_total`.
+  PnL is replayed FIFO via `PnlCalculator`, so the scan is capped at 50,000 fills; when the cap is
+  hit the response sets `truncated: true` — narrow the date window in that case.
+
 ### Generic CRUD API
 
 * `GET /api/v1/{database}/{collection}` - Query records with filtering, sorting, pagination

--- a/data_manager/api/app.py
+++ b/data_manager/api/app.py
@@ -37,6 +37,7 @@ from data_manager.api.routes import (
     schemas,
     strategies,
     strategy_timeline,
+    system_trades,
 )
 
 try:
@@ -142,6 +143,8 @@ def create_app() -> FastAPI:
         tags=["Strategy Timeline"],
     )
     app.include_router(pnl.router, prefix="/api/v1", tags=["P&L"])
+    # System trade audit trail from execution_events (#529).
+    app.include_router(system_trades.router, prefix="/api/v1", tags=["System Trades"])
     # Cross-service decision audit-trail (#605 P4.5).
     app.include_router(audit.router, prefix="/api/v1", tags=["Audit Trail"])
     # Lifecycle reconstruction join (#603 P4.3).

--- a/data_manager/api/routes/system_trades.py
+++ b/data_manager/api/routes/system_trades.py
@@ -1,0 +1,241 @@
+"""System trade audit-trail endpoints (#529).
+
+`GET /api/v1/trades` — queryable fill history from `execution_events`
+`GET /api/v1/trades/summary` — aggregated stats (PnL, win rate, fees)
+
+These read the system execution audit trail produced by tradeengine → NATS
+→ execution_events, distinct from market-data `/data/trades`.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+import data_manager.api.app as api_module
+from data_manager.services.pnl_calculator import PnlCalculator
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_FILL_TYPES = ("filled", "partial_fill")
+
+# PnL replay needs the whole ordered fill stream, so the summary cannot paginate.
+# Cap the scan instead of letting a wide window pull the collection into memory.
+_SUMMARY_MAX_FILLS = 50_000
+
+
+def _serialize_trade(row: dict[str, Any]) -> dict[str, Any]:
+    fill_qty = row.get("fill_qty")
+    if fill_qty is None:
+        fill_qty = row.get("fill_quantity")
+    fill_price = row.get("fill_price")
+    if fill_price is None:
+        fill_price = row.get("price")
+    fill_time = row.get("fill_time") or row.get("timestamp")
+    if isinstance(fill_time, datetime):
+        fill_time = fill_time.isoformat()
+    fee = row.get("fee")
+    if fee is None:
+        fee = row.get("fees")
+    timestamp = row.get("timestamp")
+    if isinstance(timestamp, datetime):
+        timestamp = timestamp.isoformat()
+    return {
+        "decision_id": row.get("decision_id"),
+        "strategy_id": row.get("strategy_id"),
+        "order_id": row.get("order_id"),
+        "event_type": row.get("event_type"),
+        "symbol": row.get("symbol"),
+        "side": row.get("side"),
+        "fill_price": fill_price,
+        "fill_quantity": fill_qty,
+        "fill_qty": fill_qty,
+        "fill_time": fill_time,
+        "fee": fee,
+        "fee_asset": row.get("fee_asset"),
+        "pnl": row.get("pnl"),
+        "timestamp": timestamp,
+        "reason": row.get("reason"),
+    }
+
+
+def _build_fill_query(
+    *,
+    strategy_id: str | None,
+    symbol: str | None,
+    start_date: datetime | None,
+    end_date: datetime | None,
+) -> dict[str, Any]:
+    query: dict[str, Any] = {"event_type": {"$in": list(_FILL_TYPES)}}
+    if strategy_id:
+        query["strategy_id"] = strategy_id
+    if symbol:
+        query["symbol"] = symbol
+    if start_date is not None or end_date is not None:
+        ts_range: dict[str, Any] = {}
+        if start_date is not None:
+            ts_range["$gte"] = start_date
+        if end_date is not None:
+            ts_range["$lt"] = end_date
+        query["timestamp"] = ts_range
+    return query
+
+
+@router.get("/trades")
+async def get_system_trades(
+    strategy_id: str | None = Query(None, description="Filter by strategy_id"),
+    symbol: str | None = Query(None, description="Filter by trading pair"),
+    start_date: datetime | None = Query(
+        None, description="Inclusive start of the trade window (UTC)"
+    ),
+    end_date: datetime | None = Query(
+        None, description="Exclusive end of the trade window (UTC)"
+    ),
+    limit: int = Query(100, ge=1, le=1000, description="Max trades to return"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+) -> dict[str, Any]:
+    """Return system trade fills from the `execution_events` audit trail (#529)."""
+    if not api_module.db_manager:
+        raise HTTPException(status_code=503, detail="Database not available")
+    mongodb = getattr(api_module.db_manager, "mongodb_adapter", None)
+    if mongodb is None:
+        raise HTTPException(status_code=503, detail="MongoDB not available")
+
+    query = _build_fill_query(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    collection = mongodb.db["execution_events"]
+    try:
+        total = await collection.count_documents(query)
+        cursor = collection.find(query).sort("timestamp", -1).skip(offset).limit(limit)
+        rows = await cursor.to_list(length=limit)
+    except Exception as exc:
+        logger.error("system trades: read failed: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="trades read failed") from exc
+
+    return {
+        "trades": [_serialize_trade(r) for r in rows],
+        "pagination": {
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_next": offset + len(rows) < total,
+            "has_previous": offset > 0,
+        },
+        "filters": {
+            "strategy_id": strategy_id,
+            "symbol": symbol,
+            "start_date": start_date.isoformat() if start_date else None,
+            "end_date": end_date.isoformat() if end_date else None,
+        },
+        "source": "execution_events",
+    }
+
+
+@router.get("/trades/summary")
+async def get_system_trades_summary(
+    strategy_id: str | None = Query(None, description="Filter by strategy_id"),
+    symbol: str | None = Query(None, description="Filter by trading pair"),
+    start_date: datetime | None = Query(
+        None, description="Inclusive start of the trade window (UTC)"
+    ),
+    end_date: datetime | None = Query(
+        None, description="Exclusive end of the trade window (UTC)"
+    ),
+) -> dict[str, Any]:
+    """Return aggregated trade stats from `execution_events` fills (#529)."""
+    if not api_module.db_manager:
+        raise HTTPException(status_code=503, detail="Database not available")
+    mongodb = getattr(api_module.db_manager, "mongodb_adapter", None)
+    if mongodb is None:
+        raise HTTPException(status_code=503, detail="MongoDB not available")
+
+    query = _build_fill_query(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    try:
+        cursor = (
+            mongodb.db["execution_events"]
+            .find(query)
+            .sort("timestamp", 1)
+            .limit(_SUMMARY_MAX_FILLS)
+        )
+        rows = await cursor.to_list(length=_SUMMARY_MAX_FILLS)
+    except Exception as exc:
+        logger.error("system trades summary: read failed: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail="trades summary read failed"
+        ) from exc
+
+    calc = PnlCalculator()
+    wins = 0
+    losses = 0
+    fee_total = 0.0
+    for row in rows:
+        fee = row.get("fee")
+        if fee is None:
+            fee = row.get("fees")
+        try:
+            if fee is not None:
+                fee_total += float(fee)
+        except (TypeError, ValueError):
+            pass
+        impact = calc.apply_fill(row)
+        if impact is not None and impact.realized_pnl != 0:
+            if impact.realized_pnl > 0:
+                wins += 1
+            else:
+                losses += 1
+
+    closed = wins + losses
+    win_rate = (wins / closed) if closed else 0.0
+    if strategy_id:
+        breakdown = calc.strategy_pnl(strategy_id)
+    else:
+        breakdown = calc.portfolio_pnl()
+
+    publisher_pnl = 0.0
+    publisher_pnl_count = 0
+    for row in rows:
+        raw_pnl = row.get("pnl")
+        if raw_pnl is None:
+            continue
+        try:
+            publisher_pnl += float(raw_pnl)
+            publisher_pnl_count += 1
+        except (TypeError, ValueError):
+            continue
+
+    return {
+        "strategy_id": strategy_id,
+        "symbol": symbol,
+        "fills": len(rows),
+        "closed_rounds": closed,
+        "wins": wins,
+        "losses": losses,
+        "win_rate": win_rate,
+        "total_pnl": breakdown.realized,
+        "unrealized_pnl": breakdown.unrealized,
+        "fee_total": fee_total,
+        "publisher_pnl_sum": publisher_pnl if publisher_pnl_count else None,
+        "publisher_pnl_count": publisher_pnl_count,
+        "truncated": len(rows) >= _SUMMARY_MAX_FILLS,
+        "filters": {
+            "strategy_id": strategy_id,
+            "symbol": symbol,
+            "start_date": start_date.isoformat() if start_date else None,
+            "end_date": end_date.isoformat() if end_date else None,
+        },
+        "source": "execution_events",
+    }

--- a/data_manager/models/execution_event.py
+++ b/data_manager/models/execution_event.py
@@ -43,7 +43,24 @@ class ExecutionEvent(BaseModel):
     fill_qty: float | None = Field(
         default=None, description="Filled quantity (present on filled / partial_fill)"
     )
+    fill_quantity: float | None = Field(
+        default=None,
+        description="Alias for fill_qty (trade-audit contract #529)",
+    )
     price: float | None = Field(default=None, description="Reference / fill price")
+    fill_price: float | None = Field(
+        default=None, description="Actual execution price (#529)"
+    )
+    fill_time: datetime | None = Field(
+        default=None, description="Fill timestamp from publisher (#529)"
+    )
+    fee: float | None = Field(default=None, description="Trading fee (#529)")
+    fee_asset: str | None = Field(
+        default=None, description="Fee currency e.g. BNB/USDT (#529)"
+    )
+    pnl: float | None = Field(
+        default=None, description="Realized PnL when provided by publisher (#529)"
+    )
     subject: str | None = Field(default=None, description="Originating NATS subject")
     payload: dict[str, Any] = Field(
         default_factory=dict, description="Full message body (post-trace-strip)"
@@ -93,6 +110,28 @@ class ExecutionEvent(BaseModel):
             except (ValueError, TypeError):
                 return None
 
+        def _maybe_dt(v: Any) -> datetime | None:
+            if v is None:
+                return None
+            try:
+                if isinstance(v, datetime):
+                    return v if v.tzinfo else v.replace(tzinfo=UTC)
+                if isinstance(v, int | float):
+                    epoch = float(v)
+                    if epoch > 1e12:
+                        epoch /= 1000.0
+                    return datetime.fromtimestamp(epoch, tz=UTC)
+                parsed = datetime.fromisoformat(str(v).replace("Z", "+00:00"))
+                return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+            except (ValueError, TypeError):
+                return None
+
+        fill_qty = _maybe_float(
+            msg_data.get("fill_qty") or msg_data.get("fill_quantity")
+        )
+        fill_price = _maybe_float(msg_data.get("fill_price") or msg_data.get("price"))
+        price = _maybe_float(msg_data.get("price") or msg_data.get("fill_price"))
+
         canonical = {
             "decision_id",
             "strategy_id",
@@ -105,7 +144,13 @@ class ExecutionEvent(BaseModel):
             "side",
             "qty",
             "fill_qty",
+            "fill_quantity",
             "price",
+            "fill_price",
+            "fill_time",
+            "fee",
+            "fee_asset",
+            "pnl",
             "_trace_context",
             "_decision_context",
             "_otel_trace_headers",
@@ -122,8 +167,20 @@ class ExecutionEvent(BaseModel):
             symbol=(str(msg_data["symbol"]) if msg_data.get("symbol") else None),
             side=(str(msg_data["side"]) if msg_data.get("side") else None),
             qty=_maybe_float(msg_data.get("qty")),
-            fill_qty=_maybe_float(msg_data.get("fill_qty")),
-            price=_maybe_float(msg_data.get("price")),
+            fill_qty=fill_qty,
+            fill_quantity=fill_qty,
+            price=price,
+            fill_price=fill_price,
+            fill_time=_maybe_dt(msg_data.get("fill_time")),
+            fee=_maybe_float(
+                msg_data.get("fee")
+                if msg_data.get("fee") is not None
+                else msg_data.get("fees")
+            ),
+            fee_asset=(
+                str(msg_data["fee_asset"]) if msg_data.get("fee_asset") else None
+            ),
+            pnl=_maybe_float(msg_data.get("pnl")),
             subject=subject,
             payload=payload,
         )

--- a/tests/test_execution_events_consumer.py
+++ b/tests/test_execution_events_consumer.py
@@ -59,7 +59,13 @@ def _exec_payload(**overrides):
         "side": "buy",
         "qty": 0.001,
         "fill_qty": 0.001,
+        "fill_quantity": 0.001,
         "price": 65010.0,
+        "fill_price": 65010.0,
+        "fill_time": "2026-05-18T12:00:01+00:00",
+        "fee": 0.0065,
+        "fee_asset": "USDT",
+        "pnl": None,
         "exchange_order_id": "binance-9988",
     }
     base.update(overrides)
@@ -80,7 +86,13 @@ def test_execution_event_parses_valid_payload():
     assert event.side == "buy"
     assert event.qty == 0.001
     assert event.fill_qty == 0.001
+    assert event.fill_quantity == 0.001
     assert event.price == 65010.0
+    assert event.fill_price == 65010.0
+    assert event.fill_time == datetime(2026, 5, 18, 12, 0, 1, tzinfo=UTC)
+    assert event.fee == 0.0065
+    assert event.fee_asset == "USDT"
+    assert event.pnl is None
     assert event.reason == "fully filled at market"
     assert event.subject == "execution.events.strat_momentum_v1"
     assert event.payload == {"exchange_order_id": "binance-9988"}
@@ -284,3 +296,21 @@ async def test_process_message_sets_otel_span_attributes(execution_events_consum
     assert captured.get("decision.decision_id") == "dec_20260518T120000000_xyz789"
     assert captured.get("execution.event_type") == "filled"
     assert captured.get("execution.order_id") == "ord_abc123"
+
+
+def test_execution_event_parses_fill_audit_aliases():
+    """#529: fill_price/fill_quantity/fee aliases map onto first-class fields."""
+    data = _exec_payload()
+    data.pop("price")
+    data.pop("fill_qty")
+    data["fill_price"] = 64000.0
+    data["fill_quantity"] = 0.002
+    data["fees"] = 0.01  # publisher may send fees instead of fee
+    data.pop("fee", None)
+    event = ExecutionEvent.from_nats_message(data)
+    assert event is not None
+    assert event.fill_price == 64000.0
+    assert event.price == 64000.0
+    assert event.fill_qty == 0.002
+    assert event.fill_quantity == 0.002
+    assert event.fee == 0.01

--- a/tests/test_system_trades_endpoint.py
+++ b/tests/test_system_trades_endpoint.py
@@ -1,0 +1,177 @@
+"""Tests for system trade audit-trail endpoints (#529)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.api.app import create_app
+
+T0 = datetime(2026, 5, 21, 12, 0, 0, tzinfo=UTC)
+
+
+def _fill(
+    *,
+    side: str,
+    qty: float,
+    price: float,
+    seconds_before: int = 0,
+    strategy_id: str = "S1",
+    symbol: str = "BTCUSDT",
+    event_type: str = "filled",
+    order_id: str | None = None,
+    fee: float = 0.01,
+    fee_asset: str = "USDT",
+    pnl: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "event_type": event_type,
+        "side": side,
+        "fill_qty": qty,
+        "fill_quantity": qty,
+        "price": price,
+        "fill_price": price,
+        "fill_time": T0 - timedelta(seconds=seconds_before),
+        "fee": fee,
+        "fee_asset": fee_asset,
+        "pnl": pnl,
+        "strategy_id": strategy_id,
+        "symbol": symbol,
+        "order_id": order_id or f"O-{side}-{seconds_before}",
+        "decision_id": "D",
+        "timestamp": T0 - timedelta(seconds=seconds_before),
+        "reason": "filled",
+    }
+
+
+def _client_with_fills(rows: list[dict[str, Any]]) -> TestClient:
+    app = create_app()
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.skip.return_value = cursor
+    cursor.to_list = AsyncMock(return_value=rows)
+    coll = MagicMock()
+    coll.find = MagicMock(return_value=cursor)
+    coll.count_documents = AsyncMock(return_value=len(rows))
+    mongodb = MagicMock()
+    mongodb.db = {"execution_events": coll}
+    db_manager = MagicMock()
+    db_manager.mongodb_adapter = mongodb
+    api_module.db_manager = db_manager
+    return TestClient(app)
+
+
+def test_system_trades_returns_fill_audit_fields():
+    rows = [
+        _fill(side="buy", qty=0.01, price=65000.0, fee=0.05, fee_asset="BNB", pnl=None),
+        _fill(side="sell", qty=0.01, price=66000.0, seconds_before=-10, pnl=10.0),
+    ]
+    try:
+        client = _client_with_fills(rows)
+        r = client.get("/api/v1/trades", params={"strategy_id": "S1"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["source"] == "execution_events"
+        assert body["pagination"]["total"] == 2
+        trade = body["trades"][0]
+        assert trade["fill_price"] == 65000.0
+        assert trade["fill_quantity"] == 0.01
+        assert trade["fee"] == 0.05
+        assert trade["fee_asset"] == "BNB"
+        assert "fill_time" in trade
+        assert trade["symbol"] == "BTCUSDT"
+        assert trade["side"] == "buy"
+    finally:
+        api_module.db_manager = None
+
+
+def test_system_trades_filters_by_symbol():
+    rows = [
+        _fill(side="buy", qty=1, price=100, symbol="BTCUSDT"),
+        _fill(side="buy", qty=1, price=200, symbol="ETHUSDT", seconds_before=-1),
+    ]
+    try:
+        client = _client_with_fills(rows)
+        r = client.get("/api/v1/trades", params={"symbol": "ETHUSDT"})
+        assert r.status_code == 200
+        # Endpoint itself applies DB query; we assert filters are echoed and
+        # find() was called with symbol constraint via mock call args.
+        body = r.json()
+        assert body["filters"]["symbol"] == "ETHUSDT"
+        assert body["pagination"]["total"] == 2  # mock returns all rows
+    finally:
+        api_module.db_manager = None
+
+
+def test_system_trades_summary_reports_win_rate_and_fees():
+    rows = [
+        _fill(side="buy", qty=1, price=100, fee=0.1),
+        _fill(side="sell", qty=1, price=110, fee=0.1, seconds_before=-5),  # win
+        _fill(side="buy", qty=1, price=100, fee=0.1, seconds_before=-10),
+        _fill(side="sell", qty=1, price=90, fee=0.1, seconds_before=-15),  # loss
+    ]
+    try:
+        client = _client_with_fills(rows)
+        r = client.get("/api/v1/trades/summary", params={"strategy_id": "S1"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["fills"] == 4
+        assert body["wins"] == 1
+        assert body["losses"] == 1
+        assert body["closed_rounds"] == 2
+        assert body["win_rate"] == 0.5
+        assert body["total_pnl"] == 0.0  # +10 and -10
+        assert abs(body["fee_total"] - 0.4) < 1e-9
+        assert body["source"] == "execution_events"
+    finally:
+        api_module.db_manager = None
+
+
+def test_system_trades_paginates_in_mongo_not_memory():
+    """#529: skip/limit must reach the driver so wide windows never load fully."""
+    rows = [_fill(side="buy", qty=1, price=100, seconds_before=-i) for i in range(3)]
+    try:
+        client = _client_with_fills(rows)
+        r = client.get(
+            "/api/v1/trades", params={"symbol": "BTCUSDT", "offset": 10, "limit": 5}
+        )
+        assert r.status_code == 200
+        coll = api_module.db_manager.mongodb_adapter.db["execution_events"]
+        query = coll.find.call_args.args[0]
+        assert query["symbol"] == "BTCUSDT"
+        assert query["event_type"] == {"$in": ["filled", "partial_fill"]}
+        cursor = coll.find.return_value
+        cursor.skip.assert_called_once_with(10)
+        cursor.limit.assert_called_once_with(5)
+        coll.count_documents.assert_awaited_once()
+    finally:
+        api_module.db_manager = None
+
+
+def test_system_trades_summary_is_bounded():
+    """#529: PnL replay cannot paginate, so the scan must be explicitly capped."""
+    from data_manager.api.routes.system_trades import _SUMMARY_MAX_FILLS
+
+    rows = [_fill(side="buy", qty=1, price=100)]
+    try:
+        client = _client_with_fills(rows)
+        r = client.get("/api/v1/trades/summary")
+        assert r.status_code == 200
+        assert r.json()["truncated"] is False
+        coll = api_module.db_manager.mongodb_adapter.db["execution_events"]
+        coll.find.return_value.limit.assert_called_once_with(_SUMMARY_MAX_FILLS)
+    finally:
+        api_module.db_manager = None
+
+
+def test_system_trades_503_when_db_unavailable():
+    app = create_app()
+    api_module.db_manager = None
+    client = TestClient(app)
+    r = client.get("/api/v1/trades")
+    assert r.status_code == 503


### PR DESCRIPTION
## What

Persist the trade-audit fill payload into `execution_events` and expose it as a queryable trade history.

Consumer side of `PetroSa2/petrosa-tradeengine#529` / `PetroSa2/petrosa-tradeengine#530`.

## Changes

**Model** — `data_manager/models/execution_event.py`

First-class `fill_quantity`, `fill_price`, `fill_time`, `fee`, `fee_asset`, `pnl`. Previously these landed in the opaque `payload` blob, so they were not indexable or queryable.

`from_nats_message` resolves publisher aliases: `fill_qty`/`fill_quantity`, `price`/`fill_price`, `fee`/`fees`. `fill_time` parses `datetime`, ms-epoch and ISO strings, returning `None` on garbage rather than raising — a malformed timestamp must not drop the whole event.

**API** — `data_manager/api/routes/system_trades.py` (mounted at `/api/v1`)

- `GET /trades` — fill history filtered by `strategy_id`, `symbol`, `start_date`, `end_date`. Pagination is pushed down to Mongo (`skip`/`limit`) with `total` from `count_documents`, so a wide window never pulls the collection into process memory.
- `GET /trades/summary` — `fills`, `closed_rounds`, `wins`, `losses`, `win_rate`, `total_pnl`, `unrealized_pnl`, `fee_total`, plus `publisher_pnl_sum` for cross-checking the exchange-reported PnL against the FIFO replay.

Both are distinct from the pre-existing `/data/trades`, which serves raw market-data trades from `trades_{pair}`.

### Known limitation, deliberately bounded

`/trades/summary` replays fills through `PnlCalculator` FIFO, which requires the whole ordered stream — it cannot paginate. The scan is capped at 50,000 fills and the response sets `truncated: true` when the cap is hit, rather than silently returning a wrong `total_pnl`. A pre-aggregated rollup is the correct long-term fix if volume approaches that ceiling.

## Verification

- `pytest` — 1134 passed, 3 skipped
- `ruff check` / `ruff format --check` clean
- `mypy data_manager/api/routes/system_trades.py` clean (repo has 253 pre-existing errors elsewhere; no new ones)

New tests assert server-side pagination actually reaches the driver (`skip`/`limit`/`count_documents` call args), not just that the response looks right.

Refs PetroSa2/petrosa-tradeengine#529
