### PR TITLE
fix(mysql): provision daily_pnl table so tradeengine daily PnL writes stop 500ing

### DIFF
--- a/data_manager/db/mysql_adapter.py
+++ b/data_manager/db/mysql_adapter.py
@@ -275,6 +275,25 @@ class MySQLAdapter(BaseAdapter):
             Index("idx_schemas_name_version", "name", "version", unique=True),
         )
 
+        # Daily P&L table (petrosa-data-manager#264) — persists tradeengine's
+        # per-day realized P&L snapshot (PUT /api/v1/mysql/daily_pnl, filtered
+        # by "date"). Unlike positions/trades — which tradeengine provisions
+        # externally via petrosa_k8s/k8s/tradeengine/mysql-schema-job.yaml and
+        # data-manager only reflects — this table is self-managed here so it
+        # self-heals via metadata.create_all() on every connect(): no manual
+        # kubectl Job step is required for it to exist or survive environment
+        # rebuilds (issue #264 AC4).
+        self.tables["daily_pnl"] = Table(
+            "daily_pnl",
+            self.metadata,
+            Column("id", String(64), primary_key=True),
+            Column("date", String(10), nullable=False),
+            Column("daily_pnl", Numeric(20, 8), nullable=False),
+            Column("created_at", DateTime, nullable=False),
+            Column("updated_at", DateTime, nullable=False),
+            Index("idx_daily_pnl_date", "date", unique=True),
+        )
+
         # Create all tables
         if self.engine is not None:
             self.metadata.create_all(self.engine)

--- a/tests/test_264_daily_pnl_table.py
+++ b/tests/test_264_daily_pnl_table.py
@@ -1,0 +1,65 @@
+"""Tests for petrosa-data-manager#264 — self-managed `daily_pnl` MySQL table.
+
+Prior to this fix, `daily_pnl` was written by petrosa-tradeengine
+(`PUT /api/v1/mysql/daily_pnl`) but never provisioned anywhere, so
+`MySQLAdapter._get_table("daily_pnl")` fell through to the reflect-or-fail
+branch and raised `DatabaseError: Unknown collection or failed to reflect:
+daily_pnl` (wrapping SQLAlchemy's `NoSuchTableError`) on every call.
+"""
+
+from data_manager.db.mysql_adapter import MySQLAdapter
+
+
+def _index_names(adapter, table_name):
+    table = adapter.tables[table_name]
+    return {idx.name for idx in table.indexes}
+
+
+def test_daily_pnl_table_is_registered_on_create_tables():
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter._create_tables()
+    assert "daily_pnl" in adapter.tables
+
+
+def test_daily_pnl_has_expected_columns():
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter._create_tables()
+    table = adapter.tables["daily_pnl"]
+    col_names = {c.name for c in table.columns}
+    # Must match the fields petrosa-tradeengine's shared/mysql_client.py
+    # sends on PUT /api/v1/mysql/daily_pnl (date, daily_pnl) plus the
+    # server-injected audit columns (created_at, updated_at) and the
+    # adapter-generated primary key (id).
+    assert {"id", "date", "daily_pnl", "created_at", "updated_at"} <= col_names
+
+
+def test_daily_pnl_date_column_has_unique_index():
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter._create_tables()
+    names = _index_names(adapter, "daily_pnl")
+    assert "idx_daily_pnl_date" in names, (
+        f"Expected idx_daily_pnl_date in daily_pnl indexes, got: {names}"
+    )
+    table = adapter.tables["daily_pnl"]
+    idx = next(i for i in table.indexes if i.name == "idx_daily_pnl_date")
+    assert idx.unique is True
+    col_names = [c.name for c in idx.columns]
+    assert col_names == ["date"]
+
+
+def test_daily_pnl_has_a_recognized_time_column():
+    # _time_column() (query_range/query_latest/get_record_count) requires
+    # one of timestamp/entry_time/created_at — daily_pnl relies on
+    # created_at, so this must not raise.
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter._create_tables()
+    table = adapter.tables["daily_pnl"]
+    col = adapter._time_column(table)
+    assert col.name == "created_at"
+
+
+def test_get_table_returns_daily_pnl_without_reflecting():
+    adapter = MySQLAdapter("sqlite:///:memory:")
+    adapter._create_tables()
+    table = adapter._get_table("daily_pnl")
+    assert table.name == "daily_pnl"

--- a/tests/test_mysql_adapter_methods.py
+++ b/tests/test_mysql_adapter_methods.py
@@ -102,6 +102,7 @@ class TestCreateTablesViaConnect:
             "backfill_jobs",
             "lineage_records",
             "schemas",
