### PR TITLE
fix: reject MongoDB update() filters with query operators (equality-only) — #262 follow-up

### DIFF
--- a/data_manager/db/mongodb_adapter.py
+++ b/data_manager/db/mongodb_adapter.py
@@ -207,8 +207,10 @@ class MongoDBAdapter(BaseAdapter):
 
         Raises:
             DatabaseError: If not connected, if ``filter_dict`` is empty
-                (refuses to run an unconditional update-all), or if the update
-                fails.
+                (refuses to run an unconditional update-all), if
+                ``filter_dict`` contains a MongoDB query operator (any key
+                starting with ``$`` or any value that is itself a dict —
+                e.g. ``{"$gte": 5}``), or if the update fails.
         """
         if not self._connected:
             raise DatabaseError("Not connected to database")
@@ -218,6 +220,22 @@ class MongoDBAdapter(BaseAdapter):
                 "update() refused: empty filter would update every document "
                 f"in {collection}"
             )
+
+        # `filter_dict` originates from the PUT request body's `filter` field
+        # (generic.py::UpdateRequest), the same object used to compute
+        # `matching_records` via the equality-only, in-memory `_apply_filter`.
+        # Passed unguarded, MongoDB would interpret operator keys/values
+        # ("$where", "$expr", {"$gte": ...}, ...) as query operators instead
+        # of literal equality — silently updating far more documents than the
+        # equality match implied elsewhere in the route. Enforce the same
+        # equality-only semantics here so `matching_records` and the actual
+        # persisted update never diverge (petrosa-data-manager#262 review).
+        for key, value in filter_dict.items():
+            if key.startswith("$") or isinstance(value, dict):
+                raise DatabaseError(
+                    "update() refused: filter must be a flat equality match, "
+                    f"got operator-like entry {key!r}: {value!r}"
+                )
 
         if not data:
             return 0

--- a/tests/test_update_method_adapters.py
+++ b/tests/test_update_method_adapters.py
@@ -158,6 +158,18 @@ class TestMongoDBAdapterUpdate:
         assert result == 0
 
     @pytest.mark.asyncio
+    async def test_update_rejects_dollar_key_filter_operator(self, adapter):
+        with pytest.raises(DatabaseError, match="flat equality match") as exc_info:
+            await adapter.update("daily_pnl", {"$where": "1==1"}, {"pnl": 1.0})
+        assert "flat equality match" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_nested_operator_expression_filter(self, adapter):
+        with pytest.raises(DatabaseError, match="flat equality match") as exc_info:
+            await adapter.update("daily_pnl", {"pnl": {"$gte": 0}}, {"pnl": 1.0})
+        assert "flat equality match" in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_update_raises_when_disconnected(self, adapter):
         adapter._connected = False
         with pytest.raises(DatabaseError, match="Not connected") as exc_info:


### PR DESCRIPTION
## Summary

Follow-up hardening for #262. `MongoDBAdapter.update()` (added in #266) passed `filter_dict`
straight through to Motor's `update_many(filter_dict, {"$set": data})`. `filter_dict` originates
from the PUT request body's `filter` field, the same object `generic.py::update_records` uses to
compute `matching_records` via an **equality-only**, in-memory `_apply_filter`. Left unguarded,
MongoDB interprets `$`-prefixed keys or dict-valued fields (`{"$where": ...}`, `{"pnl": {"$gte":
0}}`, etc.) as query operators instead of literal equality — silently updating more documents
than the equality match computed elsewhere in the route implied. This is a filter-widening /
NoSQL-injection-adjacent gap, not present in `MySQLAdapter.update()` (SQLAlchemy already
parameterizes values and only matches known table columns).

## Change

- `MongoDBAdapter.update()` now rejects any `filter_dict` entry where the key starts with `$` or
  the value is itself a dict, enforcing flat-equality-only semantics consistent with
  `matching_records`.
- 2 new regression tests: `$where`-style key rejection, nested `{"$gte": ...}` value rejection.

## Verification

- `tests/test_update_method_adapters.py`: 13 passed.
- `make test`: 1165 passed, 3 skipped, 85.93% coverage (40% threshold).

## Context

Discovered as uncommitted local work-in-progress left behind when this session's review/merge of
#266 raced past a concurrent orchestrator run still iterating on the same ticket. Completed and
shipped separately since #266/#262 are already merged/Done.

Related: #262, #266

