### PR TITLE
fix: #262 - update_records UnboundLocalError + real persistence for PUT updates

### DIFF
--- a/data_manager/api/routes/generic.py
+++ b/data_manager/api/routes/generic.py
@@ -452,8 +452,9 @@ async def update_records(
             # For updates, validate the updated data
             await _validate_data_against_schema(database, schema, [request.data])
 
-        # For now, implement a simple update by querying and re-inserting
-        # In a real implementation, you'd use proper update operations
+        # Determine which records match the filter (drives the early-return /
+        # upsert-create branching below); the actual persistence happens via
+        # adapter.update() further down, not by re-writing these in-memory rows.
 
         # Query existing records
         if database == "mysql":
@@ -479,18 +480,52 @@ async def update_records(
                 },
             }
 
-        # Update records
-        for _updated_count, record in enumerate(matching_records, 1):
-            # Merge update data
-            record.update(request.data)
-            record["updated_at"] = datetime.now(UTC)
+        # Update records: persist via a real UPDATE (mysql) / update_many
+        # (MongoDB) so changes actually land in the database instead of only
+        # mutating the in-memory dicts pulled from query_range() — those were
+        # previously discarded, and `updated_count` was only ever assigned on
+        # the empty-match/upsert branch below, causing an UnboundLocalError
+        # (500) on every update of an existing record (petrosa-data-manager#262).
+        if matching_records:
+            update_data = dict(request.data)
+            update_data["updated_at"] = datetime.now(UTC)
+
+            if database == "mysql":
+                from data_manager.utils.circuit_breaker import CircuitBreakerOpenError
+
+                try:
+                    updated_count = adapter.update(
+                        collection, request.filter, update_data
+                    )
+                except CircuitBreakerOpenError as exc:
+                    api_module.db_manager.increment_error_count(database)
+                    raise HTTPException(status_code=503, detail=str(exc)) from exc
+            else:  # MongoDB
+                updated_count = await adapter.update(
+                    collection, request.filter, update_data
+                )
 
         # If upsert and no matches, create new record
-        if not matching_records and request.upsert:
+        elif request.upsert:
             new_record = request.data.copy()
             new_record["created_at"] = datetime.now(UTC)
             new_record["updated_at"] = datetime.now(UTC)
-            updated_count = 1
+
+            from pydantic import BaseModel, ConfigDict
+
+            class GenericModel(BaseModel):
+                model_config = ConfigDict(extra="allow")
+
+            model_instance = GenericModel(**new_record)
+
+            if database == "mysql":
+                write_result = adapter.write([model_instance], collection)
+                updated_count = write_result.inserted
+            else:  # MongoDB
+                updated_count = await adapter.write([model_instance], collection)
+
+        else:
+            updated_count = 0
 
         # Track metrics
         api_module.db_manager.increment_query_count(database)
@@ -505,6 +540,8 @@ async def update_records(
             },
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error updating {database}.{collection}: {e}", exc_info=True)
         api_module.db_manager.increment_error_count(database)

--- a/data_manager/db/mongodb_adapter.py
+++ b/data_manager/db/mongodb_adapter.py
@@ -151,6 +151,49 @@ class MongoDBAdapter(BaseAdapter):
             "Use write() method directly for MongoDB. Batching should be done at caller level."
         )
 
