### PR TITLE
feat: trade-audit business metrics + Grafana dashboard data source (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,21 @@ curl "http://localhost:8000/metrics"
 # - data_manager_active_connections (connection pool status)
 ```
 
+#### Trade-audit business metrics (#256)
+
+Emitted per persisted fill by the execution-events consumer (labels: `symbol`, `side`).
+Only fill events (`filled` / `partial_fill`) contribute; duplicate-key replays are not double-counted.
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `data_manager_execution_fills_total` | counter | Persisted fill events |
+| `data_manager_execution_fill_pnl_total` | counter | Cumulative realized PnL (quote ccy) |
+| `data_manager_execution_fill_fee_total` | counter | Cumulative trading fees |
+| `data_manager_execution_fill_wins_total` | counter | Fills with positive realized PnL |
+| `data_manager_execution_fill_losses_total` | counter | Fills with negative realized PnL |
+
+Grafana dashboard: `petrosa_k8s/k8s/monitoring/dashboards/data-manager-trade-audit-dashboard.json`.
+
 ---
 
 ## 🔧 Configuration

--- a/data_manager/consumer/execution_events_consumer.py
+++ b/data_manager/consumer/execution_events_consumer.py
@@ -58,6 +58,65 @@ execution_processing_time = _meter.create_histogram(
     unit="s",
 )
 
+# Business metrics for the trade-audit Grafana dashboard (#256). These are
+# emitted per persisted fill so the dashboard can chart fill throughput,
+# realized PnL, fees, and win/loss rate straight from Prometheus instead of
+# querying MongoDB through the /api/v1/trades API on every panel refresh.
+_FILL_EVENT_TYPES = ("filled", "partial_fill")
+
+execution_fills_total = _meter.create_counter(
+    "data_manager_execution_fills_total",
+    description="Total execution fill events persisted (filled / partial_fill)",
+)
+execution_fill_pnl_total = _meter.create_counter(
+    "data_manager_execution_fill_pnl_total",
+    description="Cumulative realized PnL across persisted fills (quote currency)",
+)
+execution_fill_fee_total = _meter.create_counter(
+    "data_manager_execution_fill_fee_total",
+    description="Cumulative trading fees across persisted fills",
+)
+execution_fill_wins_total = _meter.create_counter(
+    "data_manager_execution_fill_wins_total",
+    description="Persisted fills with positive realized PnL (win)",
+)
+execution_fill_losses_total = _meter.create_counter(
+    "data_manager_execution_fill_losses_total",
+    description="Persisted fills with negative realized PnL (loss)",
+)
+
+
+def _emit_fill_business_metrics(event: "ExecutionEvent") -> None:
+    """Emit per-fill business metrics for the #256 trade-audit dashboard.
+
+    Only fill events carry PnL/fee economics; non-fill events (placed,
+    rejected) are ignored. Metric attributes are kept low-cardinality
+    (symbol + side) so Prometheus series count stays bounded.
+    """
+    if event.event_type not in _FILL_EVENT_TYPES:
+        return
+
+    attrs = {**_METRIC_ATTRS}
+    if event.symbol:
+        attrs["symbol"] = event.symbol
+    if event.side:
+        attrs["side"] = event.side
+
+    execution_fills_total.add(1, attrs)
+
+    fee = event.fee
+    if fee is not None:
+        execution_fill_fee_total.add(abs(float(fee)), attrs)
+
+    pnl = event.pnl
+    if pnl is not None:
+        pnl_value = float(pnl)
+        execution_fill_pnl_total.add(pnl_value, attrs)
+        if pnl_value > 0:
+            execution_fill_wins_total.add(1, attrs)
+        elif pnl_value < 0:
+            execution_fill_losses_total.add(1, attrs)
+
 
 class ExecutionEventsConsumer:
     """Subscribes to `execution.events.>` and persists each event to MongoDB.
@@ -91,6 +150,10 @@ class ExecutionEventsConsumer:
         # `pnl.events.<strategy_id>` in the production wiring).
         # Optional so this consumer remains usable in isolation.
         self._on_persisted = on_persisted
+        # Set by `_persist`: True only when a fresh document was inserted
+        # (False on DuplicateKeyError replay). Gates the #256 business
+        # metrics so redelivery does not double-count PnL/fees.
+        self._last_persist_was_insert = False
 
     async def start(self) -> bool:
         try:
@@ -263,6 +326,8 @@ class ExecutionEventsConsumer:
             persisted = await self._persist(event)
             if persisted:
                 execution_messages_persisted.add(1, _METRIC_ATTRS)
+                if self._last_persist_was_insert:
+                    _emit_fill_business_metrics(event)
                 logger.info("execution_event_persisted", extra=log_extra)
                 span.set_status(trace.Status(trace.StatusCode.OK))
                 # P4.1 (#601): hand the just-persisted event to the
@@ -292,6 +357,7 @@ class ExecutionEventsConsumer:
             )
 
     async def _persist(self, event: ExecutionEvent) -> bool:
+        self._last_persist_was_insert = False
         adapter = (
             getattr(self.db_manager, "mongodb_adapter", None)
             if self.db_manager
@@ -311,8 +377,13 @@ class ExecutionEventsConsumer:
                 DuplicateKeyError = Exception  # type: ignore[assignment, misc]
             try:
                 await adapter.db[EXECUTION_EVENTS_COLLECTION].insert_one(doc)
+                self._last_persist_was_insert = True
                 return True
             except DuplicateKeyError:
+                # Idempotent replay: the event is already stored, so report
+                # success but flag it as a non-insert so business metrics
+                # (#256) are not double-counted on redelivery.
+                self._last_persist_was_insert = False
                 logger.debug(
                     "execution_event_already_persisted",
                     extra={

--- a/tests/test_execution_events_consumer.py
+++ b/tests/test_execution_events_consumer.py
@@ -314,3 +314,104 @@ def test_execution_event_parses_fill_audit_aliases():
     assert event.fill_qty == 0.002
     assert event.fill_quantity == 0.002
     assert event.fee == 0.01
+
+
+# --- #256: trade-audit business metrics ---------------------------------
+
+
+def _patch_business_metrics(monkeypatch):
+    """Replace the module-level metric instruments with MagicMocks."""
+    import data_manager.consumer.execution_events_consumer as mod
+
+    names = (
+        "execution_fills_total",
+        "execution_fill_pnl_total",
+        "execution_fill_fee_total",
+        "execution_fill_wins_total",
+        "execution_fill_losses_total",
+    )
+    mocks = {}
+    for name in names:
+        m = MagicMock()
+        monkeypatch.setattr(mod, name, m)
+        mocks[name] = m
+    return mocks
+
+
+@pytest.mark.asyncio
+async def test_fill_emits_business_metrics_on_insert(
+    execution_events_consumer, mock_db_manager, monkeypatch
+):
+    mocks = _patch_business_metrics(monkeypatch)
+    msg = _build_msg(_exec_payload(event_type="filled", pnl=12.5, fee=0.0065))
+    await execution_events_consumer._process_message(msg)
+
+    mocks["execution_fills_total"].add.assert_called_once()
+    fills_args = mocks["execution_fills_total"].add.call_args
+    assert fills_args.args[0] == 1
+    attrs = fills_args.args[1]
+    assert attrs["symbol"] == "BTCUSDT"
+    assert attrs["side"] == "buy"
+
+    mocks["execution_fill_pnl_total"].add.assert_called_once_with(12.5, attrs)
+    mocks["execution_fill_fee_total"].add.assert_called_once_with(0.0065, attrs)
+    mocks["execution_fill_wins_total"].add.assert_called_once_with(1, attrs)
+    mocks["execution_fill_losses_total"].add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_loss_fill_increments_losses_counter(
+    execution_events_consumer, monkeypatch
+):
+    mocks = _patch_business_metrics(monkeypatch)
+    msg = _build_msg(_exec_payload(event_type="filled", pnl=-4.0))
+    await execution_events_consumer._process_message(msg)
+
+    mocks["execution_fill_losses_total"].add.assert_called_once()
+    mocks["execution_fill_wins_total"].add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_fill_event_emits_no_business_metrics(
+    execution_events_consumer, monkeypatch
+):
+    mocks = _patch_business_metrics(monkeypatch)
+    msg = _build_msg(_exec_payload(event_type="placed", pnl=None, fee=None))
+    await execution_events_consumer._process_message(msg)
+
+    mocks["execution_fills_total"].add.assert_not_called()
+    mocks["execution_fill_pnl_total"].add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_replay_does_not_double_count_metrics(
+    execution_events_consumer, mock_db_manager, monkeypatch
+):
+    mocks = _patch_business_metrics(monkeypatch)
+    collection = mock_db_manager.mongodb_adapter.db.__getitem__.return_value
+    try:
+        from pymongo.errors import DuplicateKeyError
+    except ImportError:
+        DuplicateKeyError = Exception  # type: ignore[assignment, misc]
+    collection.insert_one.side_effect = DuplicateKeyError("dup")
+
+    msg = _build_msg(_exec_payload(event_type="filled", pnl=9.0))
+    await execution_events_consumer._process_message(msg)
+
+    # Persist returned True (idempotent) but it was not a fresh insert.
+    mocks["execution_fills_total"].add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fill_without_pnl_emits_count_but_no_win_loss(
+    execution_events_consumer, monkeypatch
+):
+    mocks = _patch_business_metrics(monkeypatch)
+    msg = _build_msg(_exec_payload(event_type="filled", pnl=None, fee=0.02))
+    await execution_events_consumer._process_message(msg)
+
+    mocks["execution_fills_total"].add.assert_called_once()
+    mocks["execution_fill_fee_total"].add.assert_called_once()
+    mocks["execution_fill_pnl_total"].add.assert_not_called()
+    mocks["execution_fill_wins_total"].add.assert_not_called()
+    mocks["execution_fill_losses_total"].add.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #256 (follow-up to tradeengine#529).

Most of #256 shipped in **#255** (issue #529): the `execution_events`
fill-field persistence (AC1) and the `/api/v1/trades` + `/api/v1/trades/summary`
endpoints (AC2), with tests and README docs. This PR closes the remaining
gap — the **AC3 trade-history Grafana dashboard** — by giving it a Prometheus
data source.

## Changes

Per-fill business metrics emitted by the execution-events consumer
(`data_manager/consumer/execution_events_consumer.py`):

| Metric | Meaning |
|--------|---------|
| `data_manager_execution_fills_total` | persisted fill events |
| `data_manager_execution_fill_pnl_total` | cumulative realized PnL |
| `data_manager_execution_fill_fee_total` | cumulative fees |
| `data_manager_execution_fill_wins_total` | positive-PnL fills |
| `data_manager_execution_fill_losses_total` | negative-PnL fills |

- Labels kept low-cardinality: `symbol`, `side`.
- Only `filled` / `partial_fill` events contribute.
- **Idempotent**: `_persist` now flags DuplicateKeyError replays as
  non-inserts so at-least-once redelivery does not double-count PnL/fees.
- README documents the metrics + links the dashboard.

The Grafana dashboard JSON itself lives in **petrosa_k8s**
(`k8s/monitoring/dashboards/data-manager-trade-audit-dashboard.json`,
infra repo per convention) and is delivered in a companion PR there.

## Acceptance Criteria

- [x] AC1 fill-field persistence — shipped in #255
- [x] AC2 `/api/v1/trades` + `/summary` — shipped in #255
- [x] AC3 Grafana dashboard — data source (metrics) here; dashboard JSON in petrosa_k8s
- [x] Tests cover persistence + new metrics
- [x] Documentation updated

## Testing

- `pytest tests/` → 1131 passed, 3 skipped; coverage gate (40%) satisfied.
- 5 new metric tests (emit-on-insert, win/loss classification, non-fill skip,
  duplicate-replay no-double-count, fee-without-pnl).
- `ruff format`/`check` clean; pre-commit (ruff, gitleaks, bandit, assertions) green.