### PR TITLE
feat: signals collection TTL index (companion to bot-ta-analysis#267 AC6)

### DIFF
--- a/data_manager/api/routes/generic.py
+++ b/data_manager/api/routes/generic.py
@@ -375,6 +375,19 @@ async def insert_records(
             # Add timestamp if not present
             if "timestamp" not in item:
                 item["timestamp"] = datetime.now(UTC)
+            # petrosa-data-manager companion to petrosa-bot-ta-analysis#267
+            # (AC6): stamp an UNCONDITIONAL real BSON Date field for the
+            # `signals` Mongo collection specifically. Callers (e.g. the TA
+            # bot) already send their own `timestamp` as an ISO *string* for
+            # JSON compatibility, so the generic `if "timestamp" not in item`
+            # auto-stamp above never fires for them and a TTL index on
+            # `timestamp` would silently never expire anything — the exact
+            # gotcha already observed on the `alerts` collection. This field
+            # is dedicated to TTL maintenance only; see
+            # data_manager/maintenance/intents_ttl_index.py
+            # `ensure_signals_ttl_index`.
+            if database == "mongodb" and collection == "signals":
+                item["_ttl_inserted_at"] = datetime.now(UTC)
             model_instances.append(GenericModel(**item))
 
         # Execute insert

--- a/data_manager/maintenance/intents_ttl_index.py
+++ b/data_manager/maintenance/intents_ttl_index.py
@@ -46,6 +46,9 @@ Environment contract::
     MONGODB_DATABASE             explicit DB name; falls back to MONGODB_DB,
                                  then to "petrosa_data_manager" (AC4)
     MONGODB_INTENTS_TTL_SECONDS  TTL window in seconds (default 86400 = 1 day)
+    MONGODB_SIGNALS_TTL_SECONDS  signals collection TTL window in seconds
+                                 (default 604800 = 7 days; companion to
+                                 petrosa-bot-ta-analysis#267 AC6)
 
 Exit codes::
 
@@ -83,6 +86,30 @@ TTL_INDEX_NAME = "received_at_ttl_1d"
 LEGACY_BROKEN_FIELD = "createdAt"
 DEFAULT_DATABASE = "petrosa_data_manager"
 DEFAULT_TTL_SECONDS = 86400  # 1 day
+
+# --------------------------------------------------------------------------- #
+# signals TTL — companion to petrosa-bot-ta-analysis#267 AC6
+# --------------------------------------------------------------------------- #
+# The `signals` collection (trading signals persisted via the generic
+# `/api/v1/mongodb/signals` insert endpoint) has NO confirmed reader today
+# (see #267's required follow-up ticket: "who reads signals, and when?").
+# Shipping any new high-frequency Mongo write onto the shared Atlas M0
+# (512 MB) cluster — which has already suffered four P0 quota outages — is
+# only acceptable with a mandatory, bounded retention mechanism in the same
+# change. Unlike `intents.received_at`, callers already send their own
+# `timestamp` as an ISO *string* (JSON-compat requirement in
+# ta_bot/models/signal.py `to_dict()`), so a TTL on `timestamp` would never
+# actually expire anything — the generic insert route
+# (data_manager/api/routes/generic.py `insert_records`) therefore stamps a
+# dedicated, unconditional, real BSON Date field `_ttl_inserted_at` on every
+# `signals` document specifically for this TTL index to key on.
+SIGNALS_COLLECTION = "signals"
+SIGNALS_TTL_FIELD = "_ttl_inserted_at"
+SIGNALS_TTL_INDEX_NAME = "_ttl_inserted_at_ttl"
+DEFAULT_SIGNALS_TTL_SECONDS = 604800  # 7 days — generous default pending the
+# consumer/retention-window contract from #267's required follow-up ticket;
+# comfortably bounded rather than unbounded, and operator-overridable via
+# MONGODB_SIGNALS_TTL_SECONDS.
 
 # AC5 — sibling collections that could share the same unbounded-growth defect.
 # Documented decision: these are audit/financial-event trails. They are NOT
@@ -122,6 +149,7 @@ class TtlIndexConfig:
 
     database: str = DEFAULT_DATABASE
     ttl_seconds: int = DEFAULT_TTL_SECONDS
+    signals_ttl_seconds: int = DEFAULT_SIGNALS_TTL_SECONDS
     dry_run: bool = False
 
 
@@ -167,9 +195,16 @@ def load_config_from_env(environ: dict[str, str] | None = None) -> TtlIndexConfi
     ttl_seconds = _parse_int_env(
         env, "MONGODB_INTENTS_TTL_SECONDS", DEFAULT_TTL_SECONDS, minimum=60
     )
+    signals_ttl_seconds = _parse_int_env(
+        env,
+        "MONGODB_SIGNALS_TTL_SECONDS",
+        DEFAULT_SIGNALS_TTL_SECONDS,
+        minimum=60,
+    )
     return TtlIndexConfig(
         database=resolve_database_name(env),
         ttl_seconds=ttl_seconds,
+        signals_ttl_seconds=signals_ttl_seconds,
         dry_run=False,
     )
 
@@ -289,6 +324,92 @@ async def ensure_intents_ttl_index(
     return result
 
 
+async def ensure_signals_ttl_index(
+    db,
+    db_name: str,
+    *,
+    ttl_seconds: int = DEFAULT_SIGNALS_TTL_SECONDS,
+    dry_run: bool = False,
+) -> TtlIndexResult:
+    """Idempotently ensure the TTL index on `signals._ttl_inserted_at`.
+
+    Companion to petrosa-bot-ta-analysis#267 AC6. Mirrors
+    :func:`ensure_intents_ttl_index`'s idempotent create/collmod/noop logic,
+    minus the legacy-index-drop step (no prior broken TTL index exists on
+    this collection — it never had one).
+
+    * No-ops if the index already matches the desired spec.
+    * Repairs the TTL window via ``collMod`` if the field is right but
+      ``expireAfterSeconds`` differs.
+    * Creates the index if absent.
+    * If ``signals`` does not exist yet (no writer has run), still ensures
+      the index will be present at collection-creation time by creating it
+      directly — MongoDB permits creating an index on a not-yet-existing
+      collection, which implicitly creates the collection empty.
+    """
+    coll = db[SIGNALS_COLLECTION]
+    info = await coll.index_information()
+
+    existing = info.get(SIGNALS_TTL_INDEX_NAME)
+    if existing is not None and _index_key_fields(existing) == [SIGNALS_TTL_FIELD]:
+        current_ttl = existing.get("expireAfterSeconds")
+        if current_ttl == ttl_seconds:
+            action = "noop"
+        else:
+            action = "collmod"
+            if not dry_run:
+                await db.command(
+                    "collMod",
+                    SIGNALS_COLLECTION,
+                    index={
+                        "name": SIGNALS_TTL_INDEX_NAME,
+                        "expireAfterSeconds": ttl_seconds,
+                    },
+                )
+    elif existing is not None:
+        # Name squatting on the wrong field — drop and recreate cleanly.
+        action = "recreated"
+        if not dry_run:
+            await coll.drop_index(SIGNALS_TTL_INDEX_NAME)
+            await coll.create_index(
+                [(SIGNALS_TTL_FIELD, ASCENDING)],
+                name=SIGNALS_TTL_INDEX_NAME,
+                expireAfterSeconds=ttl_seconds,
+            )
+    else:
+        action = "created"
+        if not dry_run:
+            await coll.create_index(
+                [(SIGNALS_TTL_FIELD, ASCENDING)],
+                name=SIGNALS_TTL_INDEX_NAME,
+                expireAfterSeconds=ttl_seconds,
+            )
+
+    result = TtlIndexResult(
+        database=db_name,
+        collection=SIGNALS_COLLECTION,
+        index_name=SIGNALS_TTL_INDEX_NAME,
+        field=SIGNALS_TTL_FIELD,
+        ttl_seconds=ttl_seconds,
+        action=action,
+        dropped_legacy=[],
+        dry_run=dry_run,
+    )
+
+    logger.info(
+        "signals_ttl_index: db=%s collection=%s index=%s key={%s: 1} "
+        "expireAfterSeconds=%d action=%s%s",
+        result.database,
+        result.collection,
+        result.index_name,
+        result.field,
+        result.ttl_seconds,
+        result.action,
+        " (dry-run)" if dry_run else "",
+    )
+    return result
+
+
 async def audit_sibling_collections(
     db,
     db_name: str,
@@ -373,6 +494,12 @@ def _build_argparser() -> argparse.ArgumentParser:
         default=None,
         help="Override MONGODB_INTENTS_TTL_SECONDS for this run.",
     )
+    parser.add_argument(
+        "--signals-ttl-seconds",
+        type=int,
+        default=None,
+        help="Override MONGODB_SIGNALS_TTL_SECONDS for this run.",
+    )
     return parser
 
 
@@ -393,6 +520,8 @@ async def _amain(argv: list[str] | None = None) -> int:
     config.dry_run = bool(args.dry_run)
     if args.ttl_seconds is not None:
         config.ttl_seconds = max(60, args.ttl_seconds)
+    if args.signals_ttl_seconds is not None:
+        config.signals_ttl_seconds = max(60, args.signals_ttl_seconds)
 
     connection_string = os.getenv("MONGODB_URL")
     if not connection_string:
@@ -409,6 +538,14 @@ async def _amain(argv: list[str] | None = None) -> int:
             db,
             config.database,
             ttl_seconds=config.ttl_seconds,
+            dry_run=config.dry_run,
+        )
+        # Companion to petrosa-bot-ta-analysis#267 AC6 — mandatory TTL for
+        # any new high-frequency Mongo write; see module docstring above.
+        await ensure_signals_ttl_index(
+            db,
+            config.database,
+            ttl_seconds=config.signals_ttl_seconds,
             dry_run=config.dry_run,
         )
         await audit_sibling_collections(db, config.database)

--- a/tests/test_generic_insert_signals_ttl_stamp.py
+++ b/tests/test_generic_insert_signals_ttl_stamp.py
@@ -1,0 +1,135 @@
+"""
+Regression tests for POST /api/v1/{database}/{collection} (generic.py::insert_records)
+— the `_ttl_inserted_at` stamp for MongoDB `signals` inserts.
+
+Companion to petrosa-bot-ta-analysis#267 AC6: signals are persisted by callers
+that already supply their own `timestamp` as an ISO *string* (JSON-compat
+requirement), so the existing "add timestamp if not present" auto-stamp never
+fires for them, and a TTL index keyed on that string field would never expire
+anything (the same gotcha already observed on the `alerts` collection).
+`insert_records` therefore stamps an UNCONDITIONAL, real BSON ``Date`` field
+`_ttl_inserted_at` specifically on `mongodb.signals` inserts, which
+`data_manager.maintenance.intents_ttl_index.ensure_signals_ttl_index` TTL-indexes.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import data_manager.api.app as api_module
+from data_manager.db.mysql_adapter import WriteResult
+
+
+@pytest.fixture
+def client(mock_db_manager):
+    """Create test client with a mocked Mongo adapter capturing write() calls."""
+    mock_db_manager.mongodb_adapter = Mock()
+    mock_db_manager.mongodb_adapter.write = AsyncMock(return_value=1)
+
+    mock_db_manager.mysql_adapter = Mock()
+    mock_db_manager.mysql_adapter.write = Mock(
+        return_value=WriteResult(inserted=1, duplicates=0, failed=0)
+    )
+
+    app = api_module.create_app()
+    api_module.db_manager = mock_db_manager
+    yield TestClient(app)
+    api_module.db_manager = None
+
+
+def test_signals_insert_gets_ttl_inserted_at_stamp_even_with_client_timestamp(client):
+    """The core regression: a signal payload that ALREADY includes its own
+    string `timestamp` (as ta_bot always sends) must still get a real BSON
+    Date `_ttl_inserted_at` field added, so the TTL index has something to
+    key on."""
+    response = client.post(
+        "/api/v1/mongodb/signals",
+        json={
+            "data": {
+                "symbol": "BTCUSDT",
+                "action": "buy",
+                "confidence": 0.85,
+                "timestamp": "2026-09-02T20:36:31Z",  # client-supplied string
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    api_module.db_manager.mongodb_adapter.write.assert_called_once()
+    (model_instances, collection), _kwargs = (
+        api_module.db_manager.mongodb_adapter.write.call_args
+    )
+    assert collection == "signals"
+    assert len(model_instances) == 1
+    inserted = model_instances[0].model_dump()
+
+    # The client's own string timestamp must be preserved untouched...
+    assert inserted["timestamp"] == "2026-09-02T20:36:31Z"
+    # ...AND a dedicated real datetime field must be present for TTL to key on.
+    assert "_ttl_inserted_at" in inserted
+    assert isinstance(inserted["_ttl_inserted_at"], datetime)
+
+
+def test_signals_batch_insert_stamps_every_item(client):
+    """Batch inserts (persist_signals_batch) must stamp every item, not just
+    the first."""
+    response = client.post(
+        "/api/v1/mongodb/signals",
+        json={
+            "data": [
+                {
+                    "symbol": "BTCUSDT",
+                    "action": "buy",
+                    "timestamp": "2026-09-02T00:00:00Z",
+                },
+                {
+                    "symbol": "ETHUSDT",
+                    "action": "sell",
+                    "timestamp": "2026-09-02T00:01:00Z",
+                },
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    (model_instances, _collection), _kwargs = (
+        api_module.db_manager.mongodb_adapter.write.call_args
+    )
+    assert len(model_instances) == 2
+    for instance in model_instances:
+        dumped = instance.model_dump()
+        assert isinstance(dumped["_ttl_inserted_at"], datetime)
+
+
+def test_non_signals_mongo_collection_is_not_stamped(client):
+    """The stamp is scoped to `signals` only — other Mongo collections must
+    not be affected by this change."""
+    response = client.post(
+        "/api/v1/mongodb/alerts",
+        json={"data": {"symbol": "BTCUSDT", "message": "test"}},
+    )
+
+    assert response.status_code == 200
+    (model_instances, collection), _kwargs = (
+        api_module.db_manager.mongodb_adapter.write.call_args
+    )
+    assert collection == "alerts"
+    assert "_ttl_inserted_at" not in model_instances[0].model_dump()
+
+
+def test_mysql_signals_insert_is_not_stamped(client):
+    """The stamp is Mongo-only — the (legacy, being phased out) MySQL signals
+    fallback path must be untouched."""
+    response = client.post(
+        "/api/v1/mysql/signals",
+        json={"data": {"symbol": "BTCUSDT", "action": "buy"}},
+    )
+
+    assert response.status_code == 200
+    api_module.db_manager.mysql_adapter.write.assert_called_once()
+    model_instances, _collection = api_module.db_manager.mysql_adapter.write.call_args[
+        0
+    ]
+    assert "_ttl_inserted_at" not in model_instances[0].model_dump()

--- a/tests/test_intents_ttl_index.py
+++ b/tests/test_intents_ttl_index.py
@@ -243,3 +243,111 @@ async def test_audit_reports_present_and_absent_siblings():
     # (data-manager#254); every sibling now keeps the default decision.
     assert itx.SIBLING_DECISION_OVERRIDES == {}
     assert all(r.decision == itx.SIBLING_RETENTION_DECISION for r in results)
+
+
+# --------------------------------------------------------------------------- #
+# ensure_signals_ttl_index (companion to petrosa-bot-ta-analysis#267 AC6)
+# --------------------------------------------------------------------------- #
+
+
+def test_default_signals_ttl_is_seven_days():
+    assert itx.DEFAULT_SIGNALS_TTL_SECONDS == 604800
+
+
+def test_load_config_from_env_parses_signals_ttl_seconds():
+    config = itx.load_config_from_env({"MONGODB_SIGNALS_TTL_SECONDS": "3600"})
+    assert config.signals_ttl_seconds == 3600
+
+
+def test_load_config_from_env_defaults_signals_ttl():
+    assert (
+        itx.load_config_from_env({}).signals_ttl_seconds
+        == itx.DEFAULT_SIGNALS_TTL_SECONDS
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_signals_creates_index_when_absent():
+    db = _make_db(index_info_by_collection={"signals": {"_id_": {"key": [("_id", 1)]}}})
+    result = await itx.ensure_signals_ttl_index(db, "petrosa_data_manager")
+
+    assert result.action == "created"
+    assert result.database == "petrosa_data_manager"
+    assert result.collection == "signals"
+    assert result.field == "_ttl_inserted_at"
+    coll = db["signals"]
+    coll.create_index.assert_awaited_once()
+    _args, kwargs = coll.create_index.call_args
+    assert kwargs["name"] == itx.SIGNALS_TTL_INDEX_NAME
+    assert kwargs["expireAfterSeconds"] == itx.DEFAULT_SIGNALS_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_ensure_signals_noop_when_index_matches_spec():
+    db = _make_db(
+        index_info_by_collection={
+            "signals": {
+                itx.SIGNALS_TTL_INDEX_NAME: _ttl_meta("_ttl_inserted_at", 604800)
+            }
+        }
+    )
+    result = await itx.ensure_signals_ttl_index(
+        db, "petrosa_data_manager", ttl_seconds=604800
+    )
+
+    assert result.action == "noop"
+    coll = db["signals"]
+    coll.create_index.assert_not_awaited()
+    coll.drop_index.assert_not_awaited()
+    db.command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_signals_collmod_when_ttl_window_differs():
+    db = _make_db(
+        index_info_by_collection={
+            "signals": {
+                itx.SIGNALS_TTL_INDEX_NAME: _ttl_meta("_ttl_inserted_at", 604800)
+            }
+        }
+    )
+    result = await itx.ensure_signals_ttl_index(
+        db, "petrosa_data_manager", ttl_seconds=86400
+    )
+
+    assert result.action == "collmod"
+    db.command.assert_awaited_once()
+    args, kwargs = db.command.call_args
+    assert args[0] == "collMod"
+    assert args[1] == "signals"
+    assert kwargs["index"]["expireAfterSeconds"] == 86400
+
+
+@pytest.mark.asyncio
+async def test_ensure_signals_recreates_when_name_on_wrong_field():
+    db = _make_db(
+        index_info_by_collection={
+            "signals": {itx.SIGNALS_TTL_INDEX_NAME: _ttl_meta("timestamp", 604800)}
+        }
+    )
+    result = await itx.ensure_signals_ttl_index(db, "petrosa_data_manager")
+
+    assert result.action == "recreated"
+    coll = db["signals"]
+    coll.drop_index.assert_awaited_once_with(itx.SIGNALS_TTL_INDEX_NAME)
+    coll.create_index.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_signals_dry_run_mutates_nothing():
+    db = _make_db(index_info_by_collection={"signals": {"_id_": {"key": [("_id", 1)]}}})
+    result = await itx.ensure_signals_ttl_index(
+        db, "petrosa_data_manager", dry_run=True
+    )
+
+    assert result.action == "created"
+    assert result.dry_run is True
+    coll = db["signals"]
+    coll.create_index.assert_not_awaited()
+    coll.drop_index.assert_not_awaited()
+    db.command.assert_not_awaited()


### PR DESCRIPTION
## Companion PR to PetroSa2/petrosa-bot-ta-analysis#267 (AC6)

`petrosa-bot-ta-analysis#267` fixes a bug that was silently routing trading
signals to a write-only MySQL table instead of the intended Mongo `signals`
collection via this service's generic insert API. That collection has **no
confirmed reader yet** and previously had **no retention** — shipping any new
high-frequency write onto the shared Atlas M0 (512 MB) cluster (four prior P0
quota outages: #783/#819/#881/#899) is only acceptable with a mandatory,
bounded TTL in the same change. This PR is that TTL.

## What changed

- `data_manager/api/routes/generic.py` `insert_records`: stamp an
  **unconditional real BSON `Date`** field `_ttl_inserted_at` on
  `mongodb.signals` inserts specifically. Callers (bot-ta-analysis) already
  send their own `timestamp` as an ISO **string** (JSON-compat requirement in
  `Signal.to_dict()`), so the existing conditional auto-stamp
  (`if "timestamp" not in item`) never fires for them — a TTL index on that
  field would silently never expire anything, the exact gotcha already
  observed on the `alerts` collection.
- `data_manager/maintenance/intents_ttl_index.py`: add
  `ensure_signals_ttl_index`, the same idempotent create/collmod/noop TTL
  maintenance pattern as `ensure_intents_ttl_index`, wired into `_amain`.
  Default **7-day TTL** via `MONGODB_SIGNALS_TTL_SECONDS` (`--signals-ttl-seconds`
  CLI override available) — generous pending the consumer/retention-window
  contract tracked as #267's required follow-up ticket.

## Tests

- `tests/test_intents_ttl_index.py`: full TTL-index lifecycle coverage for
  `ensure_signals_ttl_index` (create / noop / collmod / recreate-on-wrong-field
  / dry-run), plus config-loading tests for `MONGODB_SIGNALS_TTL_SECONDS`.
- `tests/test_generic_insert_signals_ttl_stamp.py` (new): regression test
  proving the `_ttl_inserted_at` stamp survives a client-supplied string
  `timestamp` (the actual production shape), applies to both single and batch
  inserts, and is scoped **only** to `mongodb.signals` — `alerts` and
  `mysql.signals` are unaffected.

Full repo suite: 1188 passed, 3 skipped, 0 failed. `ruff check .` clean.

## Deployment note

Applying the TTL index to the live collection requires an operator run of
`python -m data_manager.maintenance.intents_ttl_index --apply` (mirrors how
the `intents` TTL is maintained) — this PR ships the code; running it against
the production Atlas cluster is a manual operator step, same as the existing
`intents` TTL job.

Closes AC6 of PetroSa2/petrosa-bot-ta-analysis#267.