+    async def update(
+        self, collection: str, filter_dict: dict[str, Any], data: dict[str, Any]
+    ) -> int:
+        """Update existing documents matching ``filter_dict`` with ``data``.
+
+        Companion to :class:`MySQLAdapter`'s ``update()`` — required so
+        ``PUT /api/v1/{database}/{collection}`` (``generic.py::update_records``)
+        actually persists changes to existing MongoDB documents instead of only
+        mutating an in-memory copy that is discarded (petrosa-data-manager#262).
+
+        Args:
+            collection: Collection name.
+            filter_dict: Equality conditions identifying documents to update.
+            data: Field values to set via ``$set``.
+
+        Returns:
+            Number of documents modified.
+
+        Raises:
+            DatabaseError: If not connected, if ``filter_dict`` is empty
+                (refuses to run an unconditional update-all), or if the update
+                fails.
+        """
+        if not self._connected:
+            raise DatabaseError("Not connected to database")
+
+        if not filter_dict:
+            raise DatabaseError(
+                "update() refused: empty filter would update every document "
+                f"in {collection}"
+            )
+
+        if not data:
+            return 0
+
+        try:
+            coll = self.db[collection]
+            update_data = self._prepare_for_bson(dict(data))
+            result = await coll.update_many(filter_dict, {"$set": update_data})
+            return int(result.modified_count)
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to update {collection}: {e}") from e
+
     async def query_range(
         self,
         collection: str,

--- a/data_manager/db/mysql_adapter.py
+++ b/data_manager/db/mysql_adapter.py
@@ -551,6 +551,100 @@ class MySQLAdapter(BaseAdapter):
 
         return WriteResult(inserted=inserted, duplicates=duplicates, failed=failed)
 
+    def update(
+        self, collection: str, filter_dict: dict[str, Any], data: dict[str, Any]
+    ) -> int:
+        """Update existing rows in MySQL matching ``filter_dict`` with ``data``.
+
+        Unlike :meth:`write` (INSERT / ON DUPLICATE KEY UPDATE / INSERT IGNORE,
+        keyed by the table's unique index), this issues a genuine
+        ``UPDATE ... WHERE`` built from equality conditions on ``filter_dict``.
+        Required so ``PUT /api/v1/mysql/{collection}`` (``generic.py::update_records``)
+        actually persists changes to existing rows instead of only mutating an
+        in-memory copy that is discarded (petrosa-data-manager#262).
+
+        Args:
+            collection: Table name.
+            filter_dict: Equality conditions identifying rows to update. Keys
+                that don't match a column on the table are ignored.
+            data: Column values to set. Keys that don't match a column on the
+                table are ignored.
+
+        Returns:
+            Number of rows updated (SQL rowcount).
+
+        Raises:
+            DatabaseError: If not connected, if ``filter_dict`` yields no usable
+                equality conditions against the table's columns (refuses to run
+                an unconditional UPDATE that would touch every row), or if the
+                update ultimately fails after retries.
+        """
+        if not self._connected:
+            raise DatabaseError("Not connected to database")
+
+        table = self._get_table(collection)
+
+        conditions = [
+            table.c[key] == value
+            for key, value in filter_dict.items()
+            if key in table.c
+        ]
+        if not conditions:
+            raise DatabaseError(
+                f"update() refused: filter {filter_dict!r} matches no columns "
+                f"on {collection} — would UPDATE every row"
+            )
+
+        values: dict[str, Any] = {}
+        for key, value in data.items():
+            if key not in table.c:
+                continue
+            if isinstance(value, str) and key.endswith(("_at", "timestamp")):
+                try:
+                    value = datetime.fromisoformat(value)
+                except (ValueError, TypeError):
+                    pass
+            values[key] = value
+
+        if not values:
+            return 0
+
+        def _update_attempt() -> int:
+            engine = self._ensure_connected()
+            with engine.connect() as conn:
+                trans = conn.begin()
+                try:
+                    stmt = table.update().where(and_(*conditions)).values(**values)
+                    result = conn.execute(stmt)
+                    trans.commit()
+                    return int(result.rowcount or 0)
+                except Exception:
+                    trans.rollback()
+                    raise
+
+        def _update_with_retry() -> int:
+            try:
+                return retry_transient(_update_attempt)
+            except IntegrityError:
+                logger.warning("Integrity error updating %s — not retried", collection)
+                raise
+            except DatabaseError:
+                raise
+            except Exception as exc:
+                raise DatabaseError(f"Error in MySQL update: {exc}") from exc
+
+        try:
+            return self.circuit_breaker.call(_update_with_retry)
+        except IntegrityError:
+            self._record_write_failure(collection, "integrity_error")
+            raise
+        except DatabaseError:
+            self._record_write_failure(collection, "database_error")
+            raise
+        except Exception:
+            self._record_write_failure(collection, "circuit_or_unknown")
+            raise
+
     def query_range(
         self,
         collection: str,

--- a/tests/test_generic_update_records.py
+++ b/tests/test_generic_update_records.py
@@ -1,0 +1,162 @@
+"""
+Regression tests for PUT /api/v1/{database}/{collection} (generic.py::update_records).
+
+Covers petrosa-data-manager#262: `updated_count` was only ever assigned on the
+empty-match/upsert-create branch, so any update targeting existing records
+(the common case) raised UnboundLocalError -> HTTP 500. These tests exercise
+both the previously-broken "matching_records non-empty" path and the
+previously-working "empty-match/upsert-create" path to guard against
+regression, plus the "no match / no upsert" no-op path.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.utils.circuit_breaker import CircuitBreakerOpenError
+
+
+@pytest.fixture
+def client(mock_db_manager):
+    """Create test client with mocked database adapters."""
+    mock_db_manager.mongodb_adapter = Mock()
+    mock_db_manager.mongodb_adapter.query_range = AsyncMock(return_value=[])
+    mock_db_manager.mongodb_adapter.write = AsyncMock(return_value=1)
+    mock_db_manager.mongodb_adapter.update = AsyncMock(return_value=1)
+
+    mock_db_manager.mysql_adapter = Mock()
+    mock_db_manager.mysql_adapter.query_range = Mock(return_value=[])
+    mock_db_manager.mysql_adapter.write = Mock()
+    mock_db_manager.mysql_adapter.update = Mock(return_value=1)
+
+    app = api_module.create_app()
+    api_module.db_manager = mock_db_manager
+    yield TestClient(app)
+    api_module.db_manager = None
+
+
+def test_update_existing_record_mysql_returns_200_not_500(client):
+    """The core regression: updating an EXISTING mysql.positions row must not 500."""
+    client.app.state  # noqa: B018 - touch app to keep TestClient warm
+    api_module.db_manager.mysql_adapter.query_range = Mock(
+        return_value=[{"symbol": "BTCUSDT", "side": "SHORT", "quantity": 1.0}]
+    )
+
+    response = client.put(
+        "/api/v1/mysql/positions",
+        json={
+            "filter": {"symbol": "BTCUSDT", "side": "SHORT"},
+            "data": {"quantity": 2.0},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["updated_count"] == 1
+    assert "Successfully updated 1 records" in body["message"]
+
+    api_module.db_manager.mysql_adapter.update.assert_called_once()
+    call_args = api_module.db_manager.mysql_adapter.update.call_args
+    assert call_args.args[0] == "positions"
+    assert call_args.args[1] == {"symbol": "BTCUSDT", "side": "SHORT"}
+    assert call_args.args[2]["quantity"] == 2.0
+    assert "updated_at" in call_args.args[2]
+
+
+def test_update_existing_record_mongodb_returns_200(client):
+    """Same non-empty-match path against the MongoDB adapter."""
+    api_module.db_manager.mongodb_adapter.query_range = AsyncMock(
+        return_value=[{"symbol": "BTCUSDT", "pnl": 10.0}]
+    )
+
+    response = client.put(
+        "/api/v1/mongodb/daily_pnl",
+        json={"filter": {"symbol": "BTCUSDT"}, "data": {"pnl": 25.0}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["updated_count"] == 1
+
+    api_module.db_manager.mongodb_adapter.update.assert_called_once()
+
+
+def test_update_no_match_no_upsert_is_noop(client):
+    """No matching records and upsert=False: 200, updated_count=0, no write attempted."""
+    api_module.db_manager.mysql_adapter.query_range = Mock(return_value=[])
+
+    response = client.put(
+        "/api/v1/mysql/positions",
+        json={"filter": {"symbol": "NOPE"}, "data": {"quantity": 1.0}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["updated_count"] == 0
+    assert body["message"] == "No records found matching filter"
+    api_module.db_manager.mysql_adapter.update.assert_not_called()
+    api_module.db_manager.mysql_adapter.write.assert_not_called()
+
+
+def test_update_no_match_with_upsert_creates_record_mysql(client):
+    """Empty-match/upsert-create path (previously the only working path) — no regression."""
+    from data_manager.db.mysql_adapter import WriteResult
+
+    api_module.db_manager.mysql_adapter.query_range = Mock(return_value=[])
+    api_module.db_manager.mysql_adapter.write = Mock(
+        return_value=WriteResult(inserted=1, duplicates=0, failed=0)
+    )
+
+    response = client.put(
+        "/api/v1/mysql/positions",
+        json={
+            "filter": {"symbol": "ETHUSDT"},
+            "data": {"symbol": "ETHUSDT", "quantity": 3.0},
+            "upsert": True,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["updated_count"] == 1
+    api_module.db_manager.mysql_adapter.write.assert_called_once()
+    api_module.db_manager.mysql_adapter.update.assert_not_called()
+
+
+def test_update_no_match_with_upsert_creates_record_mongodb(client):
+    """Empty-match/upsert-create path against MongoDB — no regression."""
+    api_module.db_manager.mongodb_adapter.query_range = AsyncMock(return_value=[])
+    api_module.db_manager.mongodb_adapter.write = AsyncMock(return_value=1)
+
+    response = client.put(
+        "/api/v1/mongodb/daily_pnl",
+        json={
+            "filter": {"symbol": "ETHUSDT"},
+            "data": {"symbol": "ETHUSDT", "pnl": 5.0},
+            "upsert": True,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["updated_count"] == 1
+    api_module.db_manager.mongodb_adapter.write.assert_called_once()
+
+
+def test_update_circuit_breaker_open_returns_503(client):
+    """A tripped MySQL circuit breaker on update() surfaces as 503, not 500."""
+    api_module.db_manager.mysql_adapter.query_range = Mock(
+        return_value=[{"symbol": "BTCUSDT"}]
+    )
+    api_module.db_manager.mysql_adapter.update = Mock(
+        side_effect=CircuitBreakerOpenError("mysql_write", 30)
+    )
+
+    response = client.put(
+        "/api/v1/mysql/positions",
+        json={"filter": {"symbol": "BTCUSDT"}, "data": {"quantity": 1.0}},
+    )
+
+    assert response.status_code == 503

--- a/tests/test_update_method_adapters.py
+++ b/tests/test_update_method_adapters.py
@@ -1,0 +1,165 @@
+"""
+Coverage for MySQLAdapter.update() / MongoDBAdapter.update() (petrosa-data-manager#262).
+
+These back the PUT /api/v1/{database}/{collection} route (generic.py::update_records)
+and are what actually persist a change to an existing row/document — the route-level
+tests in test_generic_update_records.py mock these methods; here we exercise the
+real SQL UPDATE against an in-memory SQLite engine and the motor update_many() call
+for MongoDB.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import sqlalchemy as sa
+
+from data_manager.db.base_adapter import DatabaseError
+from data_manager.db.mongodb_adapter import MongoDBAdapter
+from data_manager.db.mysql_adapter import MySQLAdapter
+
+
+@pytest.fixture
+def positions_adapter():
+    """MySQLAdapter backed by SQLite with a positions-shaped table pre-seeded."""
+    a = MySQLAdapter("sqlite:///:memory:")
+    a.engine_options = {}
+    a.engine = sa.create_engine("sqlite:///:memory:")
+    a._connected = True
+    a._create_tables()
+
+    table = sa.Table(
+        "positions",
+        a.metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("symbol", sa.String(20), nullable=False),
+        sa.Column("side", sa.String(10), nullable=False),
+        sa.Column("quantity", sa.Float, nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=True),
+    )
+    table.create(a.engine, checkfirst=True)
+    a.tables["positions"] = table
+    with a.engine.connect() as conn:
+        conn.execute(
+            table.insert(),
+            [
+                {
+                    "symbol": "BTCUSDT",
+                    "side": "SHORT",
+                    "quantity": 1.0,
+                    "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+                },
+                {
+                    "symbol": "ETHUSDT",
+                    "side": "LONG",
+                    "quantity": 5.0,
+                    "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+                },
+            ],
+        )
+        conn.commit()
+    return a
+
+
+class TestMySQLAdapterUpdate:
+    def test_update_existing_row_persists_and_returns_rowcount(self, positions_adapter):
+        rowcount = positions_adapter.update(
+            "positions",
+            {"symbol": "BTCUSDT", "side": "SHORT"},
+            {"quantity": 2.5},
+        )
+        assert rowcount == 1
+
+        rows = positions_adapter.query_range("positions", datetime.min, datetime.max)
+        btc = next(r for r in rows if r["symbol"] == "BTCUSDT")
+        assert btc["quantity"] == 2.5
+        eth = next(r for r in rows if r["symbol"] == "ETHUSDT")
+        assert eth["quantity"] == 5.0  # untouched
+
+    def test_update_no_matching_rows_returns_zero(self, positions_adapter):
+        rowcount = positions_adapter.update(
+            "positions", {"symbol": "NOPE"}, {"quantity": 9.0}
+        )
+        assert rowcount == 0
+
+    def test_update_empty_filter_refuses_full_table_update(self, positions_adapter):
+        with pytest.raises(DatabaseError, match="would UPDATE every row") as exc_info:
+            positions_adapter.update("positions", {}, {"quantity": 9.0})
+        assert "would UPDATE every row" in str(exc_info.value)
+
+    def test_update_filter_key_not_a_column_refuses(self, positions_adapter):
+        with pytest.raises(DatabaseError, match="would UPDATE every row") as exc_info:
+            positions_adapter.update(
+                "positions", {"not_a_column": "x"}, {"quantity": 9.0}
+            )
+        assert "would UPDATE every row" in str(exc_info.value)
+
+    def test_update_data_with_no_matching_columns_is_noop(self, positions_adapter):
+        rowcount = positions_adapter.update(
+            "positions",
+            {"symbol": "BTCUSDT"},
+            {"not_a_column": "x"},
+        )
+        assert rowcount == 0
+
+    def test_update_raises_when_disconnected(self, positions_adapter):
+        positions_adapter._connected = False
+        with pytest.raises(DatabaseError, match="Not connected") as exc_info:
+            positions_adapter.update(
+                "positions", {"symbol": "BTCUSDT"}, {"quantity": 1.0}
+            )
+        assert "Not connected" in str(exc_info.value)
+
+    def test_update_isoformat_timestamp_string_is_coerced(self, positions_adapter):
+        rowcount = positions_adapter.update(
+            "positions",
+            {"symbol": "ETHUSDT"},
+            {"updated_at": "2026-08-25T00:00:00+00:00"},
+        )
+        assert rowcount == 1
+        rows = positions_adapter.query_range("positions", datetime.min, datetime.max)
+        eth = next(r for r in rows if r["symbol"] == "ETHUSDT")
+        assert eth["updated_at"] is not None
+
+
+class TestMongoDBAdapterUpdate:
+    @pytest.fixture
+    def adapter(self):
+        a = MongoDBAdapter("mongodb://localhost:27017/test_db")
+        a.client = MagicMock()
+        a.db = MagicMock()
+        a._connected = True
+        return a
+
+    @pytest.mark.asyncio
+    async def test_update_calls_update_many_and_returns_modified_count(self, adapter):
+        coll = MagicMock()
+        coll.update_many = AsyncMock(return_value=MagicMock(modified_count=1))
+        adapter.db.__getitem__.return_value = coll
+
+        result = await adapter.update("daily_pnl", {"symbol": "BTCUSDT"}, {"pnl": 42.0})
+
+        assert result == 1
+        coll.update_many.assert_called_once()
+        call_args = coll.update_many.call_args
+        assert call_args.args[0] == {"symbol": "BTCUSDT"}
+        assert call_args.args[1] == {"$set": {"pnl": 42.0}}
+
+    @pytest.mark.asyncio
+    async def test_update_empty_filter_refuses_update_all(self, adapter):
+        with pytest.raises(DatabaseError, match="update every document") as exc_info:
+            await adapter.update("daily_pnl", {}, {"pnl": 1.0})
+        assert "update every document" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_update_empty_data_is_noop(self, adapter):
+        result = await adapter.update("daily_pnl", {"symbol": "BTCUSDT"}, {})
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_update_raises_when_disconnected(self, adapter):
+        adapter._connected = False
+        with pytest.raises(DatabaseError, match="Not connected") as exc_info:
+            await adapter.update("daily_pnl", {"symbol": "BTCUSDT"}, {"pnl": 1.0})
+        assert "Not connected" in str(exc_info.value)


### PR DESCRIPTION
## Problem

Every `PUT /api/v1/mysql/positions` and `PUT /api/v1/mysql/daily_pnl` against an **existing**
record returned HTTP 500:

```
UnboundLocalError: cannot access local variable 'updated_count' where it is not associated with a value
```

`data_manager/api/routes/generic.py::update_records` enumerated its update loop into a
throwaway `_updated_count` variable and only ever assigned `updated_count` on the
empty-match/upsert-create branch. Any update against a non-empty `matching_records` set
(the common, expected case) crashed.

**Downstream impact:** `tradeengine.position_reconciler` could never persist accurate
position/PnL state, driving continuous `malformed_position` / `unhedged` divergence
reports and retry loops (see companion `-4130` ticket in `petrosa-tradeengine`).

## Root cause + fix

1. **The crash**: fixed by having the non-empty-match branch call the new
   `adapter.update()` (see below) and use its return value as `updated_count`, instead of
   the dead `_updated_count` enumerate variable.
2. **A second, related defect** flagged in the ticket: even without the crash, the route
   only mutated in-memory dicts pulled from `query_range()` and never wrote them back —
   updates would have silently done nothing once (1) was patched. Also, the
   empty-match/upsert-create branch built a `new_record` dict but never persisted it either.
   Both are fixed by actually persisting via the adapters:
   - `MySQLAdapter.update(collection, filter_dict, data)`: issues a real
     `UPDATE ... WHERE` (equality conditions from `filter_dict`), reusing the existing
     retry/circuit-breaker conventions from `write()`. Refuses to run if `filter_dict`
     resolves to zero usable conditions (would otherwise UPDATE every row).
   - `MongoDBAdapter.update(collection, filter_dict, data)`: `update_many(filter_dict,
     {"$set": data})`. Same empty-filter guard.
   - The upsert-create branch now actually calls `adapter.write()` for the new record.
   - `CircuitBreakerOpenError` on update now surfaces as 503 (matching `insert_records`),
     not a generic 500.

## Testing

- `tests/test_generic_update_records.py` — route-level: existing-record update (mysql +
  mongo, the core regression), no-match/no-upsert no-op, empty-match/upsert-create
  (mysql + mongo, no-regression on the previously-only-working path), circuit-breaker-open
  → 503.
- `tests/test_update_method_adapters.py` — adapter-level: real SQLite `UPDATE` verified
  end-to-end (row actually changes, untouched rows don't), no-match, empty-filter refusal,
  filter-key-not-a-column refusal, disconnected guard, timestamp-string coercion; MongoDB
  `update_many` call shape + empty-filter/empty-data guards, disconnected guard.
- `make lint` (ruff) — clean.
- `make test` — full suite: **1154 passed, 3 skipped** (pre-existing, unrelated), coverage
  85.88% (threshold 40%).
- `mypy` on the three touched files — no new errors (all remaining repo-wide mypy findings
  are pre-existing and unrelated to this change).

## Acceptance criteria

- [x] `PUT /api/v1/mysql/positions` against an existing position record returns HTTP 200
      with a correct `updated_count`, not a 500.
- [x] `PUT /api/v1/mysql/daily_pnl` against an existing daily PnL row returns HTTP 200.
- [x] New unit/integration tests cover `matching_records` non-empty with no
      `UnboundLocalError` and a correct `updated_count`.
- [x] Existing empty-match/upsert-create path still passes (no regression) — and is now
      also actually persisted (previously built the record but discarded it).
- [ ] Live verification (post-deploy): `tradeengine` `PositionReconciler` divergence count
      trending to 0 within one reconciliation window — deferred to deploy-verification/
      operator monitoring per standard process, not verifiable from this sandbox.

Closes #262
