### PR TITLE
fix: fall back through timestamp/entry_time/created_at in query_range et al (#259)

### DIFF
--- a/data_manager/db/mysql_adapter.py
+++ b/data_manager/db/mysql_adapter.py
@@ -336,6 +336,29 @@ class MySQLAdapter(BaseAdapter):
             )
         return table
 
+    def _time_column(self, table: "Table") -> Any:
+        """Return the column used for time-range filtering/ordering.
+
+        Most reflected tables (klines, market data) use a literal
+        ``timestamp`` column. Others — e.g. ``positions``, whose schema
+        (petrosa_k8s/k8s/tradeengine/mysql-schema-job.yaml) declares
+        ``entry_time DATETIME NOT NULL`` with no ``timestamp`` column at
+        all — do not. ``query_range``/``query_latest``/``get_record_count``
+        previously hardcoded ``table.c.timestamp`` unconditionally, so any
+        call against the ``positions`` collection raised
+        ``KeyError: 'timestamp'`` on every single invocation (100%
+        reproducible, ~7.8/min in production traffic). Fall back through
+        known time-column aliases instead of a hardcoded per-collection
+        allowlist so any current or future reflected table keeps working.
+        """
+        for candidate in ("timestamp", "entry_time", "created_at"):
+            if candidate in table.c:
+                return table.c[candidate]
+        raise DatabaseError(
+            f"Table {table.name!r} has no recognized time column "
+            f"(tried: timestamp, entry_time, created_at)"
+        )
+
     def _get_table(self, collection: str) -> "Table":
         """Get table object for collection. Dynamically create or reflect."""
         if collection in self.tables:
@@ -541,16 +564,15 @@ class MySQLAdapter(BaseAdapter):
 
         try:
             table = self._get_table(collection)
+            time_col = self._time_column(table)
 
             # Build query
-            query = select(table).where(
-                and_(table.c.timestamp >= start, table.c.timestamp < end)
-            )
+            query = select(table).where(and_(time_col >= start, time_col < end))
 
             if symbol:
                 query = query.where(table.c.symbol == symbol)
 
-            query = query.order_by(table.c.timestamp)
+            query = query.order_by(time_col)
 
             engine = self._ensure_connected()
             with engine.connect() as conn:
@@ -569,12 +591,13 @@ class MySQLAdapter(BaseAdapter):
 
         try:
             table = self._get_table(collection)
+            time_col = self._time_column(table)
 
             query = select(table)
             if symbol:
                 query = query.where(table.c.symbol == symbol)
 
-            query = query.order_by(table.c.timestamp.desc()).limit(limit)
+            query = query.order_by(time_col.desc()).limit(limit)
 
             engine = self._ensure_connected()
             with engine.connect() as conn:
@@ -597,14 +620,15 @@ class MySQLAdapter(BaseAdapter):
 
         try:
             table = self._get_table(collection)
+            time_col = self._time_column(table) if (start or end) else None
 
             query = select(func.count()).select_from(table)
 
             conditions = []
             if start:
-                conditions.append(table.c.timestamp >= start)
+                conditions.append(time_col >= start)
             if end:
-                conditions.append(table.c.timestamp < end)
+                conditions.append(time_col < end)
             if symbol:
                 conditions.append(table.c.symbol == symbol)
 

--- a/tests/test_mysql_adapter_methods.py
+++ b/tests/test_mysql_adapter_methods.py
@@ -182,6 +182,93 @@ class TestDisconnectedGuards:
         assert result is None
 
 