+            "daily_pnl",
         ):
             assert table_name in a.tables
 
@@ -110,6 +111,14 @@ class TestGetTable:
     def test_returns_pre_registered_table(self, sqlite_adapter):
         table = sqlite_adapter._get_table("datasets")
         assert table.name == "datasets"
+
+    def test_returns_daily_pnl_table_without_reflecting(self, sqlite_adapter):
+        # petrosa-data-manager#264: daily_pnl is self-managed (registered in
+        # _create_tables()), so _get_table() must return it directly instead
+        # of falling into the reflect-or-fail branch that used to raise
+        # NoSuchTableError / "Unknown collection or failed to reflect".
+        table = sqlite_adapter._get_table("daily_pnl")
+        assert table.name == "daily_pnl"
 
     def test_creates_klines_table_from_binance_interval(self, sqlite_adapter):
         # klines_15m → physical klines_m15


### PR DESCRIPTION
## Problem

`petrosa-data-manager` never provisioned a `daily_pnl` MySQL table. Every
`PUT /api/v1/mysql/daily_pnl` write from `petrosa-tradeengine`'s
`shared/mysql_client.py` hit `mysql_adapter.py::_get_table()`'s reflect-or-fail
branch and raised:

```
sqlalchemy.exc.NoSuchTableError: daily_pnl
data_manager.db.base_adapter.DatabaseError: Unknown collection or failed to reflect: daily_pnl
```

...returning HTTP 500 and blocking daily P&L persistence.

## Fix

Register `daily_pnl` as a **self-managed** table in
`MySQLAdapter._create_tables()`, following the exact same convention already
used for `datasets` / `audit_logs` / `health_metrics` / `backfill_jobs` /
`lineage_records` / `schemas`.

Unlike `positions`/`trades` (which `tradeengine` provisions externally via
`petrosa_k8s/k8s/tradeengine/mysql-schema-job.yaml`, and data-manager only
reflects), `daily_pnl` is not owned/provisioned by any other repo — so it's a
better fit for data-manager's own self-managed-table mechanism, which already
self-heals via `metadata.create_all()` on every `connect()`. No manual
`kubectl apply` Job step is required for the table to exist or to survive
environment rebuilds — satisfies AC4 without touching `petrosa_k8s`.

**Schema** (columns match the exact payload `tradeengine` sends via
`get_daily_pnl`/`update_daily_pnl`):

| column | type | notes |
|---|---|---|
| `id` | `String(64)` PK | adapter-generated UUID (same pattern as other self-managed tables) |
| `date` | `String(10)` | `"YYYY-MM-DD"`, unique index — matches `filter={"date": date}` upsert |
| `daily_pnl` | `Numeric(20, 8)` | signed float, can be a loss |
| `created_at` | `DateTime` | required — satisfies `_time_column()`'s fallback list |
| `updated_at` | `DateTime` | |

## Testing

- New `tests/test_264_daily_pnl_table.py` (5 tests): table registration,
  column set, unique index on `date`, `_time_column()` resolution, and
  `_get_table("daily_pnl")` no longer falling into the reflect branch.
- Added `daily_pnl` to the existing membership check in
  `tests/test_mysql_adapter_methods.py::TestCreateTablesViaConnect` and added
  a regression test asserting `_get_table` returns it directly.
- Full suite: `1171 passed, 3 skipped`, coverage 85.95% (threshold 40%).
- `make format` / `make lint`: clean. `make type-check`: no new errors
  introduced (pre-existing unrelated errors only). `make security`
  (bandit/detect-secrets): no new findings.

## Acceptance criteria (issue #264)

- [x] `daily_pnl` table exists in the target MySQL database with a schema
      matching what `tradeengine.shared.mysql_client` writes.
- [x] `GET`/`PUT /api/v1/mysql/daily_pnl` no longer raises `NoSuchTableError`
      / `DatabaseError: Unknown collection or failed to reflect`.
- [ ] Live verification (post-deploy): `Failed to update daily P&L for
      {date}` errors stop appearing in `petrosa-tradeengine` logs — to be
      confirmed after this deploys.
- [x] A migration/schema-init step exists (not a manual `CREATE TABLE`) —
      `metadata.create_all()` on every `connect()`, self-healing.

Sibling-table audit (per issue scope item): only `positions` and `daily_pnl`
are referenced via the generic MySQL API across all service repos;
`positions` is already provisioned live. No other "route exists, table
missing" gap found.

Closes #264
