### PR TITLE
[BUG][P1] Normalize double timezone suffix in mongodb_adapter timestamp parsing

### DIFF
--- a/data_manager/db/mongodb_adapter.py
+++ b/data_manager/db/mongodb_adapter.py
@@ -5,6 +5,7 @@ Handles time series data storage in MongoDB.
 """
 
 import logging
+import re
 from datetime import datetime, timezone
 
 try:
@@ -30,6 +31,27 @@ import constants
 from data_manager.db.base_adapter import BaseAdapter, DatabaseError
 
 logger = logging.getLogger(__name__)
+
+# Matches a numeric UTC offset immediately followed by a literal "Z", e.g.
+# "2026-08-24T00:00:00+00:00Z" — the malformed double-suffix case from #263.
+_DOUBLE_TZ_SUFFIX_RE = re.compile(r"([+-]\d{2}:\d{2})Z$")
+
+
+def _normalize_iso_timestamp(ts: str) -> str:
+    """
+    Normalize a timestamp string into a form ``datetime.fromisoformat`` accepts.
+
+    Handles three malformed producer shapes seen in practice (#263):
+      (a) trailing literal "Z" with no numeric offset -> rewritten to "+00:00"
+      (b) a numeric UTC offset with no "Z" -> passed through unchanged
+      (c) a numeric UTC offset immediately followed by a literal "Z"
+          (double suffix, e.g. "+00:00Z") -> the redundant "Z" is stripped
+    """
+    s = ts.strip()
+    s = _DOUBLE_TZ_SUFFIX_RE.sub(r"\1", s)
+    if s.endswith("Z"):
+        s = f"{s[:-1]}+00:00"
+    return s
 
 
 class MongoDBAdapter(BaseAdapter):
@@ -104,7 +126,21 @@ class MongoDBAdapter(BaseAdapter):
                 if "symbol" in doc and "timestamp" in doc:
                     ts = doc["timestamp"]
                     if isinstance(ts, str):
-                        ts = datetime.fromisoformat(ts)
+                        try:
+                            ts = datetime.fromisoformat(ts)
+                        except ValueError:
+                            # Handle malformed producer timestamps (#263): bare
+                            # "Z" suffix, or a numeric UTC offset with a
+                            # redundant trailing "Z" (e.g. "+00:00Z").
+                            normalized = _normalize_iso_timestamp(ts)
+                            ts = datetime.fromisoformat(normalized)
+                            logger.warning(
+                                "Normalized malformed timestamp %r -> %r for "
+                                "collection %s",
+                                doc["timestamp"],
+                                normalized,
+                                collection,
+                            )
                         # Normalize back into document for correct storage type
                         doc["timestamp"] = ts
                     timestamp_ms = int(ts.timestamp() * 1000)

--- a/tests/test_mongodb_adapter.py
+++ b/tests/test_mongodb_adapter.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 
 import pytest
 
-from data_manager.db.mongodb_adapter import MongoDBAdapter
+from data_manager.db.mongodb_adapter import MongoDBAdapter, _normalize_iso_timestamp
 
 
 def test_prepare_for_bson_basic():
@@ -81,3 +81,40 @@ def test_prepare_for_bson_key_collision(caplog):
 
     # Check that a warning was logged
     assert any("Key collision detected" in record.message for record in caplog.records)
+
+
+class TestNormalizeIsoTimestamp:
+    """Regression coverage for #263 (double timezone suffix)."""
+
+    def test_double_suffix_offset_and_z_strips_redundant_z(self):
+        assert (
+            _normalize_iso_timestamp("2026-08-24T00:00:00+00:00Z")
+            == "2026-08-24T00:00:00+00:00"
+        )
+
+    def test_double_suffix_with_nonzero_offset(self):
+        assert (
+            _normalize_iso_timestamp("2026-08-24T00:00:00+05:30Z")
+            == "2026-08-24T00:00:00+05:30"
+        )
+
+    def test_bare_z_suffix_rewritten_to_offset(self):
+        assert (
+            _normalize_iso_timestamp("2026-08-24T00:00:00Z")
+            == "2026-08-24T00:00:00+00:00"
+        )
+
+    def test_offset_only_passes_through_unchanged(self):
+        assert (
+            _normalize_iso_timestamp("2026-08-24T00:00:00+00:00")
+            == "2026-08-24T00:00:00+00:00"
+        )
+
+    def test_no_timezone_info_passes_through_unchanged(self):
+        assert _normalize_iso_timestamp("2026-08-24T00:00:00") == "2026-08-24T00:00:00"
+
+    def test_result_is_parseable_by_fromisoformat(self):
+        from datetime import datetime
+
+        normalized = _normalize_iso_timestamp("2026-08-24T00:00:00+00:00Z")
+        assert datetime.fromisoformat(normalized) is not None

--- a/tests/test_mongodb_adapter_methods.py
+++ b/tests/test_mongodb_adapter_methods.py
@@ -182,6 +182,57 @@ class TestWrite:
         # Timestamp should have been parsed to datetime
         assert isinstance(doc["timestamp"], datetime)
 
+    @pytest.mark.asyncio
+    async def test_double_tz_suffix_timestamp_is_normalized(self, adapter):
+        """Regression for #263: '+00:00Z' double suffix must not raise."""
+        model = MagicMock()
+        model.model_dump.return_value = {
+            "symbol": "BTCUSDT",
+            "timestamp": "2026-08-24T00:00:00+00:00Z",
+        }
+        coll = MagicMock()
+        coll.insert_many = AsyncMock(return_value=MagicMock(inserted_ids=["x"]))
+        adapter.db.__getitem__ = MagicMock(return_value=coll)
+        n = await adapter.write([model], "klines_15m")
+        assert n == 1
+        doc = coll.insert_many.call_args[0][0][0]
+        assert isinstance(doc["timestamp"], datetime)
+        assert doc["timestamp"] == datetime(2026, 8, 24, 0, 0, 0, tzinfo=UTC)
+
+    @pytest.mark.asyncio
+    async def test_bare_z_suffix_timestamp_is_normalized(self, adapter):
+        """Regression for #263: bare 'Z' with no numeric offset must not raise."""
+        model = MagicMock()
+        model.model_dump.return_value = {
+            "symbol": "BTCUSDT",
+            "timestamp": "2026-08-24T00:00:00Z",
+        }
+        coll = MagicMock()
+        coll.insert_many = AsyncMock(return_value=MagicMock(inserted_ids=["x"]))
+        adapter.db.__getitem__ = MagicMock(return_value=coll)
+        n = await adapter.write([model], "klines_15m")
+        assert n == 1
+        doc = coll.insert_many.call_args[0][0][0]
+        assert isinstance(doc["timestamp"], datetime)
+        assert doc["timestamp"] == datetime(2026, 8, 24, 0, 0, 0, tzinfo=UTC)
+
+    @pytest.mark.asyncio
+    async def test_offset_only_timestamp_is_parsed_directly(self, adapter):
+        """A well-formed numeric-offset-only timestamp needs no normalization."""
+        model = MagicMock()
+        model.model_dump.return_value = {
+            "symbol": "BTCUSDT",
+            "timestamp": "2026-08-24T00:00:00+05:00",
+        }
+        coll = MagicMock()
+        coll.insert_many = AsyncMock(return_value=MagicMock(inserted_ids=["x"]))
+        adapter.db.__getitem__ = MagicMock(return_value=coll)
+        n = await adapter.write([model], "klines_15m")
+        assert n == 1
+        doc = coll.insert_many.call_args[0][0][0]
+        assert isinstance(doc["timestamp"], datetime)
+        assert doc["timestamp"].utcoffset().total_seconds() == 5 * 3600
+
 
 class TestWriteBatch:
     def test_raises_not_implemented(self):


### PR DESCRIPTION
## Summary

`mongodb_adapter.py::write` called `datetime.fromisoformat(ts)` directly on producer-supplied
timestamp strings. A malformed double timezone suffix (`+00:00Z` — both a numeric UTC offset
and a literal `Z`) raised `ValueError`, causing every `klines_15m` insert to fail 500 and driving
a continuous `alerts.extractor.persist_failed` alert storm.

## Changes

- `data_manager/db/mongodb_adapter.py`:
  - Added `_normalize_iso_timestamp()` — strips a redundant literal `Z` following a numeric UTC
    offset, and rewrites a bare trailing `Z` (no offset) to `+00:00` for pre-3.11
    `fromisoformat()` compatibility.
  - `write()` now falls back to the normalizer only on `ValueError` from the direct parse, and
    logs a warning noting the malformed input string was normalized — well-formed timestamps
    take the original fast path unchanged.
- Regression tests added:
  - `tests/test_mongodb_adapter.py::TestNormalizeIsoTimestamp` — unit coverage of the normalizer
    (double suffix, bare `Z`, offset-only, no-tz, and a `fromisoformat()` round-trip check).
  - `tests/test_mongodb_adapter_methods.py` — end-to-end `write()` coverage for the double-suffix
    case, the bare-`Z` case, and a well-formed offset-only case (unchanged behavior).

## Root cause (producer side)

Traced to `petrosa-binance-data-extractor`'s `models/base.py` `json_encoders`, which
unconditionally appends `+ "Z"` to an already timezone-aware `.isoformat()` output. Filed as a
follow-up per this ticket's own scope note ("do not silently mask the upstream bug by only
patching the parser"): PetroSa2/petrosa-binance-data-extractor#278.

## Testing

- `pytest tests/test_mongodb_adapter.py tests/test_mongodb_adapter_methods.py -q` — 71 passed
- Full suite: `pytest tests/ --cov=. --cov-fail-under=40` — 1146 passed, 3 skipped, 85.76% coverage
- `ruff check` / `ruff format --check` — clean
- `pre-commit run --all-files` (via pre-push hook) — all hooks passed

Closes #263