+class TestTimeColumnFallback:
+    """#548-adjacent (petrosa-tradeengine) discovery: query_range/query_latest/
+    get_record_count hardcoded ``table.c.timestamp`` for every collection, but
+    the real ``positions`` table (petrosa_k8s/k8s/tradeengine/mysql-schema-job.yaml)
+    has no ``timestamp`` column — only ``entry_time`` — so every call against
+    it raised ``KeyError: 'timestamp'`` (100% reproducible, ~7.8/min in prod).
+    """
+
+    @pytest.fixture
+    def positions_like_adapter(self, sqlite_adapter):
+        """Register a table shaped like the real ``positions`` table: has
+        ``entry_time`` but no ``timestamp`` column."""
+        table = sa.Table(
+            "positions",
+            sqlite_adapter.metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("symbol", sa.String(20), nullable=False),
+            sa.Column("entry_time", sa.DateTime, nullable=False),
+            sa.Column("created_at", sa.DateTime, nullable=False),
+        )
+        table.create(sqlite_adapter.engine, checkfirst=True)
+        sqlite_adapter.tables["positions"] = table
+        with sqlite_adapter.engine.connect() as conn:
+            conn.execute(
+                table.insert(),
+                [
+                    {
+                        "symbol": "BTCUSDT",
+                        "entry_time": datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+                        "created_at": datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+                    }
+                ],
+            )
+            conn.commit()
+        return sqlite_adapter
+
+    def test_query_range_falls_back_to_entry_time(self, positions_like_adapter):
+        rows = positions_like_adapter.query_range(
+            "positions",
+            datetime(2026, 1, 1, tzinfo=UTC),
+            datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        assert len(rows) == 1
+        assert rows[0]["symbol"] == "BTCUSDT"
+
+    def test_query_range_excludes_out_of_range_entry_time(self, positions_like_adapter):
+        rows = positions_like_adapter.query_range(
+            "positions",
+            datetime(2026, 2, 1, tzinfo=UTC),
+            datetime(2026, 2, 2, tzinfo=UTC),
+        )
+        assert rows == []
+
+    def test_query_latest_falls_back_to_entry_time(self, positions_like_adapter):
+        rows = positions_like_adapter.query_latest("positions", limit=1)
+        assert len(rows) == 1
+        assert rows[0]["symbol"] == "BTCUSDT"
+
+    def test_get_record_count_falls_back_to_entry_time(self, positions_like_adapter):
+        count = positions_like_adapter.get_record_count(
+            "positions",
+            start=datetime(2026, 1, 1, tzinfo=UTC),
+            end=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        assert count == 1
+
+    def test_time_column_prefers_timestamp_when_present(self, sqlite_adapter):
+        table = sqlite_adapter._get_table("audit_logs")
+        assert sqlite_adapter._time_column(table) is table.c.timestamp
+
+    def test_time_column_raises_for_table_with_no_known_time_column(
+        self, sqlite_adapter
+    ):
+        table = sa.Table(
+            "mystery_table",
+            sqlite_adapter.metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("symbol", sa.String(20)),
+        )
+        table.create(sqlite_adapter.engine, checkfirst=True)
+        with pytest.raises(
+            DatabaseError, match="no recognized time column"
+        ) as exc_info:
+            sqlite_adapter._time_column(table)
+        assert "mystery_table" in str(exc_info.value)
+
+
 class TestEnsureConnected:
     def test_raises_when_no_engine(self):
         a = MySQLAdapter("mysql://x")


### PR DESCRIPTION
## Summary

Closes #259. Discovered while E2E-verifying an unrelated petrosa-tradeengine fix: 1412 `data-manager POST /api/v1/data/query returned 500` in 3h, ~7.8/min sustained.

`MySQLAdapter.query_range`, `query_latest`, and `get_record_count` hardcoded `table.c.timestamp` for every reflected collection. The real `positions` table (`petrosa_k8s/k8s/tradeengine/mysql-schema-job.yaml:79-99`) has **no `timestamp` column** — only `entry_time DATETIME NOT NULL` and `created_at TIMESTAMP`. Every call against it raised `KeyError: 'timestamp'` — 100% reproducible, not intermittent.

## Fix

- Added `MySQLAdapter._time_column(table)`: tries `timestamp`, then `entry_time`, then `created_at`, in that order — no hardcoded per-collection allowlist, so any current or future reflected table with one of these common time-column names keeps working.
- Updated `query_range`, `query_latest`, `get_record_count` to use it.

## Test plan

- [x] 6 new regression tests (`TestTimeColumnFallback`) covering a synthetic `positions`-shaped table (entry_time, no timestamp): query_range/query_latest/get_record_count all succeed; `timestamp` is still preferred when present; a table with no recognized time column raises a clear `DatabaseError`.
- [x] Full local suite: 1137 passed, 3 skipped, 0 failed.
- [x] ruff check + format clean; pre-commit hooks (lint, format, gitleaks, bandit, test-assertions) all pass.